### PR TITLE
fix: materialyoucolor install hints (no pip)

### DIFF
--- a/home/dot_local/lib/dots/generate-m3-colors.py
+++ b/home/dot_local/lib/dots/generate-m3-colors.py
@@ -5,7 +5,7 @@ Uses the materialyoucolor library to extract HCT source color, generate
 a full M3 scheme (60+ color roles), success colors, and 16 ANSI terminal
 colors.  Outputs a single JSON file consumed by Quickshell's Colours service.
 
-Requires: pip install materialyoucolor
+Requires: python-materialyoucolor (Arch package)
 """
 
 import argparse
@@ -267,7 +267,8 @@ def main() -> None:
     except ImportError:
         print(
             "Error: materialyoucolor is not installed.\n"
-            "  pip install materialyoucolor --upgrade",
+            "  Arch (HorneroConfig): yay -S --needed python-materialyoucolor"
+            "  Or: uv pip install materialyoucolor   # only if you manage a local venv",
             file=sys.stderr,
         )
         sys.exit(1)


### PR DESCRIPTION
## Summary

Fixes https://github.com/ulises-jeremias/dotfiles/issues/234
Update `generate-m3-colors.py` to recommend the Arch package `python-materialyoucolor` instead of a generic `pip install` command.

## Changes

- Update the module docstring to list `python-materialyoucolor` as the required dependency.
- Replace the runtime import error message to:
  - recommend `yay -S --needed python-materialyoucolor` as the primary installation method for HorneroConfig/Arch users;
  - keep `uv pip install materialyoucolor` as an alternative for users managing their own virtual environment.

This only updates the installation guidance. Script behavior is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance for the color-generation utility.
  * Added platform-specific recommendations for installing the required color package.
  * Improved the missing-package error message with alternative installation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->