### PR TITLE
feat(recorder): rewrite dots-recorder with EasyOptions and fix recording pipeline

### DIFF
--- a/home/.chezmoiscripts/linux/run_onchange_before_install-gpu-screen-recorder.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_before_install-gpu-screen-recorder.sh.tmpl
@@ -1,0 +1,15 @@
+{{ if and (not .ephemeral) (not .headless) -}}
+
+{{      if eq .osid "linux-arch" -}}
+#!/usr/bin/env bash
+
+# GPU-accelerated screen recording
+yay -S --noconfirm --needed \
+  gpu-screen-recorder \
+  gpu-screen-recorder-ui \
+  intel-media-driver \
+  libva-utils
+
+{{      end -}}
+
+{{ end -}}

--- a/home/dot_config/hypr/hyprland.conf.d/environment.conf
+++ b/home/dot_config/hypr/hyprland.conf.d/environment.conf
@@ -45,6 +45,12 @@ env = QS_PLUGIN_PATH,$HOME/.local/lib/quickshell
 env = _JAVA_AWT_WM_NONREPARENTING,1
 
 # ============================================================================
+# VA-API — hardware video encoding (gpu-screen-recorder / libva-nvidia-driver)
+# ============================================================================
+env = LIBVA_DRIVER_NAME,nvidia
+env = LIBVA_DRIVERS_PATH,/usr/lib/dri
+
+# ============================================================================
 # Optional: HiDPI/Scaling (uncomment and adjust if needed)
 # ============================================================================
 # env = GDK_SCALE,1

--- a/home/dot_config/quickshell/services/Recorder.qml
+++ b/home/dot_config/quickshell/services/Recorder.qml
@@ -73,7 +73,7 @@ Singleton {
 
     Connections {
         target: Time
-        // enabled: props.running && !props.paused
+        enabled: props.running && !props.paused
 
         function onSecondsChanged(): void {
             props.elapsed++;

--- a/home/dot_local/bin/executable_dots-recorder
+++ b/home/dot_local/bin/executable_dots-recorder
@@ -35,125 +35,125 @@ mkdir -p "$STATE_DIR"
 PAUSE_STATE_FILE="${STATE_DIR}/paused"
 
 has_running() {
-  pgrep -f "gpu-screen-recorder" >/dev/null 2>&1
+	pgrep -f "gpu-screen-recorder" >/dev/null 2>&1
 }
 
 get_primary_monitor() {
-  gpu-screen-recorder --list-monitors 2>/dev/null | head -1 | cut -d'|' -f1
+	gpu-screen-recorder --list-monitors 2>/dev/null | head -1 | cut -d'|' -f1
 }
 
 get_output_dir() {
-  local videos_dir="${XDG_VIDEOS_DIR:-${HOME}/Videos}"
-  local recs_dir="${CAELESTIA_RECORDINGS_DIR:-${videos_dir}/Recordings}"
-  mkdir -p "$recs_dir"
-  echo "$recs_dir"
+	local videos_dir="${XDG_VIDEOS_DIR:-${HOME}/Videos}"
+	local recs_dir="${CAELESTIA_RECORDINGS_DIR:-${videos_dir}/Recordings}"
+	mkdir -p "$recs_dir"
+	echo "$recs_dir"
 }
 
 notify_start() {
-  local file="$1"
-  notify-send -i "media-record" -a "dots-recorder" \
-    "Recording started" "$file" 2>/dev/null || true
+	local file="$1"
+	notify-send -i "media-record" -a "dots-recorder" \
+		"Recording started" "$file" 2>/dev/null || true
 }
 
 notify_stop() {
-  local file="$1"
-  notify-send -i "media-playback-stop" -a "dots-recorder" \
-    "Recording saved" "$file" 2>/dev/null || true
+	local file="$1"
+	notify-send -i "media-playback-stop" -a "dots-recorder" \
+		"Recording saved" "$file" 2>/dev/null || true
 }
 
 notify_error() {
-  local msg="$1"
-  notify-send -u critical -i "dialog-error" -a "dots-recorder" \
-    "Recording failed" "$msg" 2>/dev/null || true
+	local msg="$1"
+	notify-send -u critical -i "dialog-error" -a "dots-recorder" \
+		"Recording failed" "$msg" 2>/dev/null || true
 }
 
 # ── subcommands ───────────────────────────────────────────────────────────────
 
 do_start() {
-  # --sr expands into both --region and --sound
-  if [[ -n ${sr:-} ]]; then
-    region="yes"
-    sound="yes"
-  fi
+	# --sr expands into both --region and --sound
+	if [[ -n ${sr:-} ]]; then
+		region="yes"
+		sound="yes"
+	fi
 
-  local use_region="${region:-}"
-  local use_sound="${sound:-}"
-  local rec_fps="${fps:-30}"
-  local monitor
+	local use_region="${region:-}"
+	local use_sound="${sound:-}"
+	local rec_fps="${fps:-30}"
+	local monitor
 
-  local -a gsr_args=()
+	local -a gsr_args=()
 
-  # Capture target
-  if [[ -n $use_region ]]; then
-    gsr_args+=("-w" "region")
-  else
-    monitor=$(get_primary_monitor)
-    gsr_args+=("-w" "${monitor:-eDP-1}")
-  fi
+	# Capture target
+	if [[ -n $use_region ]]; then
+		gsr_args+=("-w" "region")
+	else
+		monitor=$(get_primary_monitor)
+		gsr_args+=("-w" "${monitor:-eDP-1}")
+	fi
 
-  # Video settings — no explicit -k, let GSR pick best available codec
-  gsr_args+=("-f" "$rec_fps")
-  gsr_args+=("-c" "mp4")
-  gsr_args+=("-cursor" "yes")
+	# Video settings — no explicit -k, let GSR pick best available codec
+	gsr_args+=("-f" "$rec_fps")
+	gsr_args+=("-c" "mp4")
+	gsr_args+=("-cursor" "yes")
 
-  # Always allow CPU fallback if VA-API / NVENC is unavailable
-  gsr_args+=("-fallback-cpu-encoding" "yes")
+	# Always allow CPU fallback if VA-API / NVENC is unavailable
+	gsr_args+=("-fallback-cpu-encoding" "yes")
 
-  # Desktop audio
-  if [[ -n $use_sound ]]; then
-    gsr_args+=("-a" "default_output")
-  fi
+	# Desktop audio
+	if [[ -n $use_sound ]]; then
+		gsr_args+=("-a" "default_output")
+	fi
 
-  # Output file: recording_YYYYMMDD_HH-MM-SS.mp4  (matches RecordingList regex)
-  local timestamp
-  local output_dir
-  local filename
-  timestamp=$(date +%Y%m%d_%H-%M-%S)
-  output_dir=$(get_output_dir)
-  filename="${output_dir}/recording_${timestamp}.mp4"
-  gsr_args+=("-o" "$filename")
+	# Output file: recording_YYYYMMDD_HH-MM-SS.mp4  (matches RecordingList regex)
+	local timestamp
+	local output_dir
+	local filename
+	timestamp=$(date +%Y%m%d_%H-%M-%S)
+	output_dir=$(get_output_dir)
+	filename="${output_dir}/recording_${timestamp}.mp4"
+	gsr_args+=("-o" "$filename")
 
-  # Launch detached
-  gpu-screen-recorder "${gsr_args[@]}" >/dev/null 2>&1 &
-  disown || true
+	# Launch detached
+	gpu-screen-recorder "${gsr_args[@]}" >/dev/null 2>&1 &
+	disown || true
 
-  # Store filename for stop notification
-  echo "$filename" >"${STATE_DIR}/current_file"
+	# Store filename for stop notification
+	echo "$filename" >"${STATE_DIR}/current_file"
 
-  # Confirm it started
-  sleep 1
-  if has_running; then
-    notify_start "$filename"
-  else
-    rm -f "${STATE_DIR}/current_file"
-    notify_error "gpu-screen-recorder failed to start"
-    exit 1
-  fi
+	# Confirm it started
+	sleep 1
+	if has_running; then
+		notify_start "$filename"
+	else
+		rm -f "${STATE_DIR}/current_file"
+		notify_error "gpu-screen-recorder failed to start"
+		exit 1
+	fi
 }
 
 do_stop() {
-  local current_file=""
-  [[ -f "${STATE_DIR}/current_file" ]] && current_file=$(cat "${STATE_DIR}/current_file")
+	local current_file=""
+	[[ -f "${STATE_DIR}/current_file" ]] && current_file=$(cat "${STATE_DIR}/current_file")
 
-  pkill -f "gpu-screen-recorder" >/dev/null 2>&1 || true
-  rm -f "$PAUSE_STATE_FILE" "${STATE_DIR}/current_file"
+	pkill -f "gpu-screen-recorder" >/dev/null 2>&1 || true
+	rm -f "$PAUSE_STATE_FILE" "${STATE_DIR}/current_file"
 
-  if [[ -n $current_file ]]; then
-    notify_stop "$current_file"
-  fi
+	if [[ -n $current_file ]]; then
+		notify_stop "$current_file"
+	fi
 }
 
 do_pause() {
-  if ! has_running; then
-    exit 0
-  fi
-  if [[ -f $PAUSE_STATE_FILE ]]; then
-    pkill -CONT -f "gpu-screen-recorder" >/dev/null 2>&1 || true
-    rm -f "$PAUSE_STATE_FILE"
-  else
-    pkill -STOP -f "gpu-screen-recorder" >/dev/null 2>&1 || true
-    : >"$PAUSE_STATE_FILE"
-  fi
+	if ! has_running; then
+		exit 0
+	fi
+	if [[ -f $PAUSE_STATE_FILE ]]; then
+		pkill -CONT -f "gpu-screen-recorder" >/dev/null 2>&1 || true
+		rm -f "$PAUSE_STATE_FILE"
+	else
+		pkill -STOP -f "gpu-screen-recorder" >/dev/null 2>&1 || true
+		: >"$PAUSE_STATE_FILE"
+	fi
 }
 
 # ── dispatch ──────────────────────────────────────────────────────────────────
@@ -161,30 +161,30 @@ do_pause() {
 cmd="${arguments[0]:-}"
 
 case "$cmd" in
-  start)
-    if has_running; then
-      exit 0
-    fi
-    if ! command -v gpu-screen-recorder >/dev/null 2>&1; then
-      notify_error "gpu-screen-recorder is not installed"
-      exit 1
-    fi
-    do_start
-    ;;
-  stop)
-    do_stop
-    ;;
-  pause)
-    do_pause
-    ;;
-  "")
-    echo "Error: no command given." >&2
-    echo "Usage: dots-recorder {start|stop|pause} [OPTIONS]" >&2
-    exit 1
-    ;;
-  *)
-    echo "Error: unknown command '$cmd'." >&2
-    echo "Usage: dots-recorder {start|stop|pause} [OPTIONS]" >&2
-    exit 1
-    ;;
+start)
+	if has_running; then
+		exit 0
+	fi
+	if ! command -v gpu-screen-recorder >/dev/null 2>&1; then
+		notify_error "gpu-screen-recorder is not installed"
+		exit 1
+	fi
+	do_start
+	;;
+stop)
+	do_stop
+	;;
+pause)
+	do_pause
+	;;
+"")
+	echo "Error: no command given." >&2
+	echo "Usage: dots-recorder {start|stop|pause} [OPTIONS]" >&2
+	exit 1
+	;;
+*)
+	echo "Error: unknown command '$cmd'." >&2
+	echo "Usage: dots-recorder {start|stop|pause} [OPTIONS]" >&2
+	exit 1
+	;;
 esac

--- a/home/dot_local/bin/executable_dots-recorder
+++ b/home/dot_local/bin/executable_dots-recorder
@@ -1,59 +1,190 @@
 #!/usr/bin/env bash
 
-## dots-recorder: Recorder wrapper used by Quickshell runtime.
+## dots-recorder: Screen recorder wrapper for Quickshell.
 ## Copyright (C) 2019-2025 Ulises Jeremias Cornejo Fandos
 ## Licensed under MIT.
-## Prefer Caelestia backend when available, otherwise graceful fallback.
+##
+## Check full documentation at: https://github.com/ulises-jeremias/dotfiles/wiki
+##
+## Wraps gpu-screen-recorder to provide start/stop/pause control with output
+## saved to ~/Videos/Recordings/ (or $CAELESTIA_RECORDINGS_DIR).
+##
+## Usage:
+##   @script.name COMMAND [OPTIONS]
+##
+## Commands:
+##   start         Start a new recording
+##   stop          Stop the current recording
+##   pause         Toggle pause/resume on the current recording
+##
+## Options:
+##   -h, --help         Show this help message
+##   -r, --region       Record a selected region (interactive selection)
+##   -s, --sound        Include desktop audio in the recording
+##       --sr           Record a selected region with desktop audio (-r and -s combined)
+##       --fps=FPS      Frames per second (default: 30)
+
+source ~/.local/lib/dots/easy-options/easyoptions.sh || exit
 
 set -euo pipefail
+
+# ── helpers ──────────────────────────────────────────────────────────────────
 
 STATE_DIR="${HOME}/.local/state/dots/recorder"
 mkdir -p "$STATE_DIR"
 PAUSE_STATE_FILE="${STATE_DIR}/paused"
 
-cmd="${1:-}"
-shift 2>/dev/null || true
-
 has_running() {
-  pidof gpu-screen-recorder >/dev/null 2>&1
+  pgrep -f "gpu-screen-recorder" >/dev/null 2>&1
 }
 
-if command -v caelestia >/dev/null 2>&1; then
-  case "$cmd" in
-    start) exec caelestia record "$@" ;;
-    stop) exec caelestia record ;;
-    pause) exec caelestia record -p ;;
-  esac
-fi
+get_primary_monitor() {
+  gpu-screen-recorder --list-monitors 2>/dev/null | head -1 | cut -d'|' -f1
+}
+
+get_output_dir() {
+  local videos_dir="${XDG_VIDEOS_DIR:-${HOME}/Videos}"
+  local recs_dir="${CAELESTIA_RECORDINGS_DIR:-${videos_dir}/Recordings}"
+  mkdir -p "$recs_dir"
+  echo "$recs_dir"
+}
+
+notify_start() {
+  local file="$1"
+  notify-send -i "media-record" -a "dots-recorder" \
+    "Recording started" "$file" 2>/dev/null || true
+}
+
+notify_stop() {
+  local file="$1"
+  notify-send -i "media-playback-stop" -a "dots-recorder" \
+    "Recording saved" "$file" 2>/dev/null || true
+}
+
+notify_error() {
+  local msg="$1"
+  notify-send -u critical -i "dialog-error" -a "dots-recorder" \
+    "Recording failed" "$msg" 2>/dev/null || true
+}
+
+# ── subcommands ───────────────────────────────────────────────────────────────
+
+do_start() {
+  # --sr expands into both --region and --sound
+  if [[ -n ${sr:-} ]]; then
+    region="yes"
+    sound="yes"
+  fi
+
+  local use_region="${region:-}"
+  local use_sound="${sound:-}"
+  local rec_fps="${fps:-30}"
+  local monitor
+
+  local -a gsr_args=()
+
+  # Capture target
+  if [[ -n $use_region ]]; then
+    gsr_args+=("-w" "region")
+  else
+    monitor=$(get_primary_monitor)
+    gsr_args+=("-w" "${monitor:-eDP-1}")
+  fi
+
+  # Video settings — no explicit -k, let GSR pick best available codec
+  gsr_args+=("-f" "$rec_fps")
+  gsr_args+=("-c" "mp4")
+  gsr_args+=("-cursor" "yes")
+
+  # Always allow CPU fallback if VA-API / NVENC is unavailable
+  gsr_args+=("-fallback-cpu-encoding" "yes")
+
+  # Desktop audio
+  if [[ -n $use_sound ]]; then
+    gsr_args+=("-a" "default_output")
+  fi
+
+  # Output file: recording_YYYYMMDD_HH-MM-SS.mp4  (matches RecordingList regex)
+  local timestamp
+  local output_dir
+  local filename
+  timestamp=$(date +%Y%m%d_%H-%M-%S)
+  output_dir=$(get_output_dir)
+  filename="${output_dir}/recording_${timestamp}.mp4"
+  gsr_args+=("-o" "$filename")
+
+  # Launch detached
+  gpu-screen-recorder "${gsr_args[@]}" >/dev/null 2>&1 &
+  disown || true
+
+  # Store filename for stop notification
+  echo "$filename" >"${STATE_DIR}/current_file"
+
+  # Confirm it started
+  sleep 1
+  if has_running; then
+    notify_start "$filename"
+  else
+    rm -f "${STATE_DIR}/current_file"
+    notify_error "gpu-screen-recorder failed to start"
+    exit 1
+  fi
+}
+
+do_stop() {
+  local current_file=""
+  [[ -f "${STATE_DIR}/current_file" ]] && current_file=$(cat "${STATE_DIR}/current_file")
+
+  pkill -f "gpu-screen-recorder" >/dev/null 2>&1 || true
+  rm -f "$PAUSE_STATE_FILE" "${STATE_DIR}/current_file"
+
+  if [[ -n $current_file ]]; then
+    notify_stop "$current_file"
+  fi
+}
+
+do_pause() {
+  if ! has_running; then
+    exit 0
+  fi
+  if [[ -f $PAUSE_STATE_FILE ]]; then
+    pkill -CONT -f "gpu-screen-recorder" >/dev/null 2>&1 || true
+    rm -f "$PAUSE_STATE_FILE"
+  else
+    pkill -STOP -f "gpu-screen-recorder" >/dev/null 2>&1 || true
+    : >"$PAUSE_STATE_FILE"
+  fi
+}
+
+# ── dispatch ──────────────────────────────────────────────────────────────────
+
+cmd="${arguments[0]:-}"
 
 case "$cmd" in
   start)
     if has_running; then
       exit 0
     fi
-    if command -v gpu-screen-recorder >/dev/null 2>&1; then
-      gpu-screen-recorder "$@" >/dev/null 2>&1 &
-      disown || true
+    if ! command -v gpu-screen-recorder >/dev/null 2>&1; then
+      notify_error "gpu-screen-recorder is not installed"
+      exit 1
     fi
+    do_start
     ;;
   stop)
-    pkill -x gpu-screen-recorder >/dev/null 2>&1 || true
-    rm -f "$PAUSE_STATE_FILE"
+    do_stop
     ;;
   pause)
-    if ! has_running; then
-      exit 0
-    fi
-    if [[ -f $PAUSE_STATE_FILE ]]; then
-      pkill -CONT -x gpu-screen-recorder >/dev/null 2>&1 || true
-      rm -f "$PAUSE_STATE_FILE"
-    else
-      pkill -STOP -x gpu-screen-recorder >/dev/null 2>&1 || true
-      : >"$PAUSE_STATE_FILE"
-    fi
+    do_pause
+    ;;
+  "")
+    echo "Error: no command given." >&2
+    echo "Usage: dots-recorder {start|stop|pause} [OPTIONS]" >&2
+    exit 1
     ;;
   *)
-    echo "Usage: dots-recorder {start [args...]|stop|pause}" >&2
+    echo "Error: unknown command '$cmd'." >&2
+    echo "Usage: dots-recorder {start|stop|pause} [OPTIONS]" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## What

Rewrites the `dots-recorder` script and fixes several bugs in the screen recording pipeline for Quickshell on Hyprland.

## Why

The previous script had multiple issues that prevented recordings from working correctly or being listed in the Quickshell UI.

## Changes

- **`dots-recorder`**: Fully rewritten using EasyOptions (`## docs`, proper subcommand dispatch). Subcommands: `start`, `stop`, `pause`. Flags: `-r/--region`, `-s/--sound`, `--sr` (region+sound), `--fps=FPS`. Output format changed to `.mp4` with filename `recording_YYYYMMDD_HH-MM-SS.mp4` to match the `RecordingList.qml` filter (`nameFilters: ["recording_*.mp4"]`) and date regex. Replaces `pidof`/`pkill -x` with `pgrep -f`/`pkill -f` (process name exceeds 15-char kernel limit). Adds `-fallback-cpu-encoding yes` for VA-API/NVENC unavailability. Sends `notify-send` on start and stop with filename.

- **`environment.conf`**: Adds `LIBVA_DRIVER_NAME=nvidia` and `LIBVA_DRIVERS_PATH=/usr/lib/dri` for hardware encoding via `libva-nvidia-driver`.

- **`Recorder.qml`**: Uncomments `enabled: props.running && !props.paused` on the elapsed timer `Connections` block so the timer correctly stops counting while paused.

- **`run_onchange_before_install-gpu-screen-recorder.sh.tmpl`**: Adds `intel-media-driver` and `libva-utils` to the install list for VA-API support on Intel iGPU.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it rewrites the recording control script (process detection/kill, output naming, option parsing) and adds global VA-API environment overrides, which could affect recording behavior across different hardware/drivers.
> 
> **Overview**
> Fixes the Quickshell/Hyprland recording pipeline by **rewriting `dots-recorder`** to robustly start/stop/pause `gpu-screen-recorder` with EasyOptions flags (region, audio, fps), deterministic output naming (`recording_*.mp4`), notifications, and safer process matching via `pgrep/pkill -f` plus CPU-encoding fallback.
> 
> Enables hardware-encoding support by adding **VA-API NVIDIA env vars** in `environment.conf` and installing additional VA-API packages via the Arch `yay` install script.
> 
> Corrects UI elapsed-time behavior by gating the Recorder timer (`Recorder.qml`) to stop incrementing while paused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07cd42166d51ea4ac6cbf5f49f9bcad1a52d8c24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPU screen recorder installation support for Arch Linux systems
  * Implemented recording pause/resume functionality during active recordings
  * Enhanced recorder controls with region selection, audio capture options, and desktop notifications

* **Configuration**
  * Added hardware video encoding support with VA-API environment variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->