### PR TITLE
fix: keep dots validator running after errors

### DIFF
--- a/scripts/validate-dots-scripts.sh
+++ b/scripts/validate-dots-scripts.sh
@@ -47,19 +47,19 @@ for script in "${DOTS_BIN_DIR}"/executable_dots-*; do
     # Check for copyright header
     if ! head -n 10 "$script" | grep -q "Copyright"; then
       echo "❌ Missing copyright header: $script_name"
-      ((errors++))
+      errors=$((errors + 1))
     fi
 
     # Check for license header
     if ! head -n 15 "$script" | grep -q -E "(Licensed under MIT|GNU General Public License)"; then
       echo "❌ Missing license header: $script_name"
-      ((errors++))
+      errors=$((errors + 1))
     fi
 
     # Check for set -euo pipefail (required for robustness)
     if ! grep -q "^set -euo pipefail" "$script"; then
       echo "❌ Missing 'set -euo pipefail': $script_name"
-      ((errors++))
+      errors=$((errors + 1))
     fi
 
     # Check for easyoptions usage (warning only, not error for simple scripts)
@@ -80,7 +80,7 @@ done
 for script in "${ENTRYPOINT_SCRIPTS[@]}"; do
   if [[ ! -f $script ]]; then
     echo "❌ Missing critical entrypoint script: $script"
-    ((errors++))
+    errors=$((errors + 1))
     continue
   fi
 
@@ -88,12 +88,12 @@ for script in "${ENTRYPOINT_SCRIPTS[@]}"; do
 
   if ! grep -q "^set -euo pipefail" "$script"; then
     echo "❌ Missing 'set -euo pipefail' in entrypoint: $script_name"
-    ((errors++))
+    errors=$((errors + 1))
   fi
 
   if ! grep -q "easyoptions.sh" "$script"; then
     echo "❌ Missing EasyOptions usage in entrypoint: $script_name"
-    ((errors++))
+    errors=$((errors + 1))
   fi
 done
 
@@ -107,7 +107,7 @@ if ! diff -q <(echo "$scripts_in_dir") <(echo "$scripts_in_list") >/dev/null; th
   comm -23 <(echo "$scripts_in_dir") <(echo "$scripts_in_list")
   echo "Scripts in list but not in directory:"
   comm -13 <(echo "$scripts_in_dir") <(echo "$scripts_in_list")
-  ((errors++))
+  errors=$((errors + 1))
 fi
 
 if [[ $errors -eq 0 ]]; then


### PR DESCRIPTION
Fixes #213

## Summary
- replace all `((errors++))` counters with assignment-based increments that are safe under `set -e`
- allow the validator to report all discovered problems instead of aborting on the first error

## Testing
- `bash -n scripts/validate-dots-scripts.sh`
- confirmed no post-increment counters remain
- ran the validator with a bash `find` shim to bypass macOS `find -printf` incompatibility; it reached the final `Found 1 validation errors` summary

The real Arch/Linux `find -printf` path should be exercised by the repository CI workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation script compatibility when reporting missing headers, required safety settings, entrypoint issues, and synchronization mismatches.
  * Validation errors are now counted reliably across all failure checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->