### PR TITLE
fix(dashboard): rewrite Workspaces tab to match dashboard visual language

### DIFF
--- a/home/dot_config/quickshell/modules/dashboard/Workspaces.qml
+++ b/home/dot_config/quickshell/modules/dashboard/Workspaces.qml
@@ -11,20 +11,14 @@ import Quickshell.Hyprland
 import QtQuick
 import QtQuick.Layouts
 
-// Dashboard Workspaces tab — split pane workspace manager.
+// Dashboard Workspaces tab — matches the visual language of Dash.qml
+// and Performance.qml (GridLayout, surfaceContainer cards, rounding.large).
 //
-// Left pane: scrollable flow of workspace cards + special workspaces section.
-// Right pane: detail panel for the selected workspace (live preview, window list, actions).
-// Bottom: status bar with monitor + window summary.
+// Top row: active workspace preview card (left) + window list card (right).
+// Bottom row: workspace selector cards in a flow + special workspaces.
 Item {
     id: root
 
-    // Minimum matches dashboard panel width — avoids circular dependency
-    implicitWidth: 800
-    implicitHeight: layout.implicitHeight + Appearance.padding.large * 2
-
-    // Selection state — independent from the active workspace.
-    // Clicking a card switches the active WS AND selects it for the detail panel.
     property int selectedWsId: Hypr.activeWsId
 
     readonly property var regularWorkspaces: {
@@ -42,252 +36,184 @@ Item {
 
     readonly property string activeSpecialName: Hypr.focusedMonitor?.lastIpcObject?.specialWorkspace?.name ?? ""
 
-    readonly property int totalWindows: {
-        return root.regularWorkspaces.reduce((acc, ws) => acc + (ws.lastIpcObject?.windows ?? 0), 0);
-    }
-
-    readonly property int floatingCount: {
-        return Hypr.toplevels.values.filter(t =>
-            t.workspace?.id === root.selectedWsId && t.lastIpcObject?.floating
-        ).length;
-    }
-
-    // Reset selection to active when tab reopens
     Component.onCompleted: root.selectedWsId = Hypr.activeWsId
 
+    implicitWidth: Math.max(800, content.implicitWidth)
+    implicitHeight: content.implicitHeight
+
     ColumnLayout {
-        id: layout
+        id: content
 
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: parent.top
-        anchors.margins: Appearance.padding.large
 
         spacing: Appearance.spacing.normal
 
-        // Header
+        // ── Top row: preview + window list ────────────────────────────
         RowLayout {
             Layout.fillWidth: true
-            spacing: Appearance.spacing.normal
-
-            StyledText {
-                text: qsTr("Workspaces")
-                font.pointSize: Appearance.font.size.larger
-                font.weight: 500
-                Layout.fillWidth: true
-            }
-
-            // Status summary
-            StyledText {
-                text: qsTr("%1 windows · %2 floating").arg(root.totalWindows).arg(root.floatingCount)
-                font.pointSize: Appearance.font.size.small
-                color: Colours.palette.m3outline
-            }
-        }
-
-        // Main split: left cards + right detail
-        RowLayout {
-            Layout.fillWidth: true
-            Layout.fillHeight: true
 
             spacing: Appearance.spacing.normal
 
-            // ── Left pane: workspace cards ──────────────────────────────
-            ColumnLayout {
-                Layout.fillHeight: true
-                Layout.preferredWidth: 340
-
-                spacing: Appearance.spacing.small
-
-                // Regular workspaces — scrollable flow
-                StyledRect {
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-
-                    radius: Appearance.rounding.normal
-                    color: Colours.layer(Colours.tPalette.m3surfaceContainer, 1)
-
-                    StyledFlickable {
-                        id: wsFlick
-
-                        anchors.fill: parent
-                        anchors.margins: Appearance.padding.normal
-
-                        flickableDirection: Flickable.VerticalFlick
-                        contentHeight: wsFlow.implicitHeight
-                        clip: true
-
-                        Flow {
-                            id: wsFlow
-
-                            anchors.left: parent.left
-                            anchors.right: parent.right
-                            anchors.top: parent.top
-
-                            spacing: Appearance.spacing.small
-
-                            Repeater {
-                                model: root.regularWorkspaces
-
-                                delegate: WorkspaceCard {
-                                    isActive: modelData.id === Hypr.activeWsId
-                                    isSelected: modelData.id === root.selectedWsId
-
-                                    onClicked: {
-                                        root.selectedWsId = modelData.id;
-                                        Hypr.dispatch(`workspace ${modelData.id}`);
-                                    }
-                                }
-                            }
-
-                            // Empty state
-                            StyledText {
-                                visible: root.regularWorkspaces.length === 0
-                                text: qsTr("No workspaces open")
-                                color: Colours.palette.m3outline
-                                font.pointSize: Appearance.font.size.normal
-                            }
-                        }
-
-                        StyledScrollBar.vertical: StyledScrollBar {
-                            flickable: wsFlick
-                        }
-                    }
-                }
-
-                // Special workspaces section
-                Loader {
-                    Layout.fillWidth: true
-                    active: Config.dashboard.workspaces.showSpecialWorkspaces && root.specialWorkspaces.length > 0
-
-                    sourceComponent: ColumnLayout {
-                        spacing: Appearance.spacing.small
-
-                        StyledText {
-                            text: qsTr("Special Workspaces")
-                            font.pointSize: Appearance.font.size.normal
-                            font.weight: 600
-                            color: Colours.palette.m3tertiary
-                        }
-
-                        Flow {
-                            Layout.fillWidth: true
-                            spacing: Appearance.spacing.small
-
-                            Repeater {
-                                model: root.specialWorkspaces
-
-                                delegate: SpecialWsCard {
-                                    isActive: modelData.name === root.activeSpecialName
-
-                                    onClicked: {
-                                        Hypr.dispatch(`togglespecialworkspace ${modelData.name.slice("special:".length)}`);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // ── Right pane: workspace detail ────────────────────────────
+            // Left: active/selected workspace preview + actions
             StyledRect {
-                Layout.fillHeight: true
                 Layout.fillWidth: true
+                Layout.minimumWidth: 400
+                Layout.preferredHeight: previewCol.implicitHeight + Appearance.padding.large * 2
 
-                radius: Appearance.rounding.normal
-                color: Colours.layer(Colours.tPalette.m3surfaceContainer, 1)
+                radius: Appearance.rounding.large
+                color: Colours.tPalette.m3surfaceContainer
 
-                Loader {
-                    id: detailLoader
+                ColumnLayout {
+                    id: previewCol
 
                     anchors.fill: parent
-                    anchors.margins: Appearance.padding.normal
+                    anchors.margins: Appearance.padding.large
 
-                    active: root.selectedWorkspace !== null
+                    spacing: Appearance.spacing.normal
 
-                    sourceComponent: WorkspaceDetail {
-                        wsId: root.selectedWsId
-                        workspace: root.selectedWorkspace
-                    }
-                }
-
-                // Empty state when no workspace selected
-                Item {
-                    anchors.fill: parent
-                    visible: root.selectedWorkspace === null
-
-                    ColumnLayout {
-                        anchors.centerIn: parent
+                    // Header
+                    RowLayout {
+                        Layout.fillWidth: true
                         spacing: Appearance.spacing.small
 
                         MaterialIcon {
-                            Layout.alignment: Qt.AlignHCenter
                             text: "workspaces"
-                            color: Colours.palette.m3outline
-                            font.pointSize: Appearance.font.size.extraLarge * 2
+                            color: Colours.palette.m3primary
+                            font.pointSize: Appearance.font.size.large
                         }
 
                         StyledText {
-                            Layout.alignment: Qt.AlignHCenter
-                            text: qsTr("Select a workspace")
-                            color: Colours.palette.m3outline
-                            font.pointSize: Appearance.font.size.normal
+                            text: root.selectedWorkspace?.name ?? qsTr("Workspace %1").arg(root.selectedWsId)
+                            font.pointSize: Appearance.font.size.larger
+                            font.weight: 600
+                            color: Colours.palette.m3onSurface
+                            Layout.fillWidth: true
+                            elide: Text.ElideRight
+                        }
+
+                        StyledText {
+                            text: {
+                                const n = root.selectedWorkspace?.lastIpcObject?.windows ?? 0;
+                                return n === 0 ? qsTr("Empty") : qsTr("%1 windows").arg(n);
+                            }
+                            font.pointSize: Appearance.font.size.small
+                            color: Colours.palette.m3onSurfaceVariant
                         }
                     }
+
+                    // Live preview
+                    Loader {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: Config.dashboard.workspaces.previewHeight
+
+                        active: Config.dashboard.workspaces.showLivePreview && root.selectedWorkspace !== null
+
+                        sourceComponent: WorkspacePreview {
+                            wsId: root.selectedWsId
+                        }
+                    }
+
+                    // Actions bar
+                    WsActionsBar {
+                        Layout.fillWidth: true
+                        wsId: root.selectedWsId
+                    }
+                }
+            }
+
+            // Right: window list
+            StyledRect {
+                Layout.fillWidth: true
+                Layout.minimumWidth: 300
+                Layout.preferredHeight: previewCol.implicitHeight + Appearance.padding.large * 2
+
+                radius: Appearance.rounding.large
+                color: Colours.tPalette.m3surfaceContainer
+
+                WorkspaceDetail {
+                    anchors.fill: parent
+                    wsId: root.selectedWsId
+                    workspace: root.selectedWorkspace
                 }
             }
         }
 
-        // ── Bottom status bar ──────────────────────────────────────────
+        // ── Bottom: workspace selector cards ──────────────────────────
         StyledRect {
             Layout.fillWidth: true
-            radius: Appearance.rounding.normal
-            color: Colours.layer(Colours.tPalette.m3surfaceContainer, 1)
-            implicitHeight: statusRow.implicitHeight + Appearance.padding.small * 2
+            Layout.preferredHeight: wsFlowCol.implicitHeight + Appearance.padding.large * 2
 
-            RowLayout {
-                id: statusRow
+            radius: Appearance.rounding.large
+            color: Colours.tPalette.m3surfaceContainer
 
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.verticalCenter: parent.verticalCenter
-                anchors.margins: Appearance.padding.normal
+            ColumnLayout {
+                id: wsFlowCol
+
+                anchors.fill: parent
+                anchors.margins: Appearance.padding.large
 
                 spacing: Appearance.spacing.normal
 
-                MaterialIcon {
-                    text: "monitor"
-                    color: Colours.palette.m3primary
-                    font.pointSize: Appearance.font.size.normal
-                }
-
-                StyledText {
-                    text: {
-                        const mon = Hypr.focusedMonitor;
-                        if (mon)
-                            return qsTr("Monitor: %1 · Active: WS %2").arg(mon.name).arg(Hypr.activeWsId);
-                        return qsTr("Active: WS %1").arg(Hypr.activeWsId);
-                    }
-                    font.pointSize: Appearance.font.size.small
-                    color: Colours.palette.m3onSurfaceVariant
+                // Section header
+                RowLayout {
                     Layout.fillWidth: true
-                }
-
-                // Monitor count badge (multi-monitor)
-                StyledRect {
-                    visible: Hypr.monitors.values.length > 1
-                    radius: Appearance.rounding.full
-                    color: Qt.alpha(Colours.palette.m3primary, 0.15)
-                    implicitWidth: monCount.implicitWidth + Appearance.padding.small * 2
-                    implicitHeight: monCount.implicitHeight + 2
+                    spacing: Appearance.spacing.small
 
                     StyledText {
-                        id: monCount
-                        anchors.centerIn: parent
-                        text: qsTr("%1 monitors").arg(Hypr.monitors.values.length)
-                        font.pointSize: Appearance.font.size.small
-                        color: Colours.palette.m3primary
+                        text: qsTr("Workspaces")
+                        font.pointSize: Appearance.font.size.normal
+                        font.weight: 600
+                        color: Colours.palette.m3onSurface
+                        Layout.fillWidth: true
+                    }
+
+                    // Special workspace chips
+                    Row {
+                        visible: Config.dashboard.workspaces.showSpecialWorkspaces && root.specialWorkspaces.length > 0
+                        spacing: Appearance.spacing.small / 2
+
+                        Repeater {
+                            model: root.specialWorkspaces
+
+                            delegate: SpecialWsCard {
+                                isActive: modelData.name === root.activeSpecialName
+
+                                onClicked: {
+                                    Hypr.dispatch(`togglespecialworkspace ${modelData.name.slice("special:".length)}`);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Workspace cards flow
+                Flow {
+                    Layout.fillWidth: true
+
+                    spacing: Appearance.spacing.small
+
+                    Repeater {
+                        model: root.regularWorkspaces
+
+                        delegate: WorkspaceCard {
+                            isActive: modelData.id === Hypr.activeWsId
+                            isSelected: modelData.id === root.selectedWsId
+
+                            onClicked: {
+                                root.selectedWsId = modelData.id;
+                                Hypr.dispatch(`workspace ${modelData.id}`);
+                            }
+                        }
+                    }
+
+                    // Empty state
+                    StyledText {
+                        visible: root.regularWorkspaces.length === 0
+                        text: qsTr("No workspaces open")
+                        color: Colours.palette.m3onSurfaceVariant
+                        font.pointSize: Appearance.font.size.normal
                     }
                 }
             }

--- a/home/dot_config/quickshell/modules/dashboard/dash/SpecialWsCard.qml
+++ b/home/dot_config/quickshell/modules/dashboard/dash/SpecialWsCard.qml
@@ -8,10 +8,7 @@ import Quickshell.Hyprland
 import QtQuick
 import QtQuick.Layouts
 
-// Special workspace card for the dashboard Workspaces tab.
-//
-// Shows the special workspace icon, name, and window count.
-// Clicking toggles the special workspace.
+// Special workspace chip — compact pill for the workspace flow header.
 Item {
     id: root
 
@@ -24,20 +21,19 @@ Item {
     readonly property string iconName: Icons.getSpecialWsIcon(root.modelData.name)
     readonly property string displayName: root.modelData.name.slice("special:".length)
 
-    implicitWidth: 130
-    implicitHeight: wsCard.implicitHeight
+    implicitWidth: chip.implicitWidth
+    implicitHeight: chip.implicitHeight
 
     StyledRect {
-        id: wsCard
+        id: chip
 
-        anchors.fill: parent
-
-        radius: Appearance.rounding.normal
+        radius: Appearance.rounding.full
         color: root.isActive
             ? Colours.tPalette.m3tertiaryContainer
-            : Colours.layer(Colours.tPalette.m3surfaceContainer, 1)
-        border.width: root.isActive ? 1 : 0
-        border.color: Colours.palette.m3tertiary
+            : Colours.tPalette.m3surfaceContainerHigh
+
+        implicitWidth: content.implicitWidth + Appearance.padding.normal * 2
+        implicitHeight: content.implicitHeight + Appearance.padding.small
 
         Behavior on color {
             ColorAnimation {
@@ -56,12 +52,13 @@ Item {
         }
 
         RowLayout {
-            anchors.fill: parent
-            anchors.margins: Appearance.padding.normal
+            id: content
 
-            spacing: Appearance.spacing.small
+            anchors.centerIn: parent
 
-            // Icon or letter
+            spacing: Appearance.spacing.small / 2
+
+            // Icon
             Loader {
                 Layout.alignment: Qt.AlignVCenter
                 sourceComponent: root.iconName.length === 1 ? letterComp : iconComp
@@ -74,7 +71,7 @@ Item {
                         color: root.isActive
                             ? Colours.palette.m3onTertiaryContainer
                             : Colours.palette.m3tertiary
-                        font.pointSize: Appearance.font.size.large
+                        font.pointSize: Appearance.font.size.normal
                     }
                 }
 
@@ -86,35 +83,38 @@ Item {
                         color: root.isActive
                             ? Colours.palette.m3onTertiaryContainer
                             : Colours.palette.m3tertiary
-                        font.pointSize: Appearance.font.size.normal
+                        font.pointSize: Appearance.font.size.small
                         font.weight: 600
                     }
                 }
             }
 
-            ColumnLayout {
-                Layout.fillWidth: true
-                spacing: 0
+            // Name
+            StyledText {
+                text: root.displayName
+                font.pointSize: Appearance.font.size.small
+                font.weight: root.isActive ? 600 : 400
+                color: root.isActive
+                    ? Colours.palette.m3onTertiaryContainer
+                    : Colours.palette.m3onSurfaceVariant
+            }
+
+            // Window count
+            StyledRect {
+                visible: root.windowCount > 0
+                radius: Appearance.rounding.full
+                color: Qt.alpha(Colours.palette.m3onTertiaryContainer, 0.2)
+                implicitWidth: wcText.implicitWidth + 6
+                implicitHeight: wcText.implicitHeight + 2
 
                 StyledText {
-                    Layout.fillWidth: true
-                    text: root.displayName
-                    font.pointSize: Appearance.font.size.normal
-                    font.weight: root.isActive ? 700 : 500
+                    id: wcText
+                    anchors.centerIn: parent
+                    text: root.windowCount
+                    font.pointSize: Appearance.font.size.smaller
                     color: root.isActive
                         ? Colours.palette.m3onTertiaryContainer
-                        : Colours.palette.m3onSurface
-                    elide: Text.ElideRight
-                }
-
-                StyledText {
-                    text: root.windowCount > 0
-                        ? qsTr("%1 window(s)").arg(root.windowCount)
-                        : qsTr("Empty")
-                    font.pointSize: Appearance.font.size.small
-                    color: root.isActive
-                        ? Colours.palette.m3onTertiaryContainer
-                        : Colours.palette.m3outline
+                        : Colours.palette.m3onSurfaceVariant
                 }
             }
         }

--- a/home/dot_config/quickshell/modules/dashboard/dash/WindowListItem.qml
+++ b/home/dot_config/quickshell/modules/dashboard/dash/WindowListItem.qml
@@ -9,10 +9,8 @@ import Quickshell.Hyprland
 import QtQuick
 import QtQuick.Layouts
 
-// Window list item for the workspace detail panel.
-//
-// Shows app icon, title, state badges (floating/fullscreen/pinned),
-// and action buttons (float/tile, pin, kill, move-to-WS).
+// Window list item — flat row inside the window list card.
+// No own background (transparent), uses parent's surfaceContainer.
 Item {
     id: root
 
@@ -26,134 +24,107 @@ Item {
     readonly property bool pinned: root.modelData.lastIpcObject?.pinned ?? false
     readonly property int fullscreen: root.modelData.lastIpcObject?.fullscreen ?? 0
 
-    implicitWidth: card.implicitWidth
-    implicitHeight: card.implicitHeight
+    implicitWidth: parent ? parent.width : 300
+    implicitHeight: row.implicitHeight + Appearance.padding.small
 
+    // Highlight background for active window
     StyledRect {
-        id: card
-
         anchors.fill: parent
-
         radius: Appearance.rounding.small
         color: root.isActive
             ? Qt.alpha(Colours.palette.m3primary, 0.12)
-            : Colours.layer(Colours.tPalette.m3surfaceContainerHigh, 1)
-        border.width: root.isActive ? 1 : 0
-        border.color: Colours.palette.m3primary
+            : "transparent"
+        visible: root.isActive
+    }
 
-        Behavior on color {
-            ColorAnimation {
-                duration: Appearance.anim.durations.small
-            }
+    RowLayout {
+        id: row
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.margins: Appearance.padding.small
+
+        spacing: Appearance.spacing.small
+
+        // App icon
+        MaterialIcon {
+            Layout.alignment: Qt.AlignVCenter
+            text: Icons.getAppCategoryIcon(root.modelData.lastIpcObject?.class ?? "", "terminal")
+            color: root.isActive ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
+            font.pointSize: Appearance.font.size.normal
         }
 
-        RowLayout {
-            anchors.fill: parent
-            anchors.margins: Appearance.padding.small
+        // Title
+        StyledText {
+            Layout.fillWidth: true
+            text: root.modelData.title ?? qsTr("Unknown")
+            font.pointSize: Appearance.font.size.small
+            font.weight: root.isActive ? 600 : 400
+            color: root.isActive ? Colours.palette.m3primary : Colours.palette.m3onSurface
+            elide: Text.ElideRight
+        }
 
-            spacing: Appearance.spacing.small
+        // State badges
+        Row {
+            visible: Config.dashboard.workspaces.showWindowBadges
+            spacing: 2
 
-            // App icon
             MaterialIcon {
-                Layout.alignment: Qt.AlignVCenter
-                text: Icons.getAppCategoryIcon(root.modelData.lastIpcObject?.class ?? "", "terminal")
-                color: root.isActive ? Colours.palette.m3primary : Colours.palette.m3onSurfaceVariant
-                font.pointSize: Appearance.font.size.normal
+                visible: root.floating
+                text: "picture_in_picture"
+                color: Colours.palette.m3tertiary
+                font.pointSize: Appearance.font.size.small
             }
 
-            // Title + badges
-            ColumnLayout {
-                Layout.fillWidth: true
-                spacing: 0
-
-                StyledText {
-                    Layout.fillWidth: true
-                    text: root.modelData.title ?? qsTr("Unknown")
-                    font.pointSize: Appearance.font.size.small
-                    font.weight: root.isActive ? 600 : 400
-                    color: root.isActive ? Colours.palette.m3primary : Colours.palette.m3onSurface
-                    elide: Text.ElideRight
-                }
-
-                // Badges row
-                Row {
-                    visible: Config.dashboard.workspaces.showWindowBadges
-                    spacing: 2
-
-                    // Floating badge
-                    MaterialIcon {
-                        visible: root.floating
-                        text: "picture_in_picture"
-                        color: Colours.palette.m3tertiary
-                        font.pointSize: Appearance.font.size.small
-                    }
-
-                    // Fullscreen badge
-                    MaterialIcon {
-                        visible: root.fullscreen > 0
-                        text: "fullscreen"
-                        color: Colours.palette.m3secondary
-                        font.pointSize: Appearance.font.size.small
-                    }
-
-                    // Pinned badge
-                    MaterialIcon {
-                        visible: root.pinned
-                        text: "keep"
-                        color: Colours.palette.m3secondary
-                        font.pointSize: Appearance.font.size.small
-                    }
-                }
+            MaterialIcon {
+                visible: root.fullscreen > 0
+                text: "fullscreen"
+                color: Colours.palette.m3secondary
+                font.pointSize: Appearance.font.size.small
             }
 
-            // Action buttons (only when window actions enabled)
-            Row {
-                visible: Config.dashboard.workspaces.enableWindowActions
-                spacing: 2
-
-                // Float/Tile toggle
-                IconButton {
-                    type: IconButton.Text
-                    icon: root.floating ? "select_window" : "select_window_off"
-                    padding: Appearance.padding.small / 2
-                    font.pointSize: Appearance.font.size.small
-
-                    onClicked: Hypr.dispatch(`togglefloating address:${root.addr}`)
-                }
-
-                // Pin/Unpin
-                IconButton {
-                    type: IconButton.Text
-                    icon: root.pinned ? "push_pin" : "push_pin"
-                    padding: Appearance.padding.small / 2
-                    font.pointSize: Appearance.font.size.small
-                    internalChecked: root.pinned
-                    toggle: true
-
-                    onClicked: Hypr.dispatch(`pin address:${root.addr}`)
-                }
-
-                // Kill
-                IconButton {
-                    type: IconButton.Text
-                    icon: "close"
-                    padding: Appearance.padding.small / 2
-                    font.pointSize: Appearance.font.size.small
-
-                    onClicked: Hypr.dispatch(`killwindow address:${root.addr}`)
-                }
+            MaterialIcon {
+                visible: root.pinned
+                text: "keep"
+                color: Colours.palette.m3secondary
+                font.pointSize: Appearance.font.size.small
             }
         }
 
-        // Click to focus
-        MouseArea {
-            anchors.fill: parent
-            acceptedButtons: Qt.LeftButton
-            propagateComposedEvents: true
-            onClicked: event => {
-                root.focusRequested();
-                event.accepted = false;
+        // Action buttons
+        Row {
+            visible: Config.dashboard.workspaces.enableWindowActions
+            spacing: 2
+
+            IconButton {
+                type: IconButton.Text
+                icon: root.floating ? "select_window" : "select_window_off"
+                padding: Appearance.padding.small / 2
+                font.pointSize: Appearance.font.size.small
+
+                onClicked: Hypr.dispatch(`togglefloating address:${root.addr}`)
             }
+
+            IconButton {
+                type: IconButton.Text
+                icon: "close"
+                padding: Appearance.padding.small / 2
+                font.pointSize: Appearance.font.size.small
+
+                onClicked: Hypr.dispatch(`killwindow address:${root.addr}`)
+            }
+        }
+    }
+
+    // Click to focus
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.LeftButton
+        propagateComposedEvents: true
+        onClicked: event => {
+            root.focusRequested();
+            event.accepted = false;
         }
     }
 }

--- a/home/dot_config/quickshell/modules/dashboard/dash/WorkspaceCard.qml
+++ b/home/dot_config/quickshell/modules/dashboard/dash/WorkspaceCard.qml
@@ -1,7 +1,6 @@
 pragma ComponentBehavior: Bound
 
 import qs.components
-import qs.components.controls
 import qs.services
 import qs.utils
 import qs.config
@@ -9,11 +8,8 @@ import Quickshell.Hyprland
 import QtQuick
 import QtQuick.Layouts
 
-// Workspace card for the dashboard Workspaces tab.
-//
-// Shows workspace name, app icons (up to maxAppIcons), window count badge,
-// and optional monitor badge. Clicking switches to the workspace and
-// selects it for the detail panel.
+// Workspace selector card — compact card for the bottom flow.
+// Matches the visual style of forecast cards in Weather.qml.
 Item {
     id: root
 
@@ -25,16 +21,12 @@ Item {
 
     readonly property int windowCount: root.modelData.lastIpcObject?.windows ?? 0
     readonly property var wsToplevels: Hypr.toplevels.values.filter(t => t.workspace?.id === root.modelData.id)
-    readonly property string monitorName: {
-        const mon = Hypr.monitors.values.find(m => m.activeWorkspace?.id === root.modelData.id);
-        return mon?.name ?? "";
-    }
 
-    implicitWidth: 130
-    implicitHeight: wsCard.implicitHeight
+    implicitWidth: 150
+    implicitHeight: card.implicitHeight
 
     StyledRect {
-        id: wsCard
+        id: card
 
         anchors.fill: parent
 
@@ -43,9 +35,7 @@ Item {
             ? Colours.tPalette.m3primaryContainer
             : root.isSelected
                 ? Colours.tPalette.m3secondaryContainer
-                : Colours.layer(Colours.tPalette.m3surfaceContainer, 1)
-        border.width: root.isActive || root.isSelected ? 1 : 0
-        border.color: root.isActive ? Colours.palette.m3primary : Colours.palette.m3secondary
+                : Colours.tPalette.m3surfaceContainerHigh
 
         Behavior on color {
             ColorAnimation {
@@ -66,75 +56,52 @@ Item {
         }
 
         ColumnLayout {
-            id: content
-
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.verticalCenter: parent.verticalCenter
+            anchors.fill: parent
             anchors.margins: Appearance.padding.normal
 
             spacing: Appearance.spacing.small / 2
 
-            // Header: WS name + monitor badge + window count
+            // Header: WS number + name
             RowLayout {
                 Layout.fillWidth: true
                 spacing: Appearance.spacing.small
 
                 StyledText {
-                    text: root.modelData.name
+                    text: root.modelData.id
                     font.pointSize: Appearance.font.size.normal
-                    font.weight: root.isActive ? 700 : 500
+                    font.weight: 700
                     color: root.isActive
                         ? Colours.palette.m3onPrimaryContainer
                         : root.isSelected
                             ? Colours.palette.m3onSecondaryContainer
-                            : Colours.palette.m3onSurface
-                    elide: Text.ElideRight
+                            : Colours.palette.m3primary
+                }
+
+                StyledText {
                     Layout.fillWidth: true
-                }
-
-                // Monitor badge (only if multi-monitor and config enabled)
-                StyledRect {
-                    visible: root.monitorName !== "" && Config.dashboard.workspaces.showMonitorBadge && Hypr.monitors.values.length > 1
-                    radius: Appearance.rounding.full
-                    color: Qt.alpha(Colours.palette.m3outline, 0.15)
-                    implicitWidth: monLabel.implicitWidth + Appearance.padding.small
-                    implicitHeight: monLabel.implicitHeight + 2
-
-                    StyledText {
-                        id: monLabel
-                        anchors.centerIn: parent
-                        text: root.monitorName
-                        font.pointSize: Appearance.font.size.small
-                        color: root.isActive
-                            ? Colours.palette.m3onPrimaryContainer
-                            : Colours.palette.m3onSurfaceVariant
-                    }
-                }
-
-                // Window count badge
-                StyledRect {
-                    visible: root.windowCount > 0
-                    radius: Appearance.rounding.full
+                    text: root.modelData.name === String(root.modelData.id) ? "" : root.modelData.name
+                    font.pointSize: Appearance.font.size.small
                     color: root.isActive
-                        ? Qt.alpha(Colours.palette.m3onPrimaryContainer, 0.2)
-                        : Colours.layer(Colours.tPalette.m3surfaceContainerHigh, 1)
-                    implicitWidth: winCount.implicitWidth + Appearance.padding.small * 2
-                    implicitHeight: winCount.implicitHeight + 2
-
-                    StyledText {
-                        id: winCount
-                        anchors.centerIn: parent
-                        text: root.windowCount
-                        font.pointSize: Appearance.font.size.smaller
-                        color: root.isActive
-                            ? Colours.palette.m3onPrimaryContainer
+                        ? Colours.palette.m3onPrimaryContainer
+                        : root.isSelected
+                            ? Colours.palette.m3onSecondaryContainer
                             : Colours.palette.m3onSurfaceVariant
-                    }
+                    elide: Text.ElideRight
+                    visible: text !== ""
+                }
+
+                // Window count
+                StyledText {
+                    text: root.windowCount > 0 ? String(root.windowCount) : ""
+                    font.pointSize: Appearance.font.size.smaller
+                    color: root.isActive
+                        ? Colours.palette.m3onPrimaryContainer
+                        : Colours.palette.m3onSurfaceVariant
+                    visible: root.windowCount > 0
                 }
             }
 
-            // App icons row (up to maxAppIcons)
+            // App icons
             Row {
                 Layout.fillWidth: true
                 spacing: 4
@@ -156,25 +123,15 @@ Item {
                     }
                 }
 
-                // Overflow indicator
                 StyledText {
                     visible: root.wsToplevels.length > Config.dashboard.workspaces.maxAppIcons
                     text: qsTr("+%1").arg(root.wsToplevels.length - Config.dashboard.workspaces.maxAppIcons)
                     font.pointSize: Appearance.font.size.smaller
                     color: root.isActive
                         ? Colours.palette.m3onPrimaryContainer
-                        : Colours.palette.m3outline
+                        : Colours.palette.m3onSurfaceVariant
                     anchors.verticalCenter: parent.verticalCenter
                 }
-            }
-
-            // Active check mark
-            MaterialIcon {
-                Layout.alignment: Qt.AlignHCenter
-                visible: root.isActive
-                text: "check_circle"
-                color: Colours.palette.m3onPrimaryContainer
-                font.pointSize: Appearance.font.size.small
             }
         }
     }

--- a/home/dot_config/quickshell/modules/dashboard/dash/WorkspaceDetail.qml
+++ b/home/dot_config/quickshell/modules/dashboard/dash/WorkspaceDetail.qml
@@ -7,15 +7,11 @@ import qs.services
 import qs.config
 import Quickshell
 import Quickshell.Hyprland
-import Quickshell.Wayland
 import QtQuick
 import QtQuick.Layouts
 
-// Detail panel for the selected workspace.
-//
-// Shows a live preview of the focused window (ScreencopyView),
-// a scrollable list of windows with badges and actions,
-// and a workspace action bar (rename / new / close-all).
+// Window list panel — sits inside a surfaceContainer card.
+// No background of its own (parent provides the card background).
 Item {
     id: root
 
@@ -23,146 +19,78 @@ Item {
     required property HyprlandWorkspace workspace
 
     readonly property var wsToplevels: Hypr.toplevels.values.filter(t => t.workspace?.id === root.wsId)
-    readonly property HyprlandToplevel focusedToplevel: {
-        return root.wsToplevels.find(t => t.wayland?.activated) ?? root.wsToplevels[0] ?? null;
-    }
-    readonly property int windowCount: root.workspace?.lastIpcObject?.windows ?? 0
-    readonly property string wsName: root.workspace?.name ?? qsTr("Workspace %1").arg(root.wsId)
 
-    implicitWidth: layout.implicitWidth
+    implicitWidth: parent ? parent.width : 300
     implicitHeight: layout.implicitHeight
 
     ColumnLayout {
         id: layout
 
         anchors.fill: parent
+        anchors.margins: Appearance.padding.large
 
         spacing: Appearance.spacing.normal
 
-        // Header: workspace name + window count
+        // Header
         RowLayout {
             Layout.fillWidth: true
             spacing: Appearance.spacing.small
 
+            MaterialIcon {
+                text: "select_window"
+                color: Colours.palette.m3secondary
+                font.pointSize: Appearance.font.size.large
+            }
+
             StyledText {
-                text: root.wsName
-                font.pointSize: Appearance.font.size.larger
+                text: qsTr("Windows")
+                font.pointSize: Appearance.font.size.normal
                 font.weight: 600
-                color: Colours.palette.m3primary
+                color: Colours.palette.m3onSurface
                 Layout.fillWidth: true
-                elide: Text.ElideRight
             }
 
             StyledText {
-                text: root.windowCount === 0
-                    ? qsTr("Empty")
-                    : qsTr("%1 window(s)").arg(root.windowCount)
+                text: root.wsToplevels.length > 0
+                    ? qsTr("%1").arg(root.wsToplevels.length)
+                    : ""
                 font.pointSize: Appearance.font.size.small
-                color: Colours.palette.m3outline
+                color: Colours.palette.m3onSurfaceVariant
+                visible: root.wsToplevels.length > 0
             }
         }
 
-        // Live preview of the focused window
-        Loader {
-            id: previewLoader
-
-            Layout.fillWidth: true
-            Layout.preferredHeight: Config.dashboard.workspaces.previewHeight
-
-            active: Config.dashboard.workspaces.showLivePreview && root.focusedToplevel !== null
-
-            sourceComponent: StyledClippingRect {
-                id: preview
-
-                anchors.fill: parent
-                radius: Appearance.rounding.normal
-                color: Colours.tPalette.m3surfaceContainer
-
-                ScreencopyView {
-                    id: view
-
-                    anchors.centerIn: parent
-
-                    captureSource: root.focusedToplevel?.wayland ?? null
-                    live: true
-
-                    constraintSize.width: root.focusedToplevel
-                        ? parent.height * Math.min(
-                            Screen.width / Screen.height,
-                            root.focusedToplevel?.lastIpcObject?.size?.[0] / root.focusedToplevel?.lastIpcObject?.size?.[1] ?? 1
-                        )
-                        : parent.width
-                    constraintSize.height: parent.height
-                }
-
-                // Empty state
-                Item {
-                    anchors.fill: parent
-                    visible: root.focusedToplevel === null
-
-                    ColumnLayout {
-                        anchors.centerIn: parent
-                        spacing: Appearance.spacing.small
-
-                        MaterialIcon {
-                            Layout.alignment: Qt.AlignHCenter
-                            text: "image_not_supported"
-                            color: Colours.palette.m3outline
-                            font.pointSize: Appearance.font.size.extraLarge * 2
-                        }
-
-                        StyledText {
-                            Layout.alignment: Qt.AlignHCenter
-                            text: qsTr("No windows to preview")
-                            color: Colours.palette.m3outline
-                            font.pointSize: Appearance.font.size.normal
-                        }
-                    }
-                }
-            }
-        }
-
-        // Window list
-        StyledRect {
+        // Window list or empty state
+        Item {
             Layout.fillWidth: true
             Layout.fillHeight: true
 
-            radius: Appearance.rounding.normal
-            color: Colours.layer(Colours.tPalette.m3surfaceContainer, 1)
-
-            implicitHeight: winList.implicitHeight + Appearance.padding.normal * 2
-
             // Empty state
-            Item {
-                anchors.fill: parent
+            ColumnLayout {
+                anchors.centerIn: parent
                 visible: root.wsToplevels.length === 0
+                spacing: Appearance.spacing.small
 
-                ColumnLayout {
-                    anchors.centerIn: parent
-                    spacing: Appearance.spacing.small
+                MaterialIcon {
+                    Layout.alignment: Qt.AlignHCenter
+                    text: "select_window_off"
+                    color: Colours.palette.m3onSurfaceVariant
+                    font.pointSize: Appearance.font.size.extraLarge
+                }
 
-                    MaterialIcon {
-                        Layout.alignment: Qt.AlignHCenter
-                        text: "select_window_off"
-                        color: Colours.palette.m3outline
-                        font.pointSize: Appearance.font.size.extraLarge
-                    }
-
-                    StyledText {
-                        Layout.alignment: Qt.AlignHCenter
-                        text: qsTr("No windows in this workspace")
-                        color: Colours.palette.m3outline
-                        font.pointSize: Appearance.font.size.normal
-                    }
+                StyledText {
+                    Layout.alignment: Qt.AlignHCenter
+                    text: qsTr("No windows")
+                    color: Colours.palette.m3onSurfaceVariant
+                    font.pointSize: Appearance.font.size.small
                 }
             }
 
+            // Window list
             StyledListView {
                 id: winList
 
                 anchors.fill: parent
-                anchors.margins: Appearance.padding.normal
-
                 visible: root.wsToplevels.length > 0
 
                 spacing: Appearance.spacing.small / 2
@@ -185,12 +113,6 @@ Item {
                     flickable: winList
                 }
             }
-        }
-
-        // Workspace actions bar
-        WsActionsBar {
-            Layout.fillWidth: true
-            wsId: root.wsId
         }
     }
 }

--- a/home/dot_config/quickshell/modules/dashboard/dash/WorkspacePreview.qml
+++ b/home/dot_config/quickshell/modules/dashboard/dash/WorkspacePreview.qml
@@ -1,0 +1,77 @@
+pragma ComponentBehavior: Bound
+
+import qs.components
+import qs.services
+import qs.utils
+import qs.config
+import Quickshell
+import Quickshell.Hyprland
+import Quickshell.Wayland
+import QtQuick
+import QtQuick.Layouts
+
+// Live preview of the focused window in a workspace.
+// Uses ScreencopyView — same pattern as WindowInfo/Preview.qml.
+Item {
+    id: root
+
+    required property int wsId
+
+    readonly property var wsToplevels: Hypr.toplevels.values.filter(t => t.workspace?.id === root.wsId)
+    readonly property HyprlandToplevel focusedToplevel: {
+        return root.wsToplevels.find(t => t.wayland?.activated) ?? root.wsToplevels[0] ?? null;
+    }
+
+    implicitWidth: parent ? parent.width : 400
+    implicitHeight: Config.dashboard.workspaces.previewHeight
+
+    StyledClippingRect {
+        id: preview
+
+        anchors.fill: parent
+        radius: Appearance.rounding.normal
+        color: Colours.tPalette.m3surfaceContainerHigh
+
+        ScreencopyView {
+            id: view
+
+            anchors.centerIn: parent
+
+            captureSource: root.focusedToplevel?.wayland ?? null
+            live: true
+
+            constraintSize.width: root.focusedToplevel
+                ? parent.height * Math.min(
+                    Screen.width / Screen.height,
+                    (root.focusedToplevel?.lastIpcObject?.size?.[0] ?? 1) / (root.focusedToplevel?.lastIpcObject?.size?.[1] ?? 1)
+                )
+                : parent.width
+            constraintSize.height: parent.height
+        }
+
+        // Empty state
+        Item {
+            anchors.fill: parent
+            visible: root.focusedToplevel === null
+
+            ColumnLayout {
+                anchors.centerIn: parent
+                spacing: Appearance.spacing.small
+
+                MaterialIcon {
+                    Layout.alignment: Qt.AlignHCenter
+                    text: "image_not_supported"
+                    color: Colours.palette.m3onSurfaceVariant
+                    font.pointSize: Appearance.font.size.extraLarge * 2
+                }
+
+                StyledText {
+                    Layout.alignment: Qt.AlignHCenter
+                    text: qsTr("No windows to preview")
+                    color: Colours.palette.m3onSurfaceVariant
+                    font.pointSize: Appearance.font.size.normal
+                }
+            }
+        }
+    }
+}

--- a/home/dot_config/quickshell/modules/dashboard/dash/WsActionsBar.qml
+++ b/home/dot_config/quickshell/modules/dashboard/dash/WsActionsBar.qml
@@ -8,16 +8,14 @@ import Quickshell.Hyprland
 import QtQuick
 import QtQuick.Layouts
 
-// Action bar for workspace-level operations: rename, new, close-all.
-//
-// Rename shows an inline text field; New creates an empty workspace;
-// Close-all kills every window in the selected workspace.
+// Workspace action bar — rename, new, close-all.
+// Sits inside the preview card, no own background.
 Item {
     id: root
 
     required property int wsId
 
-    implicitWidth: layout.implicitWidth
+    implicitWidth: parent ? parent.width : 400
     implicitHeight: layout.implicitHeight
 
     property bool renameActive: false
@@ -25,14 +23,15 @@ Item {
     RowLayout {
         id: layout
 
-        anchors.fill: parent
+        anchors.left: parent.left
+        anchors.right: parent.right
 
         spacing: Appearance.spacing.small
 
         // Rename inline
         Item {
             Layout.fillWidth: true
-            Layout.preferredHeight: renameField.visible ? renameField.implicitHeight : renameBtn.implicitHeight
+            Layout.preferredHeight: renameField.visible ? renameField.implicitHeight + Appearance.padding.small : renameBtn.implicitHeight
             clip: true
 
             TextButton {


### PR DESCRIPTION
## Summary

The initial Workspaces tab implementation (PR #160) used a split-pane layout with visual patterns that didn't match any other dashboard tab. This PR rewrites it to match the established visual language of Dash.qml, Performance.qml, and Weather.qml.

## Issues fixed

| Issue | Before | After |
|-------|--------|-------|
| Card backgrounds | `Colours.layer(m3surfaceContainer, 1)` (washed out) | `Colours.tPalette.m3surfaceContainer` (direct) |
| Card corners | `Appearance.rounding.normal` | `Appearance.rounding.large` |
| Outer padding | `anchors.margins: Appearance.padding.large` (double-padded with Content.qml) | No outer margins (Content.qml handles it) |
| Layout | Split-pane RowLayout with fixed 340px left pane | Top row (preview + windows) + bottom row (cards flow) — matches Dash.qml |
| Status bar | Redundant bottom status bar | Removed |
| Nested containers | StyledRect > Loader > WorkspaceDetail > StyledRect | Single card background, no nesting |
| Card sizing | 130px fixed width | 150px, surfaceContainerHigh idle state (matches Weather hourly cards) |

## New file

- `dash/WorkspacePreview.qml` — extracted from WorkspaceDetail, contains only the ScreencopyView live preview

## Verification

- [x] QS loads without errors
- [x] No binding loops or TypeErrors in logs
- [x] Dashboard opens and Workspaces tab renders