### PR TITLE
fix: proper sss integration with config, install v0.2.1, and fix fullscreen output

### DIFF
--- a/home/.chezmoiscripts/linux/run_onchange_before_install-packages.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_before_install-packages.sh.tmpl
@@ -61,8 +61,6 @@ set -eufo pipefail
   "pwvucontrol"
   "snappy-switcher"
   "poweralertd"
-  "sss-bin"
-  "sss_code-bin"
 ) -}}
 {{ end -}}
 

--- a/home/.chezmoiscripts/linux/run_onchange_before_install-sss.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_before_install-sss.sh.tmpl
@@ -1,0 +1,20 @@
+{{ if and (not .ephemeral) (not .headless) -}}
+
+{{      if eq .osid "linux-arch" -}}
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+# sss (Super ScreenShot) v0.2.1 — main screenshot CLI with interactive selector
+if ! type -p sss &>/dev/null; then
+  curl -fsSL https://github.com/SergioRibera/sss/releases/download/sss_cli/v0.2.1/install.sh | sh
+fi
+
+# sss_code v0.3.1 — code-to-PNG renderer
+if ! type -p sss_code &>/dev/null; then
+  curl -fsSL https://github.com/SergioRibera/sss/releases/download/sss_code/v0.3.1/install.sh | sh -s -- --binary sss_code
+fi
+
+{{      end -}}
+
+{{ end -}}

--- a/home/dot_config/sss/config.toml
+++ b/home/dot_config/sss/config.toml
@@ -1,0 +1,21 @@
+[general]
+copy = true
+notify = true
+shadow = true
+shadow-blur = 30.0
+shadow-image = true
+radius = 15
+save-format = "png"
+show-cursor = false
+author = "@ulises-jeremias"
+
+[general.colors]
+background = "#FFFFFF"
+shadow = "#707070"
+author = "#000000"
+
+[general.window-controls]
+enable = false
+
+[ocr]
+enable = false

--- a/home/dot_local/bin/executable_dots-screenshooter
+++ b/home/dot_local/bin/executable_dots-screenshooter
@@ -21,23 +21,23 @@ source ~/.local/lib/dots/easy-options/easyoptions.sh || exit
 set -euo pipefail
 
 shoot() {
-  if [ -n "${region:-}" ]; then
-    sss
-  else
-    local pictures filename
-    pictures="${XDG_PICTURES_DIR:-$HOME/Pictures}"
-    filename="${pictures}/screenshot_$(date +%Y%m%d_%H%M%S).png"
-    sss --screen --current --copy --output "$filename"
-  fi
+	if [ -n "${region:-}" ]; then
+		sss
+	else
+		local pictures filename
+		pictures="${XDG_PICTURES_DIR:-$HOME/Pictures}"
+		filename="${pictures}/screenshot_$(date +%Y%m%d_%H%M%S).png"
+		sss --screen --current --copy --output "$filename"
+	fi
 }
 
 if [[ -n ${version:-} ]]; then
-  echo "dots-screenshooter -- Version 0.4"
-  exit 0
+	echo "dots-screenshooter -- Version 0.4"
+	exit 0
 fi
 
 if [[ -n ${region:-} ]]; then
-  region=1
+	region=1
 fi
 
 shoot

--- a/home/dot_local/bin/executable_dots-screenshooter
+++ b/home/dot_local/bin/executable_dots-screenshooter
@@ -24,7 +24,10 @@ shoot() {
   if [ -n "${region:-}" ]; then
     sss
   else
-    sss --screen --current
+    local pictures filename
+    pictures="${XDG_PICTURES_DIR:-$HOME/Pictures}"
+    filename="${pictures}/screenshot_$(date +%Y%m%d_%H%M%S).png"
+    sss --screen --current --copy --output "$filename"
   fi
 }
 


### PR DESCRIPTION
## Summary

Fix the sss integration that was broken after the initial Flameshot → sss migration. The AUR package `sss-bin` (v0.1.4) lacks the interactive selector needed for region screenshots and requires `--output` for all commands.

### Problems found

1. **AUR v0.1.4 lacks interactive mode** — no region/window selector, no annotation editor. The `-r` (region) flag in `dots-screenshooter` was calling `sss` which would crash or capture all screens without interaction
2. **`--output` required for fullscreen** — `sss --screen --current` fails because `--output <path>` is mandatory in direct capture mode
3. **No sss config file** — sensible defaults (clipboard copy, notifications, shadow) were not set

### Changes

| Action | File |
|--------|------|
| ✨ Created | `dot_config/sss/config.toml` — default config with `copy=true`, `notify=true`, `shadow=true` |
| ✏️ Edited | `dots-screenshooter` — region calls `sss` (interactive AnyOf selector), fullscreen calls `sss --screen --current --copy --output $file` |
| ✏️ Edited | `install-packages.sh.tmpl` — removed `sss-bin` and `sss_code-bin` from AUR list |
| ✨ Created | `install-sss.sh.tmpl` — installs `sss` v0.2.1 and `sss_code` v0.3.1 via official GitHub release scripts |

### Why not AUR?

The AUR package `sss-bin` is stuck at v0.1.4 (outdated since 2026-06-26). The interactive region selector and annotation editor were introduced in v0.2.0 and are essential for the `dots-screenshooter -r` workflow. The official install script is the recommended method — it auto-detects Arch Linux, downloads the verified `.pkg.tar.zst`, and supports clean uninstall via `--uninstall`.

### How it works now

| Action | Keybinding | Command | Behavior |
|--------|-----------|---------|----------|
| **Fullscreen** | `Print` | `sss --screen --current --copy --output screenshot.png` | Captures focused monitor, copies to clipboard, saves to `~/Pictures/` |
| **Region** | `Shift+Print` | `sss` (no flags) | Opens interactive AnyOf selector — pick area, window, or monitor, then annotate |