### PR TITLE
[#184] Migrate Hyprland animation profiles and rice switching to Lua

### DIFF
--- a/home/dot_config/hypr/hyprland.lua.d/animations-cozy.lua
+++ b/home/dot_config/hypr/hyprland.lua.d/animations-cozy.lua
@@ -1,0 +1,29 @@
+require("hyprland.lua.d.animations")
+
+hl.curve("soft", { type = "bezier", points = {{0.2, 0.8}, {0.2, 1.0}} })
+hl.curve("bounce", { type = "bezier", points = {{0.2, 1.3}, {0.3, 1.0}} })
+hl.curve("gentle", { type = "bezier", points = {{0.1, 0.8}, {0.2, 1.0}} })
+hl.curve("float", { type = "bezier", points = {{0.3, 0.9}, {0.4, 1.0}} })
+hl.curve("cuddle", { type = "bezier", points = {{0.15, 1.0}, {0.25, 1.0}} })
+
+hl.animation({ leaf = "windows", enabled = true, speed = 1.67, bezier = "bounce", style = "popin 75%" })
+hl.animation({ leaf = "windowsIn", enabled = true, speed = 1.33, bezier = "cuddle", style = "popin 80%" })
+hl.animation({ leaf = "windowsOut", enabled = true, speed = 1.33, bezier = "gentle", style = "popin 70%" })
+hl.animation({ leaf = "windowsMove", enabled = true, speed = 1.67, bezier = "float", style = "slide" })
+
+hl.animation({ leaf = "border", enabled = true, speed = 2.0, bezier = "soft" })
+hl.animation({ leaf = "borderangle", enabled = true, speed = 10.0, bezier = "float", style = "loop" })
+
+hl.animation({ leaf = "fade", enabled = true, speed = 1.33, bezier = "gentle" })
+hl.animation({ leaf = "fadeIn", enabled = true, speed = 1.67, bezier = "soft" })
+hl.animation({ leaf = "fadeOut", enabled = true, speed = 1.33, bezier = "soft" })
+hl.animation({ leaf = "fadeSwitch", enabled = true, speed = 1.33, bezier = "gentle" })
+hl.animation({ leaf = "fadeShadow", enabled = true, speed = 1.67, bezier = "soft" })
+hl.animation({ leaf = "fadeDim", enabled = true, speed = 1.67, bezier = "soft" })
+
+hl.animation({ leaf = "workspaces", enabled = true, speed = 2.0, bezier = "float", style = "slide" })
+hl.animation({ leaf = "specialWorkspace", enabled = true, speed = 1.67, bezier = "bounce", style = "slidevert" })
+
+hl.animation({ leaf = "layers", enabled = true, speed = 1.0, bezier = "soft", style = "slide" })
+hl.animation({ leaf = "layersIn", enabled = true, speed = 1.33, bezier = "gentle", style = "slide" })
+hl.animation({ leaf = "layersOut", enabled = true, speed = 1.0, bezier = "gentle", style = "fade" })

--- a/home/dot_config/hypr/hyprland.lua.d/animations-cyberpunk.lua
+++ b/home/dot_config/hypr/hyprland.lua.d/animations-cyberpunk.lua
@@ -1,0 +1,28 @@
+require("hyprland.lua.d.animations")
+
+hl.curve("glitch", { type = "bezier", points = {{0.7, 0.0}, {0.3, 1.0}} })
+hl.curve("neon", { type = "bezier", points = {{0.2, 1.2}, {0.3, 1.0}} })
+hl.curve("cyber", { type = "bezier", points = {{0.85, 0.0}, {0.15, 1.0}} })
+hl.curve("flash", { type = "bezier", points = {{0.9, 0.0}, {0.1, 1.0}} })
+
+hl.animation({ leaf = "windows", enabled = true, speed = 0.67, bezier = "cyber", style = "popin 85%" })
+hl.animation({ leaf = "windowsIn", enabled = true, speed = 0.5, bezier = "neon", style = "popin 90%" })
+hl.animation({ leaf = "windowsOut", enabled = true, speed = 0.5, bezier = "flash", style = "popin 85%" })
+hl.animation({ leaf = "windowsMove", enabled = true, speed = 0.67, bezier = "glitch", style = "slide" })
+
+hl.animation({ leaf = "border", enabled = true, speed = 0.67, bezier = "cyber" })
+hl.animation({ leaf = "borderangle", enabled = true, speed = 8.33, bezier = "liner", style = "loop" })
+
+hl.animation({ leaf = "fade", enabled = true, speed = 0.5, bezier = "flash" })
+hl.animation({ leaf = "fadeIn", enabled = true, speed = 0.33, bezier = "flash" })
+hl.animation({ leaf = "fadeOut", enabled = true, speed = 0.33, bezier = "flash" })
+hl.animation({ leaf = "fadeSwitch", enabled = true, speed = 0.5, bezier = "cyber" })
+hl.animation({ leaf = "fadeShadow", enabled = true, speed = 0.67, bezier = "cyber" })
+hl.animation({ leaf = "fadeDim", enabled = true, speed = 0.5, bezier = "cyber" })
+
+hl.animation({ leaf = "workspaces", enabled = true, speed = 0.67, bezier = "glitch", style = "slide" })
+hl.animation({ leaf = "specialWorkspace", enabled = true, speed = 0.67, bezier = "neon", style = "slidevert" })
+
+hl.animation({ leaf = "layers", enabled = true, speed = 0.33, bezier = "flash", style = "fade" })
+hl.animation({ leaf = "layersIn", enabled = true, speed = 0.33, bezier = "flash", style = "fade" })
+hl.animation({ leaf = "layersOut", enabled = true, speed = 0.33, bezier = "flash", style = "fade" })

--- a/home/dot_config/hypr/hyprland.lua.d/animations-minimal.lua
+++ b/home/dot_config/hypr/hyprland.lua.d/animations-minimal.lua
@@ -1,0 +1,26 @@
+require("hyprland.lua.d.animations")
+
+hl.curve("snap", { type = "bezier", points = {{0.5, 0.0}, {0.5, 1.0}} })
+hl.curve("direct", { type = "bezier", points = {{0.4, 0.0}, {0.6, 1.0}} })
+
+hl.animation({ leaf = "windows", enabled = true, speed = 0.33, bezier = "snap", style = "slide" })
+hl.animation({ leaf = "windowsIn", enabled = true, speed = 0.33, bezier = "linear", style = "slide" })
+hl.animation({ leaf = "windowsOut", enabled = true, speed = 0.17, bezier = "linear", style = "slide" })
+hl.animation({ leaf = "windowsMove", enabled = true, speed = 0.33, bezier = "direct", style = "slide" })
+
+hl.animation({ leaf = "border", enabled = true, speed = 0.33, bezier = "linear" })
+hl.animation({ leaf = "borderangle", enabled = false })
+
+hl.animation({ leaf = "fade", enabled = true, speed = 0.33, bezier = "linear" })
+hl.animation({ leaf = "fadeIn", enabled = true, speed = 0.17, bezier = "linear" })
+hl.animation({ leaf = "fadeOut", enabled = true, speed = 0.17, bezier = "linear" })
+hl.animation({ leaf = "fadeSwitch", enabled = true, speed = 0.33, bezier = "linear" })
+hl.animation({ leaf = "fadeShadow", enabled = true, speed = 0.33, bezier = "linear" })
+hl.animation({ leaf = "fadeDim", enabled = true, speed = 0.33, bezier = "linear" })
+
+hl.animation({ leaf = "workspaces", enabled = true, speed = 0.33, bezier = "snap", style = "slide" })
+hl.animation({ leaf = "specialWorkspace", enabled = true, speed = 0.33, bezier = "snap", style = "slidevert" })
+
+hl.animation({ leaf = "layers", enabled = true, speed = 0.17, bezier = "linear", style = "fade" })
+hl.animation({ leaf = "layersIn", enabled = true, speed = 0.17, bezier = "linear", style = "fade" })
+hl.animation({ leaf = "layersOut", enabled = true, speed = 0.17, bezier = "linear", style = "fade" })

--- a/home/dot_config/hypr/hyprland.lua.d/animations-nature.lua
+++ b/home/dot_config/hypr/hyprland.lua.d/animations-nature.lua
@@ -1,0 +1,28 @@
+require("hyprland.lua.d.animations")
+
+hl.curve("leaf", { type = "bezier", points = {{0.25, 0.46}, {0.45, 0.94}} })
+hl.curve("breeze", { type = "bezier", points = {{0.16, 1.00}, {0.30, 1.00}} })
+hl.curve("root", { type = "bezier", points = {{0.22, 1.00}, {0.36, 1.00}} })
+hl.curve("branch", { type = "bezier", points = {{0.34, 1.56}, {0.64, 1.00}} })
+hl.curve("settle", { type = "bezier", points = {{0.08, 0.82}, {0.30, 1.00}} })
+
+hl.animation({ leaf = "windows", enabled = true, speed = 1.17, bezier = "branch", style = "popin 80%" })
+hl.animation({ leaf = "windowsIn", enabled = true, speed = 1.0, bezier = "breeze", style = "popin 85%" })
+hl.animation({ leaf = "windowsOut", enabled = true, speed = 0.83, bezier = "settle", style = "popin 75%" })
+hl.animation({ leaf = "windowsMove", enabled = true, speed = 1.33, bezier = "leaf", style = "slide" })
+
+hl.animation({ leaf = "border", enabled = true, speed = 1.67, bezier = "settle" })
+
+hl.animation({ leaf = "fade", enabled = true, speed = 0.83, bezier = "settle" })
+hl.animation({ leaf = "fadeIn", enabled = true, speed = 0.67, bezier = "breeze" })
+hl.animation({ leaf = "fadeOut", enabled = true, speed = 0.67, bezier = "leaf" })
+hl.animation({ leaf = "fadeSwitch", enabled = true, speed = 0.83, bezier = "root" })
+hl.animation({ leaf = "fadeShadow", enabled = true, speed = 1.0, bezier = "settle" })
+hl.animation({ leaf = "fadeDim", enabled = true, speed = 0.83, bezier = "leaf" })
+
+hl.animation({ leaf = "workspaces", enabled = true, speed = 1.33, bezier = "breeze", style = "slide" })
+hl.animation({ leaf = "specialWorkspace", enabled = true, speed = 1.17, bezier = "root", style = "slidevert" })
+
+hl.animation({ leaf = "layers", enabled = true, speed = 0.83, bezier = "breeze", style = "fade" })
+hl.animation({ leaf = "layersIn", enabled = true, speed = 0.67, bezier = "breeze", style = "fade" })
+hl.animation({ leaf = "layersOut", enabled = true, speed = 0.67, bezier = "settle", style = "fade" })

--- a/home/dot_config/hypr/hyprland.lua.d/animations-vaporwave.lua
+++ b/home/dot_config/hypr/hyprland.lua.d/animations-vaporwave.lua
@@ -1,0 +1,28 @@
+require("hyprland.lua.d.animations")
+
+hl.curve("retro", { type = "bezier", points = {{0.3, 0.8}, {0.2, 1.0}} })
+hl.curve("dream", { type = "bezier", points = {{0.2, 1.1}, {0.3, 1.0}} })
+hl.curve("sunset", { type = "bezier", points = {{0.4, 0.0}, {0.2, 1.0}} })
+hl.curve("vhs", { type = "bezier", points = {{0.6, 0.0}, {0.4, 1.0}} })
+
+hl.animation({ leaf = "windows", enabled = true, speed = 1.33, bezier = "dream", style = "popin 80%" })
+hl.animation({ leaf = "windowsIn", enabled = true, speed = 1.33, bezier = "retro", style = "popin 85%" })
+hl.animation({ leaf = "windowsOut", enabled = true, speed = 1.0, bezier = "sunset", style = "popin 75%" })
+hl.animation({ leaf = "windowsMove", enabled = true, speed = 1.33, bezier = "retro", style = "slide" })
+
+hl.animation({ leaf = "border", enabled = true, speed = 1.67, bezier = "retro" })
+hl.animation({ leaf = "borderangle", enabled = true, speed = 13.33, bezier = "liner", style = "loop" })
+
+hl.animation({ leaf = "fade", enabled = true, speed = 1.33, bezier = "vhs" })
+hl.animation({ leaf = "fadeIn", enabled = true, speed = 1.67, bezier = "retro" })
+hl.animation({ leaf = "fadeOut", enabled = true, speed = 1.33, bezier = "sunset" })
+hl.animation({ leaf = "fadeSwitch", enabled = true, speed = 1.33, bezier = "retro" })
+hl.animation({ leaf = "fadeShadow", enabled = true, speed = 1.67, bezier = "retro" })
+hl.animation({ leaf = "fadeDim", enabled = true, speed = 1.33, bezier = "sunset" })
+
+hl.animation({ leaf = "workspaces", enabled = true, speed = 1.67, bezier = "retro", style = "slide" })
+hl.animation({ leaf = "specialWorkspace", enabled = true, speed = 1.33, bezier = "dream", style = "slidevert" })
+
+hl.animation({ leaf = "layers", enabled = true, speed = 1.0, bezier = "retro", style = "slide" })
+hl.animation({ leaf = "layersIn", enabled = true, speed = 1.33, bezier = "dream", style = "slide" })
+hl.animation({ leaf = "layersOut", enabled = true, speed = 1.0, bezier = "sunset", style = "fade" })

--- a/home/dot_config/hypr/hyprland.lua.d/animations.lua
+++ b/home/dot_config/hypr/hyprland.lua.d/animations.lua
@@ -1,0 +1,30 @@
+hl.curve("wind", { type = "bezier", points = {{0.05, 0.9}, {0.1, 1.05}} })
+hl.curve("winIn", { type = "bezier", points = {{0.1, 1.1}, {0.1, 1.0}} })
+hl.curve("winOut", { type = "bezier", points = {{0.3, -0.3}, {0, 1}} })
+hl.curve("liner", { type = "bezier", points = {{1, 1}, {1, 1}} })
+hl.curve("linear", { type = "bezier", points = {{0.0, 0.0}, {1.0, 1.0}} })
+hl.curve("easeInOut", { type = "bezier", points = {{0.42, 0.0}, {0.58, 1.0}} })
+hl.curve("easeOut", { type = "bezier", points = {{0.0, 0.0}, {0.58, 1.0}} })
+hl.curve("focusPulse", { type = "bezier", points = {{0.4, 0.0}, {0.2, 1.0}} })
+
+hl.animation({ leaf = "windows", enabled = true, speed = 1.0, bezier = "wind", style = "slide" })
+hl.animation({ leaf = "windowsIn", enabled = true, speed = 1.0, bezier = "winIn", style = "slide" })
+hl.animation({ leaf = "windowsOut", enabled = true, speed = 1.0, bezier = "winOut", style = "slide" })
+hl.animation({ leaf = "windowsMove", enabled = true, speed = 1.0, bezier = "wind", style = "slide" })
+
+hl.animation({ leaf = "border", enabled = true, speed = 1.0, bezier = "easeInOut" })
+hl.animation({ leaf = "borderangle", enabled = true, speed = 5.0, bezier = "liner", style = "loop" })
+
+hl.animation({ leaf = "fade", enabled = true, speed = 1.0, bezier = "easeInOut" })
+hl.animation({ leaf = "fadeIn", enabled = true, speed = 1.0, bezier = "easeOut" })
+hl.animation({ leaf = "fadeOut", enabled = true, speed = 1.0, bezier = "easeOut" })
+hl.animation({ leaf = "fadeSwitch", enabled = true, speed = 1.0, bezier = "easeInOut" })
+hl.animation({ leaf = "fadeShadow", enabled = true, speed = 1.0, bezier = "easeInOut" })
+hl.animation({ leaf = "fadeDim", enabled = true, speed = 1.0, bezier = "easeInOut" })
+
+hl.animation({ leaf = "workspaces", enabled = true, speed = 1.0, bezier = "wind", style = "slidevert" })
+hl.animation({ leaf = "specialWorkspace", enabled = true, speed = 1.0, bezier = "wind", style = "slidevert" })
+
+hl.animation({ leaf = "layers", enabled = true, speed = 0.67, bezier = "easeOut", style = "slide" })
+hl.animation({ leaf = "layersIn", enabled = true, speed = 0.67, bezier = "easeOut", style = "slide" })
+hl.animation({ leaf = "layersOut", enabled = true, speed = 0.67, bezier = "easeOut", style = "slide" })

--- a/home/dot_config/quickshell/services/Rice.qml
+++ b/home/dot_config/quickshell/services/Rice.qml
@@ -13,7 +13,7 @@ Singleton {
     readonly property string wallpaperPointer: `${Quickshell.env("HOME")}/.local/state/dots/wallpaper/path`
     readonly property string m3Script: `${Quickshell.env("HOME")}/.local/lib/dots/generate-m3-colors.py`
     readonly property string schemeJson: `${Quickshell.env("HOME")}/.cache/dots/smart-colors/scheme.json`
-    readonly property string hyprAnimDir: `${Quickshell.env("HOME")}/.config/hypr/hyprland.conf.d`
+    readonly property string hyprAnimDir: `${Quickshell.env("HOME")}/.config/hypr/hyprland.lua.d`
 
     property string currentId: ""
     property var currentConfig: ({})
@@ -309,10 +309,10 @@ Singleton {
 
         property string animProfile: ""
 
-        command: ["sh", "-c", '[ -f "$DOTS_ANIM_SRC" ] && ln -sf "$DOTS_ANIM_SRC" "$DOTS_ANIM_DST" || true']
+        command: ["sh", "-c", 'mkdir -p "$(dirname "$DOTS_ANIM_DST")" && printf '"'"'require("hyprland.lua.d.animations-%s")\n'"'"' "$DOTS_ANIM_PROFILE" > "$DOTS_ANIM_DST"']
         environment: ({
-            "DOTS_ANIM_SRC": `${root.hyprAnimDir}/animations-${hyprAnimProc.animProfile}.conf`,
-            "DOTS_ANIM_DST": `${root.hyprAnimDir}/animations-current.conf`
+            "DOTS_ANIM_DST": `${root.hyprAnimDir}/animations-current.lua`,
+            "DOTS_ANIM_PROFILE": hyprAnimProc.animProfile,
         })
     }
 


### PR DESCRIPTION
## Summary

Migrates Hyprland animation profiles and the rice animation switching mechanism from hyprlang to Lua.

### New files

| File | Description |
|------|-------------|
| `animations.lua` | Base default profile (8 bezier curves, 23 animation leaves) |
| `animations-cyberpunk.lua` | Fast/glitchy profile overrides |
| `animations-cozy.lua` | Slow/bouncy profile overrides |
| `animations-vaporwave.lua` | Retro/dreamy profile overrides |
| `animations-nature.lua` | Gentle/organic profile overrides |
| `animations-minimal.lua` | Instant/snappy profile overrides |

### Changes

| File | Change |
|------|--------|
| `home/dot_config/quickshell/services/Rice.qml` | Updated animation paths from `.conf.d` to `.lua.d`; changed symlinking strategy to writing a `require` wrapper |

### Animation speed conversion

Old hyprlang used "frames" (≈16.67ms at 60fps). Hyprland 0.55+ Lua uses
deciseconds (`speed = 1.0` = 100ms). Conversion table:

| Frames | ms | Lua speed |
|--------|----|-----------|
| 2 | 33 | 0.33 |
| 3 | 50 | 0.50 |
| 4 | 67 | 0.67 |
| 5 | 83 | 0.83 |
| 6 | 100 | 1.00 |
| 7 | 117 | 1.17 |
| 8 | 133 | 1.33 |
| 10 | 167 | 1.67 |
| 12 | 200 | 2.00 |
| 30 | 500 | 5.00 |

### Profile architecture

Each profile file `require()`s the base `animations.lua` first, then calls
`hl.curve()` and `hl.animation()` to override specific entries. The base is
cached by `require()`, remaining animations inherit from the default.

Rice.qml generates `animations-current.lua` containing a `require()` call to
the active profile, which is then loaded by the entrypoint `hyprland.lua`.

## Related Issues

- Epic: #179
- Closes: #184
