### PR TITLE
fix: redesign banner SVGs with consistent M3 dark theme

### DIFF
--- a/static/template-banner.svg
+++ b/static/template-banner.svg
@@ -1,46 +1,29 @@
-<svg width="800" height="220" xmlns="http://www.w3.org/2000/svg">
+<svg width="800" height="200" viewBox="0 0 800 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="templateTitle">
+  <title id="templateTitle">HorneroConfig template banner</title>
   <defs>
-    <linearGradient id="backgroundGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#667eea;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#764ba2;stop-opacity:1" />
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1a1215"/>
+      <stop offset="100%" stop-color="#261d20"/>
     </linearGradient>
-    <linearGradient id="buttonGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#28a745;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#20c997;stop-opacity:1" />
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#ffb0ca"/>
+      <stop offset="100%" stop-color="#f0bc95"/>
     </linearGradient>
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#000000" flood-opacity="0.2"/>
-    </filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="800" height="220" rx="15" ry="15" fill="url(#backgroundGradient)" filter="url(#shadow)"/>
-
-  <!-- Main Title -->
-  <text x="400" y="45" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="24" font-weight="bold">
-    🎉 NEW: Template Repository Available!
+  <rect width="800" height="200" rx="12" fill="url(#bg)"/>
+  <rect width="800" height="200" rx="12" fill="none" stroke="#514347" stroke-width="1.5"/>
+  <rect x="0" y="0" width="4" height="200" rx="2" fill="url(#accent)"/>
+  <text x="36" y="54" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#efdfe2">
+    Template Repository Available
   </text>
-
-  <!-- Subtitle -->
-  <text x="400" y="75" text-anchor="middle" fill="#f0f8ff" font-family="Arial, sans-serif" font-size="16">
-    Want to use this powerful framework for your own dotfiles?
+  <text x="36" y="84" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#c2afb3">
+    Use this powerful framework as a starting point for your own dotfiles
   </text>
-
-  <!-- Call to action -->
-  <text x="400" y="105" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="18" font-weight="bold">
-    ✨ Get the reusable template version ✨
+  <rect x="36" y="110" width="220" height="40" rx="8" fill="#ffb0ca"/>
+  <text x="146" y="136" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#39071f" text-anchor="middle">
+    Use Template Repository
   </text>
-
-  <!-- Button background -->
-  <rect x="275" y="125" width="250" height="45" rx="10" ry="10" fill="url(#buttonGradient)" filter="url(#shadow)"/>
-
-  <!-- Button text -->
-  <text x="400" y="153" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">
-    🚀 Use Template Repository
-  </text>
-
-  <!-- Features text -->
-  <text x="400" y="195" text-anchor="middle" fill="#e6f3ff" font-family="Arial, sans-serif" font-size="14">
-    Pre-sanitized • Ready to fork • Easy to customize • Regularly updated
+  <text x="36" y="178" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#9e8c91">
+    Pre-sanitized · Ready to fork · Easy to customize · Regularly updated
   </text>
 </svg>

--- a/static/template-banner.svg
+++ b/static/template-banner.svg
@@ -1,5 +1,6 @@
 <svg width="800" height="200" viewBox="0 0 800 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="templateTitle">
   <title id="templateTitle">HorneroConfig template banner</title>
+  <desc>Banner linking to the reusable HorneroConfig template repository.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#1a1215"/>

--- a/static/wayland-legacy-branch-banner.svg
+++ b/static/wayland-legacy-branch-banner.svg
@@ -1,26 +1,29 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="320" viewBox="0 0 1600 320" role="img" aria-labelledby="title desc">
-  <title id="title">Wayland legacy branch banner</title>
-  <desc id="desc">Banner linking to branch with Hyprland, Waybar, Rofi, and EWW stack.</desc>
+<svg width="800" height="200" viewBox="0 0 800 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="waylandTitle">
+  <title id="waylandTitle">Wayland legacy branch banner</title>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#10223a"/>
-      <stop offset="100%" stop-color="#1f4f7a"/>
+      <stop offset="0%" stop-color="#1a1215"/>
+      <stop offset="100%" stop-color="#261d20"/>
     </linearGradient>
-    <linearGradient id="pill" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#67d7ff"/>
-      <stop offset="100%" stop-color="#8ef0b5"/>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f0bc95"/>
+      <stop offset="100%" stop-color="#ffb0ca"/>
     </linearGradient>
   </defs>
-  <rect width="1600" height="320" rx="26" fill="url(#bg)"/>
-  <rect x="28" y="28" width="1544" height="264" rx="20" fill="none" stroke="#8fd3ff" stroke-opacity="0.25" stroke-width="2"/>
-  <text x="80" y="120" fill="#f5fbff" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="54" font-weight="800">
+  <rect width="800" height="200" rx="12" fill="url(#bg)"/>
+  <rect width="800" height="200" rx="12" fill="none" stroke="#514347" stroke-width="1.5"/>
+  <rect x="0" y="0" width="4" height="200" rx="2" fill="url(#accent)"/>
+  <text x="36" y="54" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#efdfe2">
     Looking for the classic Wayland stack?
   </text>
-  <text x="80" y="176" fill="#d7ecff" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="38" font-weight="600">
-    Hyprland + Waybar + Rofi + EWW branch
+  <text x="36" y="84" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#c2afb3">
+    Hyprland + Waybar + Rofi + EWW
   </text>
-  <rect x="80" y="214" width="820" height="56" rx="28" fill="url(#pill)"/>
-  <text x="108" y="250" fill="#052134" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="30" font-weight="800">
+  <rect x="36" y="110" width="220" height="40" rx="8" fill="#f0bc95"/>
+  <text x="146" y="136" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#2f1500" text-anchor="middle">
+    Check Legacy Wayland Branch
+  </text>
+  <text x="36" y="178" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#9e8c91">
     branch: wayland-hyprland-waybar-rofi-eww
   </text>
 </svg>

--- a/static/wayland-legacy-branch-banner.svg
+++ b/static/wayland-legacy-branch-banner.svg
@@ -1,5 +1,6 @@
 <svg width="800" height="200" viewBox="0 0 800 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="waylandTitle">
   <title id="waylandTitle">Wayland legacy branch banner</title>
+  <desc>Banner linking to the legacy Wayland branch with Hyprland, Waybar, Rofi, and EWW.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#1a1215"/>

--- a/static/x11-branch-banner.svg
+++ b/static/x11-branch-banner.svg
@@ -1,5 +1,6 @@
 <svg width="800" height="200" viewBox="0 0 800 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="x11Title">
   <title id="x11Title">X11 branch banner</title>
+  <desc>Banner linking to the X11 branch with i3, OpenBox, XFCE4, Polybar, Dunst, and Picom.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#1a1215"/>

--- a/static/x11-branch-banner.svg
+++ b/static/x11-branch-banner.svg
@@ -1,58 +1,29 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 150">
+<svg width="800" height="200" viewBox="0 0 800 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="x11Title">
+  <title id="x11Title">X11 branch banner</title>
   <defs>
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#667eea;stop-opacity:1" />
-      <stop offset="50%" style="stop-color:#764ba2;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#f093fb;stop-opacity:1" />
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1a1215"/>
+      <stop offset="100%" stop-color="#261d20"/>
     </linearGradient>
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#4facfe;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#00f2fe;stop-opacity:1" />
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#e2bdc7"/>
+      <stop offset="100%" stop-color="#8b4a62"/>
     </linearGradient>
-    <filter id="glow">
-      <feGaussianBlur stdDeviation="2" result="coloredBlur"/>
-      <feMerge>
-        <feMergeNode in="coloredBlur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1000" height="150" fill="url(#bgGradient)" rx="12"/>
-
-  <!-- Decorative X11 window frames -->
-  <rect x="20" y="20" width="80" height="60" fill="none" stroke="rgba(255,255,255,0.3)" stroke-width="2" rx="4"/>
-  <rect x="24" y="24" width="72" height="8" fill="rgba(255,255,255,0.2)" rx="2"/>
-
-  <rect x="900" y="70" width="80" height="60" fill="none" stroke="rgba(255,255,255,0.3)" stroke-width="2" rx="4"/>
-  <rect x="904" y="74" width="72" height="8" fill="rgba(255,255,255,0.2)" rx="2"/>
-
-  <!-- X11 Logo Symbol -->
-  <g transform="translate(130, 30)">
-    <path d="M 0,0 L 20,30 M 20,0 L 0,30" stroke="url(#accentGradient)" stroke-width="4" stroke-linecap="round" filter="url(#glow)"/>
-    <text x="30" y="22" font-family="'JetBrains Mono', monospace" font-size="20" font-weight="700" fill="white" filter="url(#glow)">11</text>
-  </g>
-
-  <!-- Main Content -->
-  <text x="500" y="55" font-family="'Segoe UI', Arial, sans-serif" font-size="28" font-weight="700" fill="white" text-anchor="middle" filter="url(#glow)">
-    🪟 Looking for X11 + Classic WMs?
+  <rect width="800" height="200" rx="12" fill="url(#bg)"/>
+  <rect width="800" height="200" rx="12" fill="none" stroke="#514347" stroke-width="1.5"/>
+  <rect x="0" y="0" width="4" height="200" rx="2" fill="url(#accent)"/>
+  <text x="36" y="54" font-family="system-ui, -apple-system, sans-serif" font-size="22" font-weight="700" fill="#efdfe2">
+    Looking for X11 + Classic WMs?
   </text>
-
-  <text x="500" y="85" font-family="'Segoe UI', Arial, sans-serif" font-size="16" fill="rgba(255,255,255,0.95)" text-anchor="middle">
+  <text x="36" y="84" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#c2afb3">
     X11 with i3, OpenBox, XFCE4, Polybar, Dunst &amp; Picom
   </text>
-
-  <!-- Call to Action Button -->
-  <g transform="translate(370, 100)">
-    <rect width="260" height="38" fill="url(#accentGradient)" rx="20" filter="url(#glow)"/>
-    <text x="130" y="25" font-family="'Segoe UI', Arial, sans-serif" font-size="16" font-weight="600" fill="white" text-anchor="middle">
-      ✨ Check the X11 Branch →
-    </text>
-  </g>
-
-  <!-- Decorative dots -->
-  <circle cx="850" cy="35" r="4" fill="rgba(255,255,255,0.6)" filter="url(#glow)"/>
-  <circle cx="865" cy="30" r="3" fill="rgba(255,255,255,0.4)"/>
-  <circle cx="875" cy="40" r="2" fill="rgba(255,255,255,0.5)"/>
+  <rect x="36" y="110" width="220" height="40" rx="8" fill="#e2bdc7"/>
+  <text x="146" y="136" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#2b151d" text-anchor="middle">
+    Check the X11 Branch
+  </text>
+  <text x="36" y="178" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#9e8c91">
+    branch: x11-openbox-i3wm-xfce4
+  </text>
 </svg>


### PR DESCRIPTION
fix: redesign banner SVGs with consistent M3 dark theme

## Summary

Replaces the three banner SVGs in the README with a unified design system based on the dotfiles' Material 3 color palette. The old banners had inconsistent styles, font choices, and color schemes that clashed with the HorneroConfig ecosystem.

## Design system

- **Background**: Deep rose-dark (#1a1215 → #261d20) matching the M3 surface palette
- **Border**: `#514347` (M3 surfaceVariant) at 1.5px
- **Accent bar**: 4px left border with M3 accent gradients
- **Text**: `#efdfe2` (onSurface), `#c2afb3` (onSurfaceVariant), `#9e8c91` (outline)
- **Typography**: `system-ui` font stack
- **Anatomy**: Accent bar · Title · Subtitle · CTA button · Footer metadata
- **Dimensions**: Uniform 800×200 for all three (old sizes varied wildly)

## Files

| SVG | Accent |
|-----|--------|
| template-banner | primary (#ffb0ca → #f0bc95) |
| x11-branch-banner | secondary (#e2bdc7 → #8b4a62) |
| wayland-legacy-branch-banner | tertiary (#f0bc95 → #ffb0ca) |
