### PR TITLE
fix: update cspell dictionary for uv migration

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -106,6 +106,7 @@
     "trivy",
     "ulises",
     "uname",
+    "uvx",
     "videogame",
     "waybar",
     "wayland",


### PR DESCRIPTION
## Summary

Fixes #235.

Updates the cspell dictionary to include `uvx`, preventing spellcheck failures for the new uv migration documentation. Reviewed `scripts`, `docs`, and `CONTRIBUTING.md` for any additional terms requiring dictionary updates.

## Changes

- Add `uvx` to `.cspell.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated spell-checking configuration to recognize the term “uvx.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->