### PR TITLE
[#187] Update Hyprland Lua migration documentation

### DIFF
--- a/docs/Hyprland-Setup.md
+++ b/docs/Hyprland-Setup.md
@@ -27,7 +27,7 @@ dots appearance apply neon-city
 
 ## Core Paths
 
-- Hyprland config: `~/.config/hypr/`
+- Hyprland config: `~/.config/hypr/hyprland.lua` (Hyprland 0.55+ Lua)
 - Quickshell config: `~/.config/quickshell/`
 - Smart colors cache: `~/.cache/dots/smart-colors/`
 

--- a/docs/wiki/Changelog-2025.md
+++ b/docs/wiki/Changelog-2025.md
@@ -77,7 +77,7 @@ dots-smart-colors --analyze --colors
 **Hyprland Floating Window Configuration**:
 
 ```conf
-# Hyprland floating window rules are configured in hyprland.conf
+# Hyprland floating window rules are configured in hyprland.lua
 ```
 ```text
 

--- a/docs/wiki/Changelog-2025.md
+++ b/docs/wiki/Changelog-2025.md
@@ -79,6 +79,7 @@ dots-smart-colors --analyze --colors
 ```conf
 # Hyprland floating window rules are configured in hyprland.lua
 ```
+
 ```text
 
 # Global floating window constraints

--- a/docs/wiki/Hybrid-GPU-Performance.md
+++ b/docs/wiki/Hybrid-GPU-Performance.md
@@ -252,12 +252,12 @@ __NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia <app>
 
 NVIDIA GPUs have different performance states (P-states):
 
-| P-State | Mode | Power Usage | Use Case |
-|---------|------|-------------|----------|
-| P0 | Maximum Performance | ~50-55W | Gaming, Heavy Compute |
-| P2 | Balanced | ~20-30W | Video Editing |
-| P5 | Low Power | ~5-10W | Display Output Only |
-| P8 | Idle (not achievable with display) | ~1-2W | No display connected |
+| P-State | Mode                               | Power Usage | Use Case              |
+|---------|------------------------------------|-------------|-----------------------|
+| P0      | Maximum Performance                | ~50-55W     | Gaming, Heavy Compute |
+| P2      | Balanced                           | ~20-30W     | Video Editing         |
+| P5      | Low Power                          | ~5-10W      | Display Output Only   |
+| P8      | Idle (not achievable with display) | ~1-2W       | No display connected  |
 
 In Reverse PRIME mode with external monitor, NVIDIA stays at **P5** (5W) minimum.
 

--- a/docs/wiki/Hybrid-GPU-Performance.md
+++ b/docs/wiki/Hybrid-GPU-Performance.md
@@ -218,7 +218,7 @@ sudo systemctl restart display-manager
 **Solution**:
 
 ```properties
-# In hyprland.conf, verify:
+# In hyprland.lua, verify:
 misc {
     vrr = 1  # Variable Refresh Rate
     no_direct_scanout = false

--- a/docs/wiki/Hyprland-Keybindings.md
+++ b/docs/wiki/Hyprland-Keybindings.md
@@ -180,31 +180,25 @@ Interactive gaps adjustment:
 
 ## Configuration Files
 
-Keybindings are organized in:
+Keybindings are defined in:
 
 ```bash
-~/.config/hypr/hyprland.conf.d/
-├── keybindings.conf           # Core keybindings
-├── keybindings-media.conf     # Media and volume controls
-└── keybindings-custom.conf    # User customizations
+~/.config/hypr/hyprland.lua.d/keybindings.lua
 ```
 
 ## Customization
 
-To add custom keybindings, edit:
+To add custom keybindings, edit the Lua module:
 
 ```bash
-~/.config/hypr/hyprland.conf.d/keybindings-custom.conf
+~/.config/hypr/hyprland.lua.d/keybindings.lua
 ```
 
-Example:
+Example (Hyprland 0.55+ Lua syntax):
 
-```conf
-# Custom application launcher
-bind = $Mod, B, exec, firefox
-
-# Custom window manipulation
-bind = $Mod SHIFT, M, togglesplit
+```lua
+hl.bind("SUPER + B", hl.dsp.exec_cmd("firefox"), { description = "[Custom] Firefox" })
+hl.bind("SUPER + SHIFT + M", hl.dsp.layout("togglesplit"), { description = "[Custom] Toggle split" })
 ```
 
 ## Tips

--- a/docs/wiki/Hyprland-Keybindings.md
+++ b/docs/wiki/Hyprland-Keybindings.md
@@ -4,156 +4,156 @@ Complete reference for all keybindings in HorneroConfig's Hyprland setup.
 
 ## Applications and Utilities
 
-| Keybinding | Function |
-|------------|----------|
-| `Super+Return` | Terminal (Kitty) |
-| `Super+D` | Application launcher (Quickshell) |
-| `Alt+Ctrl+C` | Clipboard manager (`dots-clipboard`) |
+| Keybinding             | Function                                               |
+|------------------------|--------------------------------------------------------|
+| `Super+Return`         | Terminal (Kitty)                                       |
+| `Super+D`              | Application launcher (Quickshell)                      |
+| `Alt+Ctrl+C`           | Clipboard manager (`dots-clipboard`)                   |
 | `Super+?` or `Super+/` | Keyboard shortcuts help overlay (`dots-keyboard-help`) |
-| `Super+Ctrl+Space` | AI assistant (sgpt via IBus) |
-| `Super+Shift+Tab` | Task switcher (`dots-snappy-switcher prev`) |
-| `Super+E` | File manager (Thunar) |
-| `Super+Shift+S` | Screenshot tool (grimblast/grim) |
-| `Print` | Screenshot (area selection) |
+| `Super+Ctrl+Space`     | AI assistant (sgpt via IBus)                           |
+| `Super+Shift+Tab`      | Task switcher (`dots-snappy-switcher prev`)            |
+| `Super+E`              | File manager (Thunar)                                  |
+| `Super+Shift+S`        | Screenshot tool (grimblast/grim)                       |
+| `Print`                | Screenshot (area selection)                            |
 
 ## Window Management
 
-| Keybinding | Function |
-|------------|----------|
-| `Super+Q` | Close focused window |
-| `Super+Shift+Q` | Kill focused window (force) |
-| `Super+F` | Toggle fullscreen |
-| `Super+Shift+F` | Smart floating (toggle + center + resize) |
-| `Super+Shift+Space` | Focus toggle (floating ↔ tiled) |
-| `Super+Ctrl+C` | Center floating window |
-| `Super+Space` | Toggle tiling/floating |
-| `Super+P` | Focus parent (group) |
-| `Super+C` | Focus child (group) |
-| `Super+U` | Promote focused window to its own column (scrolling layout) |
-| `Super+'` | Toggle focus fit mode (center ↔ fit) |
-| `Super+Ctrl+W` | Toggle layout profile (scrolling ↔ dwindle) |
-| `Super+Ctrl+Shift+W` | Force scrolling profile |
-| `Super+Ctrl+Alt+W` | Force dwindle profile |
+| Keybinding           | Function                                                    |
+|----------------------|-------------------------------------------------------------|
+| `Super+Q`            | Close focused window                                        |
+| `Super+Shift+Q`      | Kill focused window (force)                                 |
+| `Super+F`            | Toggle fullscreen                                           |
+| `Super+Shift+F`      | Smart floating (toggle + center + resize)                   |
+| `Super+Shift+Space`  | Focus toggle (floating ↔ tiled)                             |
+| `Super+Ctrl+C`       | Center floating window                                      |
+| `Super+Space`        | Toggle tiling/floating                                      |
+| `Super+P`            | Focus parent (group)                                        |
+| `Super+C`            | Focus child (group)                                         |
+| `Super+U`            | Promote focused window to its own column (scrolling layout) |
+| `Super+'`            | Toggle focus fit mode (center ↔ fit)                        |
+| `Super+Ctrl+W`       | Toggle layout profile (scrolling ↔ dwindle)                 |
+| `Super+Ctrl+Shift+W` | Force scrolling profile                                     |
+| `Super+Ctrl+Alt+W`   | Force dwindle profile                                       |
 
 ## Window Focus
 
-| Keybinding | Function |
-|------------|----------|
-| `Super+H` / `Super+Left` | Focus window left |
-| `Super+J` / `Super+Down` | Focus window down |
-| `Super+K` / `Super+Up` | Focus window up |
+| Keybinding                | Function           |
+|---------------------------|--------------------|
+| `Super+H` / `Super+Left`  | Focus window left  |
+| `Super+J` / `Super+Down`  | Focus window down  |
+| `Super+K` / `Super+Up`    | Focus window up    |
 | `Super+L` / `Super+Right` | Focus window right |
 
 ## Window Movement
 
-| Keybinding | Function |
-|------------|----------|
-| `Super+Shift+H` / `Super+Shift+Left` | Move window left |
-| `Super+Shift+J` / `Super+Shift+Down` | Move window down |
-| `Super+Shift+K` / `Super+Shift+Up` | Move window up |
+| Keybinding                            | Function          |
+|---------------------------------------|-------------------|
+| `Super+Shift+H` / `Super+Shift+Left`  | Move window left  |
+| `Super+Shift+J` / `Super+Shift+Down`  | Move window down  |
+| `Super+Shift+K` / `Super+Shift+Up`    | Move window up    |
 | `Super+Shift+L` / `Super+Shift+Right` | Move window right |
 
 ## Window Resizing
 
-| Keybinding | Function |
-|------------|----------|
-| `Super+R` | Enter resize mode |
-| `Super+Ctrl+H` | Resize shrink width |
-| `Super+Ctrl+J` | Resize grow height |
+| Keybinding     | Function             |
+|----------------|----------------------|
+| `Super+R`      | Enter resize mode    |
+| `Super+Ctrl+H` | Resize shrink width  |
+| `Super+Ctrl+J` | Resize grow height   |
 | `Super+Ctrl+K` | Resize shrink height |
-| `Super+Ctrl+L` | Resize grow width |
+| `Super+Ctrl+L` | Resize grow width    |
 
 ## Workspace Navigation
 
-| Keybinding | Function |
-|------------|----------|
-| `Super+1-9,0` | Switch to workspace 1-10 |
-| `Super+KP_1-9,0` | Switch to workspace 1-10 (numpad) |
-| `Super+Alt+Left` | Previous active workspace |
-| `Super+Alt+Right` | Next active workspace |
-| `Super+Ctrl+Left` | Previous existing workspace |
-| `Super+Ctrl+Right` | Next existing workspace |
-| `Super+Tab` | Cycle through workspaces |
+| Keybinding         | Function                          |
+|--------------------|-----------------------------------|
+| `Super+1-9,0`      | Switch to workspace 1-10          |
+| `Super+KP_1-9,0`   | Switch to workspace 1-10 (numpad) |
+| `Super+Alt+Left`   | Previous active workspace         |
+| `Super+Alt+Right`  | Next active workspace             |
+| `Super+Ctrl+Left`  | Previous existing workspace       |
+| `Super+Ctrl+Right` | Next existing workspace           |
+| `Super+Tab`        | Cycle through workspaces          |
 
 ## Window to Workspace
 
-| Keybinding | Function |
-|------------|----------|
-| `Super+Shift+1-9,0` | Move window to workspace 1-10 |
+| Keybinding             | Function                               |
+|------------------------|----------------------------------------|
+| `Super+Shift+1-9,0`    | Move window to workspace 1-10          |
 | `Super+Shift+KP_1-9,0` | Move window to workspace 1-10 (numpad) |
 
 ## Scratchpad
 
-| Keybinding | Function |
-|------------|----------|
-| `Super+Z` | Toggle scratchpad visibility |
-| `Super+Shift+Z` | Move window to scratchpad |
+| Keybinding      | Function                     |
+|-----------------|------------------------------|
+| `Super+Z`       | Toggle scratchpad visibility |
+| `Super+Shift+Z` | Move window to scratchpad    |
 
 ## Scrolling Layout (Niri-style)
 
-| Keybinding | Function |
-|------------|----------|
-| `Super+Alt+H` | Move layout viewport one column to the left |
-| `Super+Alt+L` | Move layout viewport one column to the right |
-| `Super+Alt+,` | Swap active column with left neighbor |
-| `Super+Alt+.` | Swap active column with right neighbor |
-| `Super+Alt+-` / `Super+Alt+=` | Decrease/increase column width preset |
-| `Super+Alt+Shift+-` / `Super+Alt+Shift+=` | Fine resize column width |
-| `Super+Alt+F` | Fit active column into view |
-| `Super+Alt+Shift+F` | Fit visible columns into view |
+| Keybinding                                | Function                                     |
+|-------------------------------------------|----------------------------------------------|
+| `Super+Alt+H`                             | Move layout viewport one column to the left  |
+| `Super+Alt+L`                             | Move layout viewport one column to the right |
+| `Super+Alt+,`                             | Swap active column with left neighbor        |
+| `Super+Alt+.`                             | Swap active column with right neighbor       |
+| `Super+Alt+-` / `Super+Alt+=`             | Decrease/increase column width preset        |
+| `Super+Alt+Shift+-` / `Super+Alt+Shift+=` | Fine resize column width                     |
+| `Super+Alt+F`                             | Fit active column into view                  |
+| `Super+Alt+Shift+F`                       | Fit visible columns into view                |
 
 ## Gaps Control
 
-| Keybinding | Function |
-|------------|----------|
-| `Super+G, +` | Increase gaps |
-| `Super+G, -` | Decrease gaps |
-| `Super+G, 0` | Reset gaps to default |
-| `Super+G, Shift+0` | Remove all gaps |
+| Keybinding         | Function              |
+|--------------------|-----------------------|
+| `Super+G, +`       | Increase gaps         |
+| `Super+G, -`       | Decrease gaps         |
+| `Super+G, 0`       | Reset gaps to default |
+| `Super+G, Shift+0` | Remove all gaps       |
 
 ## System Controls
 
-| Keybinding | Function |
-|------------|----------|
-| `Super+Ctrl+P` | Toggle Bar (Quickshell) |
-| `Super+Ctrl+M` | Toggle Notification Center (Quickshell) |
-| `Super+Shift+R` | Reload Hyprland configuration |
-| `Super+Shift+E` | Exit Hyprland |
-| `Super+X` | System power menu (Quickshell) |
-| `Super+L` | Lock screen (Hyprlock) |
+| Keybinding      | Function                                |
+|-----------------|-----------------------------------------|
+| `Super+Ctrl+P`  | Toggle Bar (Quickshell)                 |
+| `Super+Ctrl+M`  | Toggle Notification Center (Quickshell) |
+| `Super+Shift+R` | Reload Hyprland configuration           |
+| `Super+Shift+E` | Exit Hyprland                           |
+| `Super+X`       | System power menu (Quickshell)          |
+| `Super+L`       | Lock screen (Hyprlock)                  |
 
 ## Media Controls
 
-| Keybinding | Function |
-|------------|----------|
-| `XF86AudioPlay` | Play/pause media |
-| `XF86AudioPause` | Pause media |
-| `XF86AudioNext` | Next track |
-| `XF86AudioPrev` | Previous track |
-| `XF86AudioStop` | Stop playback |
+| Keybinding       | Function         |
+|------------------|------------------|
+| `XF86AudioPlay`  | Play/pause media |
+| `XF86AudioPause` | Pause media      |
+| `XF86AudioNext`  | Next track       |
+| `XF86AudioPrev`  | Previous track   |
+| `XF86AudioStop`  | Stop playback    |
 
 ## Volume Controls
 
-| Keybinding | Function |
-|------------|----------|
-| `XF86AudioRaiseVolume` | Increase volume (+1%) |
-| `XF86AudioLowerVolume` | Decrease volume (-1%) |
-| `XF86AudioMute` | Toggle mute |
-| `XF86AudioMicMute` | Toggle microphone mute |
+| Keybinding             | Function               |
+|------------------------|------------------------|
+| `XF86AudioRaiseVolume` | Increase volume (+1%)  |
+| `XF86AudioLowerVolume` | Decrease volume (-1%)  |
+| `XF86AudioMute`        | Toggle mute            |
+| `XF86AudioMicMute`     | Toggle microphone mute |
 
 ## Brightness Controls
 
-| Keybinding | Function |
-|------------|----------|
-| `XF86MonBrightnessUp` | Increase brightness |
+| Keybinding              | Function            |
+|-------------------------|---------------------|
+| `XF86MonBrightnessUp`   | Increase brightness |
 | `XF86MonBrightnessDown` | Decrease brightness |
 
 ## Mouse Bindings
 
-| Action | Function |
-|--------|----------|
-| `Super+Left Click` | Move window |
-| `Super+Right Click` | Resize window |
+| Action               | Function        |
+|----------------------|-----------------|
+| `Super+Left Click`   | Move window     |
+| `Super+Right Click`  | Resize window   |
 | `Super+Middle Click` | Toggle floating |
 
 ## Special Modes

--- a/docs/wiki/Window-Managers.md
+++ b/docs/wiki/Window-Managers.md
@@ -33,7 +33,7 @@ The Hyprland configuration controls:
 To edit:
 
 ```sh
-chezmoi edit ~/.config/hypr/hyprland.conf
+chezmoi edit ~/.config/hypr/hyprland.lua
 chezmoi apply
 ```
 


### PR DESCRIPTION
## Summary

Updates maintained documentation to reflect the Hyprland 0.55+ Lua configuration layout.

### Changes

| File | Change |
|------|--------|
| `docs/Hyprland-Setup.md` | Updated config path to `hyprland.lua` |
| `docs/wiki/Hyprland-Keybindings.md` | Replaced `.conf.d/` tree with `keybindings.lua` path; examples use Lua syntax |
| `docs/wiki/Window-Managers.md` | Updated edit instructions to `chezmoi edit ~/.config/hypr/hyprland.lua` |
| `docs/wiki/Hybrid-GPU-Performance.md` | Updated `hyprland.conf` reference to `hyprland.lua` |
| `docs/wiki/Changelog-2025.md` | Updated config reference to `hyprland.lua` |

No stale `hyprland.conf` references remain in maintained docs.

## Related Issues

- Epic: #179
- Closes: #187
