### PR TITLE
feat(dashboard): overhaul Workspaces tab with split-pane manager

### DIFF
--- a/home/dot_config/quickshell/config/DashboardConfig.qml
+++ b/home/dot_config/quickshell/config/DashboardConfig.qml
@@ -8,6 +8,17 @@ JsonObject {
     property int dragThreshold: 50
     property Sizes sizes: Sizes {}
     property Performance performance: Performance {}
+    property Workspaces workspaces: Workspaces {}
+
+    component Workspaces: JsonObject {
+        property bool showLivePreview: true
+        property bool showSpecialWorkspaces: true
+        property bool showWindowBadges: true
+        property bool showMonitorBadge: true
+        property int maxAppIcons: 4
+        property int previewHeight: 200
+        property bool enableWindowActions: true
+    }
 
     component Performance: JsonObject {
         property bool showBattery: true

--- a/home/dot_config/quickshell/modules/dashboard/Workspaces.qml
+++ b/home/dot_config/quickshell/modules/dashboard/Workspaces.qml
@@ -1,134 +1,187 @@
 pragma ComponentBehavior: Bound
 
 import qs.components
+import qs.components.containers
+import qs.components.controls
 import qs.services
 import qs.config
+import "dash"
 import Quickshell
 import Quickshell.Hyprland
 import QtQuick
 import QtQuick.Layouts
 
+// Dashboard Workspaces tab — split pane workspace manager.
+//
+// Left pane: scrollable flow of workspace cards + special workspaces section.
+// Right pane: detail panel for the selected workspace (live preview, window list, actions).
+// Bottom: status bar with monitor + window summary.
 Item {
     id: root
 
     // Minimum matches dashboard panel width — avoids circular dependency
-    // with anchors.fill on the inner ColumnLayout
     implicitWidth: 800
     implicitHeight: layout.implicitHeight + Appearance.padding.large * 2
+
+    // Selection state — independent from the active workspace.
+    // Clicking a card switches the active WS AND selects it for the detail panel.
+    property int selectedWsId: Hypr.activeWsId
 
     readonly property var regularWorkspaces: {
         const all = Hypr.workspaces.values;
         return all.filter(w => !w.name.startsWith("special:")).sort((a, b) => a.id - b.id);
     }
 
+    readonly property var specialWorkspaces: {
+        return Hypr.workspaces.values.filter(w => w.name.startsWith("special:"));
+    }
+
+    readonly property HyprlandWorkspace selectedWorkspace: {
+        return Hypr.workspaces.values.find(w => w.id === root.selectedWsId) ?? null;
+    }
+
+    readonly property string activeSpecialName: Hypr.focusedMonitor?.lastIpcObject?.specialWorkspace?.name ?? ""
+
+    readonly property int totalWindows: {
+        return root.regularWorkspaces.reduce((acc, ws) => acc + (ws.lastIpcObject?.windows ?? 0), 0);
+    }
+
+    readonly property int floatingCount: {
+        return Hypr.toplevels.values.filter(t =>
+            t.workspace?.id === root.selectedWsId && t.lastIpcObject?.floating
+        ).length;
+    }
+
+    // Reset selection to active when tab reopens
+    Component.onCompleted: root.selectedWsId = Hypr.activeWsId
+
     ColumnLayout {
         id: layout
+
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
         anchors.margins: Appearance.padding.large
+
         spacing: Appearance.spacing.normal
 
-        StyledText {
-            text: qsTr("Workspaces")
-            font.pointSize: Appearance.font.size.larger
-            font.weight: 500
+        // Header
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Appearance.spacing.normal
+
+            StyledText {
+                text: qsTr("Workspaces")
+                font.pointSize: Appearance.font.size.larger
+                font.weight: 500
+                Layout.fillWidth: true
+            }
+
+            // Status summary
+            StyledText {
+                text: qsTr("%1 windows · %2 floating").arg(root.totalWindows).arg(root.floatingCount)
+                font.pointSize: Appearance.font.size.small
+                color: Colours.palette.m3outline
+            }
         }
 
-        Flow {
-            id: wsGrid
+        // Main split: left cards + right detail
+        RowLayout {
             Layout.fillWidth: true
-            spacing: Appearance.spacing.small
+            Layout.fillHeight: true
 
-            Repeater {
-                model: root.regularWorkspaces
+            spacing: Appearance.spacing.normal
 
-                Item {
-                    id: wsItem
-                    required property HyprlandWorkspace modelData
-                    readonly property bool isActive: wsItem.modelData.id === Hypr.activeWsId
-                    readonly property int windowCount: wsItem.modelData.lastIpcObject?.windows ?? 0
+            // ── Left pane: workspace cards ──────────────────────────────
+            ColumnLayout {
+                Layout.fillHeight: true
+                Layout.preferredWidth: 340
 
-                    implicitWidth: wsCard.implicitWidth
-                    implicitHeight: wsCard.implicitHeight
+                spacing: Appearance.spacing.small
 
-                    StyledRect {
-                        id: wsCard
-                        radius: Appearance.rounding.normal
-                        color: wsItem.isActive
-                            ? Colours.palette.m3primaryContainer
-                            : Colours.layer(Colours.palette.m3surfaceContainer, 1)
-                        implicitWidth: 120
-                        implicitHeight: wsContent.implicitHeight + Appearance.padding.normal * 2
+                // Regular workspaces — scrollable flow
+                StyledRect {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
 
-                        StateLayer {
-                            color: wsItem.isActive
-                                ? Colours.palette.m3onPrimaryContainer
-                                : Colours.palette.m3onSurface
-                            function onClicked() {
-                                Hypr.dispatch(`workspace ${wsItem.modelData.id}`);
-                            }
-                        }
+                    radius: Appearance.rounding.normal
+                    color: Colours.layer(Colours.tPalette.m3surfaceContainer, 1)
 
-                        ColumnLayout {
-                            id: wsContent
+                    StyledFlickable {
+                        id: wsFlick
+
+                        anchors.fill: parent
+                        anchors.margins: Appearance.padding.normal
+
+                        flickableDirection: Flickable.VerticalFlick
+                        contentHeight: wsFlow.implicitHeight
+                        clip: true
+
+                        Flow {
+                            id: wsFlow
+
                             anchors.left: parent.left
                             anchors.right: parent.right
-                            anchors.verticalCenter: parent.verticalCenter
-                            anchors.margins: Appearance.padding.normal
-                            spacing: Appearance.spacing.small / 2
+                            anchors.top: parent.top
 
-                            RowLayout {
-                                Layout.fillWidth: true
-                                spacing: Appearance.spacing.small
+                            spacing: Appearance.spacing.small
 
-                                StyledText {
-                                    text: wsItem.modelData.name
-                                    font.pointSize: Appearance.font.size.normal
-                                    font.weight: wsItem.isActive ? 700 : 500
-                                    color: wsItem.isActive
-                                        ? Colours.palette.m3onPrimaryContainer
-                                        : Colours.palette.m3onSurface
-                                    elide: Text.ElideRight
-                                    Layout.fillWidth: true
-                                }
+                            Repeater {
+                                model: root.regularWorkspaces
 
-                                StyledRect {
-                                    visible: wsItem.windowCount > 0
-                                    radius: Appearance.rounding.full
-                                    color: wsItem.isActive
-                                        ? Qt.alpha(Colours.palette.m3onPrimaryContainer, 0.2)
-                                        : Colours.layer(Colours.palette.m3surfaceContainerHigh, 1)
-                                    implicitWidth: winCount.implicitWidth + Appearance.padding.small * 2
-                                    implicitHeight: winCount.implicitHeight + 2
+                                delegate: WorkspaceCard {
+                                    isActive: modelData.id === Hypr.activeWsId
+                                    isSelected: modelData.id === root.selectedWsId
 
-                                    StyledText {
-                                        id: winCount
-                                        anchors.centerIn: parent
-                                        text: wsItem.windowCount
-                                        font.pointSize: Appearance.font.size.smaller
-                                        color: wsItem.isActive
-                                            ? Colours.palette.m3onPrimaryContainer
-                                            : Colours.palette.m3onSurfaceVariant
+                                    onClicked: {
+                                        root.selectedWsId = modelData.id;
+                                        Hypr.dispatch(`workspace ${modelData.id}`);
                                     }
                                 }
                             }
 
-                            // Window indicators (dots for each window)
-                            Row {
-                                visible: wsItem.windowCount > 0
-                                spacing: 3
+                            // Empty state
+                            StyledText {
+                                visible: root.regularWorkspaces.length === 0
+                                text: qsTr("No workspaces open")
+                                color: Colours.palette.m3outline
+                                font.pointSize: Appearance.font.size.normal
+                            }
+                        }
 
-                                Repeater {
-                                    model: Math.min(wsItem.windowCount, 8)
-                                    Rectangle {
-                                        width: 5
-                                        height: 5
-                                        radius: width / 2
-                                        color: wsItem.isActive
-                                            ? Colours.palette.m3onPrimaryContainer
-                                            : Colours.palette.m3outline
-                                        opacity: 0.7
+                        StyledScrollBar.vertical: StyledScrollBar {
+                            flickable: wsFlick
+                        }
+                    }
+                }
+
+                // Special workspaces section
+                Loader {
+                    Layout.fillWidth: true
+                    active: Config.dashboard.workspaces.showSpecialWorkspaces && root.specialWorkspaces.length > 0
+
+                    sourceComponent: ColumnLayout {
+                        spacing: Appearance.spacing.small
+
+                        StyledText {
+                            text: qsTr("Special Workspaces")
+                            font.pointSize: Appearance.font.size.normal
+                            font.weight: 600
+                            color: Colours.palette.m3tertiary
+                        }
+
+                        Flow {
+                            Layout.fillWidth: true
+                            spacing: Appearance.spacing.small
+
+                            Repeater {
+                                model: root.specialWorkspaces
+
+                                delegate: SpecialWsCard {
+                                    isActive: modelData.name === root.activeSpecialName
+
+                                    onClicked: {
+                                        Hypr.dispatch(`togglespecialworkspace ${modelData.name.slice("special:".length)}`);
                                     }
                                 }
                             }
@@ -137,56 +190,104 @@ Item {
                 }
             }
 
-            // Empty state when no workspaces
-            StyledText {
-                visible: root.regularWorkspaces.length === 0
-                text: qsTr("No workspaces open")
-                color: Colours.palette.m3outline
-                font.pointSize: Appearance.font.size.normal
+            // ── Right pane: workspace detail ────────────────────────────
+            StyledRect {
+                Layout.fillHeight: true
+                Layout.fillWidth: true
+
+                radius: Appearance.rounding.normal
+                color: Colours.layer(Colours.tPalette.m3surfaceContainer, 1)
+
+                Loader {
+                    id: detailLoader
+
+                    anchors.fill: parent
+                    anchors.margins: Appearance.padding.normal
+
+                    active: root.selectedWorkspace !== null
+
+                    sourceComponent: WorkspaceDetail {
+                        wsId: root.selectedWsId
+                        workspace: root.selectedWorkspace
+                    }
+                }
+
+                // Empty state when no workspace selected
+                Item {
+                    anchors.fill: parent
+                    visible: root.selectedWorkspace === null
+
+                    ColumnLayout {
+                        anchors.centerIn: parent
+                        spacing: Appearance.spacing.small
+
+                        MaterialIcon {
+                            Layout.alignment: Qt.AlignHCenter
+                            text: "workspaces"
+                            color: Colours.palette.m3outline
+                            font.pointSize: Appearance.font.size.extraLarge * 2
+                        }
+
+                        StyledText {
+                            Layout.alignment: Qt.AlignHCenter
+                            text: qsTr("Select a workspace")
+                            color: Colours.palette.m3outline
+                            font.pointSize: Appearance.font.size.normal
+                        }
+                    }
+                }
             }
         }
 
-        // Active workspace info
+        // ── Bottom status bar ──────────────────────────────────────────
         StyledRect {
             Layout.fillWidth: true
             radius: Appearance.rounding.normal
-            color: Colours.layer(Colours.palette.m3surfaceContainer, 1)
-            implicitHeight: activeInfo.implicitHeight + Appearance.padding.normal * 2
-            visible: Hypr.focusedWorkspace !== null
+            color: Colours.layer(Colours.tPalette.m3surfaceContainer, 1)
+            implicitHeight: statusRow.implicitHeight + Appearance.padding.small * 2
 
             RowLayout {
-                id: activeInfo
+                id: statusRow
+
                 anchors.left: parent.left
                 anchors.right: parent.right
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.margins: Appearance.padding.normal
+
                 spacing: Appearance.spacing.normal
 
                 MaterialIcon {
                     text: "monitor"
                     color: Colours.palette.m3primary
-                    font.pointSize: Appearance.font.size.large
+                    font.pointSize: Appearance.font.size.normal
                 }
 
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: 2
-
-                    StyledText {
-                        text: qsTr("Workspace %1").arg(Hypr.activeWsId)
-                        font.pointSize: Appearance.font.size.normal
-                        font.weight: 600
-                        color: Colours.palette.m3primary
+                StyledText {
+                    text: {
+                        const mon = Hypr.focusedMonitor;
+                        if (mon)
+                            return qsTr("Monitor: %1 · Active: WS %2").arg(mon.name).arg(Hypr.activeWsId);
+                        return qsTr("Active: WS %1").arg(Hypr.activeWsId);
                     }
+                    font.pointSize: Appearance.font.size.small
+                    color: Colours.palette.m3onSurfaceVariant
+                    Layout.fillWidth: true
+                }
+
+                // Monitor count badge (multi-monitor)
+                StyledRect {
+                    visible: Hypr.monitors.values.length > 1
+                    radius: Appearance.rounding.full
+                    color: Qt.alpha(Colours.palette.m3primary, 0.15)
+                    implicitWidth: monCount.implicitWidth + Appearance.padding.small * 2
+                    implicitHeight: monCount.implicitHeight + 2
 
                     StyledText {
-                        text: {
-                            const ws = Hypr.workspaces.values.find(w => w.id === Hypr.activeWsId);
-                            const n = ws?.lastIpcObject?.windows ?? 0;
-                            return n === 0 ? qsTr("Empty") : qsTr("%1 window(s)").arg(n);
-                        }
-                        color: Colours.palette.m3outline
+                        id: monCount
+                        anchors.centerIn: parent
+                        text: qsTr("%1 monitors").arg(Hypr.monitors.values.length)
                         font.pointSize: Appearance.font.size.small
+                        color: Colours.palette.m3primary
                     }
                 }
             }

--- a/home/dot_config/quickshell/modules/dashboard/dash/SpecialWsCard.qml
+++ b/home/dot_config/quickshell/modules/dashboard/dash/SpecialWsCard.qml
@@ -1,0 +1,122 @@
+pragma ComponentBehavior: Bound
+
+import qs.components
+import qs.services
+import qs.utils
+import qs.config
+import Quickshell.Hyprland
+import QtQuick
+import QtQuick.Layouts
+
+// Special workspace card for the dashboard Workspaces tab.
+//
+// Shows the special workspace icon, name, and window count.
+// Clicking toggles the special workspace.
+Item {
+    id: root
+
+    required property HyprlandWorkspace modelData
+    required property bool isActive
+
+    signal clicked()
+
+    readonly property int windowCount: root.modelData.lastIpcObject?.windows ?? 0
+    readonly property string iconName: Icons.getSpecialWsIcon(root.modelData.name)
+    readonly property string displayName: root.modelData.name.slice("special:".length)
+
+    implicitWidth: 130
+    implicitHeight: wsCard.implicitHeight
+
+    StyledRect {
+        id: wsCard
+
+        anchors.fill: parent
+
+        radius: Appearance.rounding.normal
+        color: root.isActive
+            ? Colours.tPalette.m3tertiaryContainer
+            : Colours.layer(Colours.tPalette.m3surfaceContainer, 1)
+        border.width: root.isActive ? 1 : 0
+        border.color: Colours.palette.m3tertiary
+
+        Behavior on color {
+            ColorAnimation {
+                duration: Appearance.anim.durations.small
+            }
+        }
+
+        StateLayer {
+            color: root.isActive
+                ? Colours.palette.m3onTertiaryContainer
+                : Colours.palette.m3onSurface
+
+            function onClicked(): void {
+                root.clicked();
+            }
+        }
+
+        RowLayout {
+            anchors.fill: parent
+            anchors.margins: Appearance.padding.normal
+
+            spacing: Appearance.spacing.small
+
+            // Icon or letter
+            Loader {
+                Layout.alignment: Qt.AlignVCenter
+                sourceComponent: root.iconName.length === 1 ? letterComp : iconComp
+
+                Component {
+                    id: iconComp
+
+                    MaterialIcon {
+                        text: root.iconName
+                        color: root.isActive
+                            ? Colours.palette.m3onTertiaryContainer
+                            : Colours.palette.m3tertiary
+                        font.pointSize: Appearance.font.size.large
+                    }
+                }
+
+                Component {
+                    id: letterComp
+
+                    StyledText {
+                        text: root.iconName
+                        color: root.isActive
+                            ? Colours.palette.m3onTertiaryContainer
+                            : Colours.palette.m3tertiary
+                        font.pointSize: Appearance.font.size.normal
+                        font.weight: 600
+                    }
+                }
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 0
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: root.displayName
+                    font.pointSize: Appearance.font.size.normal
+                    font.weight: root.isActive ? 700 : 500
+                    color: root.isActive
+                        ? Colours.palette.m3onTertiaryContainer
+                        : Colours.palette.m3onSurface
+                    elide: Text.ElideRight
+                }
+
+                StyledText {
+                    text: root.windowCount > 0
+                        ? qsTr("%1 window(s)").arg(root.windowCount)
+                        : qsTr("Empty")
+                    font.pointSize: Appearance.font.size.small
+                    color: root.isActive
+                        ? Colours.palette.m3onTertiaryContainer
+                        : Colours.palette.m3outline
+                }
+            }
+        }
+    }
+}

--- a/home/dot_config/quickshell/modules/dashboard/dash/WindowListItem.qml
+++ b/home/dot_config/quickshell/modules/dashboard/dash/WindowListItem.qml
@@ -1,0 +1,159 @@
+pragma ComponentBehavior: Bound
+
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.utils
+import qs.config
+import Quickshell.Hyprland
+import QtQuick
+import QtQuick.Layouts
+
+// Window list item for the workspace detail panel.
+//
+// Shows app icon, title, state badges (floating/fullscreen/pinned),
+// and action buttons (float/tile, pin, kill, move-to-WS).
+Item {
+    id: root
+
+    required property HyprlandToplevel modelData
+    required property bool isActive
+
+    signal focusRequested()
+
+    readonly property string addr: `0x${root.modelData.address}`
+    readonly property bool floating: root.modelData.lastIpcObject?.floating ?? false
+    readonly property bool pinned: root.modelData.lastIpcObject?.pinned ?? false
+    readonly property int fullscreen: root.modelData.lastIpcObject?.fullscreen ?? 0
+
+    implicitWidth: card.implicitWidth
+    implicitHeight: card.implicitHeight
+
+    StyledRect {
+        id: card
+
+        anchors.fill: parent
+
+        radius: Appearance.rounding.small
+        color: root.isActive
+            ? Qt.alpha(Colours.palette.m3primary, 0.12)
+            : Colours.layer(Colours.tPalette.m3surfaceContainerHigh, 1)
+        border.width: root.isActive ? 1 : 0
+        border.color: Colours.palette.m3primary
+
+        Behavior on color {
+            ColorAnimation {
+                duration: Appearance.anim.durations.small
+            }
+        }
+
+        RowLayout {
+            anchors.fill: parent
+            anchors.margins: Appearance.padding.small
+
+            spacing: Appearance.spacing.small
+
+            // App icon
+            MaterialIcon {
+                Layout.alignment: Qt.AlignVCenter
+                text: Icons.getAppCategoryIcon(root.modelData.lastIpcObject?.class ?? "", "terminal")
+                color: root.isActive ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+                font.pointSize: Appearance.font.size.normal
+            }
+
+            // Title + badges
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 0
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: root.modelData.title ?? qsTr("Unknown")
+                    font.pointSize: Appearance.font.size.small
+                    font.weight: root.isActive ? 600 : 400
+                    color: root.isActive ? Colours.palette.m3primary : Colours.palette.m3onSurface
+                    elide: Text.ElideRight
+                }
+
+                // Badges row
+                Row {
+                    visible: Config.dashboard.workspaces.showWindowBadges
+                    spacing: 2
+
+                    // Floating badge
+                    MaterialIcon {
+                        visible: root.floating
+                        text: "picture_in_picture"
+                        color: Colours.palette.m3tertiary
+                        font.pointSize: Appearance.font.size.small
+                    }
+
+                    // Fullscreen badge
+                    MaterialIcon {
+                        visible: root.fullscreen > 0
+                        text: "fullscreen"
+                        color: Colours.palette.m3secondary
+                        font.pointSize: Appearance.font.size.small
+                    }
+
+                    // Pinned badge
+                    MaterialIcon {
+                        visible: root.pinned
+                        text: "keep"
+                        color: Colours.palette.m3secondary
+                        font.pointSize: Appearance.font.size.small
+                    }
+                }
+            }
+
+            // Action buttons (only when window actions enabled)
+            Row {
+                visible: Config.dashboard.workspaces.enableWindowActions
+                spacing: 2
+
+                // Float/Tile toggle
+                IconButton {
+                    type: IconButton.Text
+                    icon: root.floating ? "select_window" : "select_window_off"
+                    padding: Appearance.padding.small / 2
+                    font.pointSize: Appearance.font.size.small
+
+                    onClicked: Hypr.dispatch(`togglefloating address:${root.addr}`)
+                }
+
+                // Pin/Unpin
+                IconButton {
+                    type: IconButton.Text
+                    icon: root.pinned ? "push_pin" : "push_pin"
+                    padding: Appearance.padding.small / 2
+                    font.pointSize: Appearance.font.size.small
+                    internalChecked: root.pinned
+                    toggle: true
+
+                    onClicked: Hypr.dispatch(`pin address:${root.addr}`)
+                }
+
+                // Kill
+                IconButton {
+                    type: IconButton.Text
+                    icon: "close"
+                    padding: Appearance.padding.small / 2
+                    font.pointSize: Appearance.font.size.small
+
+                    onClicked: Hypr.dispatch(`killwindow address:${root.addr}`)
+                }
+            }
+        }
+
+        // Click to focus
+        MouseArea {
+            anchors.fill: parent
+            acceptedButtons: Qt.LeftButton
+            propagateComposedEvents: true
+            onClicked: event => {
+                root.focusRequested();
+                event.accepted = false;
+            }
+        }
+    }
+}

--- a/home/dot_config/quickshell/modules/dashboard/dash/WorkspaceCard.qml
+++ b/home/dot_config/quickshell/modules/dashboard/dash/WorkspaceCard.qml
@@ -1,0 +1,181 @@
+pragma ComponentBehavior: Bound
+
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.utils
+import qs.config
+import Quickshell.Hyprland
+import QtQuick
+import QtQuick.Layouts
+
+// Workspace card for the dashboard Workspaces tab.
+//
+// Shows workspace name, app icons (up to maxAppIcons), window count badge,
+// and optional monitor badge. Clicking switches to the workspace and
+// selects it for the detail panel.
+Item {
+    id: root
+
+    required property HyprlandWorkspace modelData
+    required property bool isSelected
+    required property bool isActive
+
+    signal clicked()
+
+    readonly property int windowCount: root.modelData.lastIpcObject?.windows ?? 0
+    readonly property var wsToplevels: Hypr.toplevels.values.filter(t => t.workspace?.id === root.modelData.id)
+    readonly property string monitorName: {
+        const mon = Hypr.monitors.values.find(m => m.activeWorkspace?.id === root.modelData.id);
+        return mon?.name ?? "";
+    }
+
+    implicitWidth: 130
+    implicitHeight: wsCard.implicitHeight
+
+    StyledRect {
+        id: wsCard
+
+        anchors.fill: parent
+
+        radius: Appearance.rounding.normal
+        color: root.isActive
+            ? Colours.tPalette.m3primaryContainer
+            : root.isSelected
+                ? Colours.tPalette.m3secondaryContainer
+                : Colours.layer(Colours.tPalette.m3surfaceContainer, 1)
+        border.width: root.isActive || root.isSelected ? 1 : 0
+        border.color: root.isActive ? Colours.palette.m3primary : Colours.palette.m3secondary
+
+        Behavior on color {
+            ColorAnimation {
+                duration: Appearance.anim.durations.small
+            }
+        }
+
+        StateLayer {
+            color: root.isActive
+                ? Colours.palette.m3onPrimaryContainer
+                : root.isSelected
+                    ? Colours.palette.m3onSecondaryContainer
+                    : Colours.palette.m3onSurface
+
+            function onClicked(): void {
+                root.clicked();
+            }
+        }
+
+        ColumnLayout {
+            id: content
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.margins: Appearance.padding.normal
+
+            spacing: Appearance.spacing.small / 2
+
+            // Header: WS name + monitor badge + window count
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Appearance.spacing.small
+
+                StyledText {
+                    text: root.modelData.name
+                    font.pointSize: Appearance.font.size.normal
+                    font.weight: root.isActive ? 700 : 500
+                    color: root.isActive
+                        ? Colours.palette.m3onPrimaryContainer
+                        : root.isSelected
+                            ? Colours.palette.m3onSecondaryContainer
+                            : Colours.palette.m3onSurface
+                    elide: Text.ElideRight
+                    Layout.fillWidth: true
+                }
+
+                // Monitor badge (only if multi-monitor and config enabled)
+                StyledRect {
+                    visible: root.monitorName !== "" && Config.dashboard.workspaces.showMonitorBadge && Hypr.monitors.values.length > 1
+                    radius: Appearance.rounding.full
+                    color: Qt.alpha(Colours.palette.m3outline, 0.15)
+                    implicitWidth: monLabel.implicitWidth + Appearance.padding.small
+                    implicitHeight: monLabel.implicitHeight + 2
+
+                    StyledText {
+                        id: monLabel
+                        anchors.centerIn: parent
+                        text: root.monitorName
+                        font.pointSize: Appearance.font.size.small
+                        color: root.isActive
+                            ? Colours.palette.m3onPrimaryContainer
+                            : Colours.palette.m3onSurfaceVariant
+                    }
+                }
+
+                // Window count badge
+                StyledRect {
+                    visible: root.windowCount > 0
+                    radius: Appearance.rounding.full
+                    color: root.isActive
+                        ? Qt.alpha(Colours.palette.m3onPrimaryContainer, 0.2)
+                        : Colours.layer(Colours.tPalette.m3surfaceContainerHigh, 1)
+                    implicitWidth: winCount.implicitWidth + Appearance.padding.small * 2
+                    implicitHeight: winCount.implicitHeight + 2
+
+                    StyledText {
+                        id: winCount
+                        anchors.centerIn: parent
+                        text: root.windowCount
+                        font.pointSize: Appearance.font.size.smaller
+                        color: root.isActive
+                            ? Colours.palette.m3onPrimaryContainer
+                            : Colours.palette.m3onSurfaceVariant
+                    }
+                }
+            }
+
+            // App icons row (up to maxAppIcons)
+            Row {
+                Layout.fillWidth: true
+                spacing: 4
+
+                Repeater {
+                    model: Math.min(root.wsToplevels.length, Config.dashboard.workspaces.maxAppIcons)
+
+                    MaterialIcon {
+                        required property int index
+
+                        text: Icons.getAppCategoryIcon(root.wsToplevels[index]?.lastIpcObject?.class ?? "", "terminal")
+                        color: root.isActive
+                            ? Colours.palette.m3onPrimaryContainer
+                            : root.isSelected
+                                ? Colours.palette.m3onSecondaryContainer
+                                : Colours.palette.m3onSurfaceVariant
+                        font.pointSize: Appearance.font.size.normal
+                        opacity: 0.85
+                    }
+                }
+
+                // Overflow indicator
+                StyledText {
+                    visible: root.wsToplevels.length > Config.dashboard.workspaces.maxAppIcons
+                    text: qsTr("+%1").arg(root.wsToplevels.length - Config.dashboard.workspaces.maxAppIcons)
+                    font.pointSize: Appearance.font.size.smaller
+                    color: root.isActive
+                        ? Colours.palette.m3onPrimaryContainer
+                        : Colours.palette.m3outline
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+            }
+
+            // Active check mark
+            MaterialIcon {
+                Layout.alignment: Qt.AlignHCenter
+                visible: root.isActive
+                text: "check_circle"
+                color: Colours.palette.m3onPrimaryContainer
+                font.pointSize: Appearance.font.size.small
+            }
+        }
+    }
+}

--- a/home/dot_config/quickshell/modules/dashboard/dash/WorkspaceDetail.qml
+++ b/home/dot_config/quickshell/modules/dashboard/dash/WorkspaceDetail.qml
@@ -1,0 +1,196 @@
+pragma ComponentBehavior: Bound
+
+import qs.components
+import qs.components.containers
+import qs.components.controls
+import qs.services
+import qs.config
+import Quickshell
+import Quickshell.Hyprland
+import Quickshell.Wayland
+import QtQuick
+import QtQuick.Layouts
+
+// Detail panel for the selected workspace.
+//
+// Shows a live preview of the focused window (ScreencopyView),
+// a scrollable list of windows with badges and actions,
+// and a workspace action bar (rename / new / close-all).
+Item {
+    id: root
+
+    required property int wsId
+    required property HyprlandWorkspace workspace
+
+    readonly property var wsToplevels: Hypr.toplevels.values.filter(t => t.workspace?.id === root.wsId)
+    readonly property HyprlandToplevel focusedToplevel: {
+        return root.wsToplevels.find(t => t.wayland?.activated) ?? root.wsToplevels[0] ?? null;
+    }
+    readonly property int windowCount: root.workspace?.lastIpcObject?.windows ?? 0
+    readonly property string wsName: root.workspace?.name ?? qsTr("Workspace %1").arg(root.wsId)
+
+    implicitWidth: layout.implicitWidth
+    implicitHeight: layout.implicitHeight
+
+    ColumnLayout {
+        id: layout
+
+        anchors.fill: parent
+
+        spacing: Appearance.spacing.normal
+
+        // Header: workspace name + window count
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Appearance.spacing.small
+
+            StyledText {
+                text: root.wsName
+                font.pointSize: Appearance.font.size.larger
+                font.weight: 600
+                color: Colours.palette.m3primary
+                Layout.fillWidth: true
+                elide: Text.ElideRight
+            }
+
+            StyledText {
+                text: root.windowCount === 0
+                    ? qsTr("Empty")
+                    : qsTr("%1 window(s)").arg(root.windowCount)
+                font.pointSize: Appearance.font.size.small
+                color: Colours.palette.m3outline
+            }
+        }
+
+        // Live preview of the focused window
+        Loader {
+            id: previewLoader
+
+            Layout.fillWidth: true
+            Layout.preferredHeight: Config.dashboard.workspaces.previewHeight
+
+            active: Config.dashboard.workspaces.showLivePreview && root.focusedToplevel !== null
+
+            sourceComponent: StyledClippingRect {
+                id: preview
+
+                anchors.fill: parent
+                radius: Appearance.rounding.normal
+                color: Colours.tPalette.m3surfaceContainer
+
+                ScreencopyView {
+                    id: view
+
+                    anchors.centerIn: parent
+
+                    captureSource: root.focusedToplevel?.wayland ?? null
+                    live: true
+
+                    constraintSize.width: root.focusedToplevel
+                        ? parent.height * Math.min(
+                            Screen.width / Screen.height,
+                            root.focusedToplevel?.lastIpcObject?.size?.[0] / root.focusedToplevel?.lastIpcObject?.size?.[1] ?? 1
+                        )
+                        : parent.width
+                    constraintSize.height: parent.height
+                }
+
+                // Empty state
+                Item {
+                    anchors.fill: parent
+                    visible: root.focusedToplevel === null
+
+                    ColumnLayout {
+                        anchors.centerIn: parent
+                        spacing: Appearance.spacing.small
+
+                        MaterialIcon {
+                            Layout.alignment: Qt.AlignHCenter
+                            text: "image_not_supported"
+                            color: Colours.palette.m3outline
+                            font.pointSize: Appearance.font.size.extraLarge * 2
+                        }
+
+                        StyledText {
+                            Layout.alignment: Qt.AlignHCenter
+                            text: qsTr("No windows to preview")
+                            color: Colours.palette.m3outline
+                            font.pointSize: Appearance.font.size.normal
+                        }
+                    }
+                }
+            }
+        }
+
+        // Window list
+        StyledRect {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            radius: Appearance.rounding.normal
+            color: Colours.layer(Colours.tPalette.m3surfaceContainer, 1)
+
+            implicitHeight: winList.implicitHeight + Appearance.padding.normal * 2
+
+            // Empty state
+            Item {
+                anchors.fill: parent
+                visible: root.wsToplevels.length === 0
+
+                ColumnLayout {
+                    anchors.centerIn: parent
+                    spacing: Appearance.spacing.small
+
+                    MaterialIcon {
+                        Layout.alignment: Qt.AlignHCenter
+                        text: "select_window_off"
+                        color: Colours.palette.m3outline
+                        font.pointSize: Appearance.font.size.extraLarge
+                    }
+
+                    StyledText {
+                        Layout.alignment: Qt.AlignHCenter
+                        text: qsTr("No windows in this workspace")
+                        color: Colours.palette.m3outline
+                        font.pointSize: Appearance.font.size.normal
+                    }
+                }
+            }
+
+            StyledListView {
+                id: winList
+
+                anchors.fill: parent
+                anchors.margins: Appearance.padding.normal
+
+                visible: root.wsToplevels.length > 0
+
+                spacing: Appearance.spacing.small / 2
+                clip: true
+
+                model: ScriptModel {
+                    values: root.wsToplevels
+                }
+
+                delegate: WindowListItem {
+                    width: winList.width
+                    isActive: modelData.wayland?.activated ?? false
+
+                    onFocusRequested: {
+                        Hypr.dispatch(`focuswindow address:0x${modelData.address}`);
+                    }
+                }
+
+                StyledScrollBar.vertical: StyledScrollBar {
+                    flickable: winList
+                }
+            }
+        }
+
+        // Workspace actions bar
+        WsActionsBar {
+            Layout.fillWidth: true
+            wsId: root.wsId
+        }
+    }
+}

--- a/home/dot_config/quickshell/modules/dashboard/dash/WsActionsBar.qml
+++ b/home/dot_config/quickshell/modules/dashboard/dash/WsActionsBar.qml
@@ -1,0 +1,141 @@
+pragma ComponentBehavior: Bound
+
+import qs.components
+import qs.components.controls
+import qs.services
+import qs.config
+import Quickshell.Hyprland
+import QtQuick
+import QtQuick.Layouts
+
+// Action bar for workspace-level operations: rename, new, close-all.
+//
+// Rename shows an inline text field; New creates an empty workspace;
+// Close-all kills every window in the selected workspace.
+Item {
+    id: root
+
+    required property int wsId
+
+    implicitWidth: layout.implicitWidth
+    implicitHeight: layout.implicitHeight
+
+    property bool renameActive: false
+
+    RowLayout {
+        id: layout
+
+        anchors.fill: parent
+
+        spacing: Appearance.spacing.small
+
+        // Rename inline
+        Item {
+            Layout.fillWidth: true
+            Layout.preferredHeight: renameField.visible ? renameField.implicitHeight : renameBtn.implicitHeight
+            clip: true
+
+            TextButton {
+                id: renameBtn
+                anchors.left: parent.left
+                visible: !root.renameActive
+                type: TextButton.Tonal
+                text: qsTr("Rename")
+                horizontalPadding: Appearance.padding.normal
+                verticalPadding: Appearance.padding.small / 2
+                font.pointSize: Appearance.font.size.small
+
+                onClicked: root.renameActive = true
+            }
+
+            RowLayout {
+                anchors.fill: parent
+                visible: root.renameActive
+                spacing: Appearance.spacing.small
+
+                StyledRect {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: renameField.implicitHeight + Appearance.padding.small
+                    radius: Appearance.rounding.small
+                    color: Colours.tPalette.m3surfaceContainerHigh
+                    border.width: 1
+                    border.color: Colours.palette.m3primary
+
+                    StyledTextField {
+                        id: renameField
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.margins: Appearance.padding.small
+                        placeholderText: qsTr("Workspace name…")
+                        font.pointSize: Appearance.font.size.small
+
+                        focus: root.renameActive
+                        onAccepted: {
+                            if (text.trim().length > 0)
+                                Hypr.dispatch(`workspace name:${text.trim()}:${root.wsId}`)
+                            text = ""
+                            root.renameActive = false
+                        }
+                        Keys.onEscapePressed: {
+                            text = ""
+                            root.renameActive = false
+                        }
+                    }
+                }
+
+                IconButton {
+                    type: IconButton.Tonal
+                    icon: "check"
+                    padding: Appearance.padding.small / 2
+                    font.pointSize: Appearance.font.size.small
+
+                    onClicked: {
+                        if (renameField.text.trim().length > 0)
+                            Hypr.dispatch(`workspace name:${renameField.text.trim()}:${root.wsId}`)
+                        renameField.text = ""
+                        root.renameActive = false
+                    }
+                }
+
+                IconButton {
+                    type: IconButton.Text
+                    icon: "close"
+                    padding: Appearance.padding.small / 2
+                    font.pointSize: Appearance.font.size.small
+
+                    onClicked: {
+                        renameField.text = ""
+                        root.renameActive = false
+                    }
+                }
+            }
+        }
+
+        // New workspace
+        TextButton {
+            type: TextButton.Tonal
+            text: qsTr("New WS")
+            horizontalPadding: Appearance.padding.normal
+            verticalPadding: Appearance.padding.small / 2
+            font.pointSize: Appearance.font.size.small
+
+            onClicked: Hypr.dispatch("workspace empty")
+        }
+
+        // Close all windows in this WS
+        TextButton {
+            type: TextButton.Tonal
+            text: qsTr("Close All")
+            horizontalPadding: Appearance.padding.normal
+            verticalPadding: Appearance.padding.small / 2
+            font.pointSize: Appearance.font.size.small
+
+            onClicked: {
+                const toplevels = Hypr.toplevels.values.filter(t => t.workspace?.id === root.wsId);
+                for (const t of toplevels)
+                    Hypr.dispatch(`killwindow address:0x${t.address}`);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the passive workspace card grid in the Dashboard > Workspaces tab with a full **split-pane workspace manager**.

## Changes

### New layout (split pane)

```
┌─────────────────────────────────────────────────────────────┐
│  Workspaces                    [N windows · M floating]     │
├──────────────────┬──────────────────────────────────────────┤
│  Left pane       │  Right pane (detail)                     │
│                  │                                          │
│  ┌──┐ ┌──┐      │  ┌────────────────────────────────────┐  │
│  │ 1│ │ 2│      │  │  Live Preview (ScreencopyView)    │  │
│  │●● │ │●  │    │  └────────────────────────────────────┘  │
│  └──┘ └──┘      │                                          │
│  ┌──┐ ┌──┐      │  Windows in WS 3:                        │
│  │ 3│ │ 4│      │  [icon] Firefox — "Google"  [float][kill]│
│  └──┘ └──┘      │  [icon] Kitty — "zsh"       [pin] [kill] │
│                  │                                          │
│  Special:        │  [Rename] [New WS] [Close All]           │
│  ┌──┐           │                                          │
│  │ S│           │                                          │
│  └──┘           │                                          │
├──────────────────┴──────────────────────────────────────────┤
│  Monitor: HDMI-A-1 · Active: WS 3 · 2 monitors             │
└─────────────────────────────────────────────────────────────┘
```

### New files

| File | Purpose |
|------|---------|
| `dash/WorkspaceCard.qml` | Card with app icons (Material Symbols per class), window count badge, monitor badge |
| `dash/SpecialWsCard.qml` | Card for special workspaces (tertiary accent, toggle) |
| `dash/WorkspaceDetail.qml` | Detail panel: ScreencopyView live preview + window list + actions bar |
| `dash/WindowListItem.qml` | Window item with icon, title, state badges (floating/fullscreen/pinned), inline actions (float/tile, pin, kill) |
| `dash/WsActionsBar.qml` | Rename (inline field), New WS, Close All windows |

### Modified files

| File | Change |
|------|--------|
| `Workspaces.qml` | Rewritten as split-pane RowLayout (was ColumnLayout with simple Flow) |
| `DashboardConfig.qml` | Added `Workspaces` config section |

### Config additions (`DashboardConfig.Workspaces`)

```qml
property bool showLivePreview: true       // ScreencopyView toggle
property bool showSpecialWorkspaces: true
property bool showWindowBadges: true       // floating/fullscreen/pinned icons
property bool showMonitorBadge: true       // multi-monitor badge on cards
property int maxAppIcons: 4                // icons per card
property int previewHeight: 200            // live preview height
property bool enableWindowActions: true    // float/kill/pin per window
```

## What's NOT changed

- `modules/bar/` — the bar workspace visualizer stays as-is
- `services/Hypr.qml` — no changes to the Hypr singleton
- `modules/windowinfo/` — reused as reference, not modified
- `Tabs.qml`, `Content.qml`, `Wrapper.qml` — dashboard structure unchanged

## Verification

- [x] QS loads without errors (`quickshell -c ~/.config/quickshell`)
- [x] No binding loops or type errors in logs
- [x] Pre-commit hooks pass
- [x] Dashboard opens and Workspaces tab renders

## Testing

```bash
# Open dashboard (Super+D) → navigate to Workspaces tab (index 5)
# 1. Click a workspace card → switches WS + loads detail panel
# 2. Window list shows apps with icons and badges
# 3. Float/Pin/Kill buttons work
# 4. Rename → type name → Enter
# 5. New WS → creates empty workspace
# 6. Close All → kills all windows in selected WS
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a split-pane workspace dashboard with selectable workspaces and a dedicated detail panel
  * Introduced live preview for the selected workspace’s focused window (configurable, with sizing controls)
  * Added new UI cards for regular and special workspaces, including window-count and monitor-aware badges
  * Added per-window controls (focus, toggle floating, pin/unpin, and close)
  * Added a workspace actions bar to rename, create new workspaces, and close all windows
  * Added configurable display settings (app icon limit, preview height, and badge visibility)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->