### PR TITLE
fix: guard pipx before installing wpgtk

### DIFF
--- a/home/.chezmoiscripts/linux/run_onchange_before_install-wpg.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_before_install-wpg.sh.tmpl
@@ -8,6 +8,7 @@ yay -S --noconfirm --needed \
   python-pywal \
   sassc
 
+command -v pipx >/dev/null 2>&1 || sudo pacman -S --noconfirm --needed pipx
 pipx install wpgtk
 pipx inject wpgtk pygobject
 {{      end -}}


### PR DESCRIPTION
## What

Fixes #215 by ensuring `pipx` is installed before the WPG theme setup invokes it.

## Why

The script can run before `pipx` is available on a fresh Arch installation, causing the setup to fail with an unclear command-not-found error.

## Changes

- Add the requested idempotent `command -v pipx` guard before `pipx install wpgtk`.

## Testing

- `git diff --check`
- Rendered shell body syntax check with `sed "/^{{/d" ... | bash -n`
- `shellcheck` and `chezmoi` were unavailable locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Linux Arch installations now automatically install `pipx` when it is unavailable, allowing the `wpgtk` setup to continue successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->