### PR TITLE
docs: document pre-commit install via uv tool / uvx

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 # Pre-commit hooks for dotfiles quality assurance
 # See https://pre-commit.com for more information
-# Install with: pipx install pre-commit
+# Install with: uv tool install pre-commit
+# One-shot alternative: uvx pre-commit run --all-files
 # Setup: pre-commit install
 # Run manually: pre-commit run --all-files
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,21 +73,22 @@ Before you start, make sure you have:
 
 5. **Set up pre-commit hooks** (required for contributors):
 
-   We use [pre-commit](https://pre-commit.com/) to maintain code quality. Install it with [pipx](https://pipx.pypa.io/) (recommended):
+   We use [pre-commit](https://pre-commit.com/) to maintain code quality.
 
    ```bash
-   # Install pipx if not already installed
+   # Install uv if not already installed
    # Arch Linux:
-   sudo pacman -S python-pipx
+   sudo pacman -S uv
 
    # Ubuntu/Debian:
-   sudo apt install pipx && pipx ensurepath
+   curl -LsSf https://astral.sh/uv/install.sh | sh
 
    # macOS:
-   brew install pipx && pipx ensurepath
+   brew install uv
 
    # Install pre-commit
-   pipx install pre-commit
+   uv tool install pre-commit
+   # One-shot alternative: uvx pre-commit run --all-files
 
    # Set up git hooks in the repository
    pre-commit install

--- a/README.md
+++ b/README.md
@@ -217,10 +217,19 @@ git clone https://github.com/ulises-jeremias/dotfiles && cd dotfiles
 
 We use [pre-commit](https://pre-commit.com/) for code quality:
 
+Install `uv` first:
+
+- **Arch Linux:** `sudo pacman -S uv`
+- **Other platforms:**
+  - Installation script: `curl -LsSf https://astral.sh/uv/install.sh | sh`
+  - Homebrew: `brew install uv`
+
 ```bash
-pipx install pre-commit           # Install pre-commit
-cd ~/.dotfiles && pre-commit install   # Set up hooks
-pre-commit run --all-files        # Run all checks
+uv tool install pre-commit  # Install pre-commit
+# One-shot alternative: uvx pre-commit run --all-files
+
+pre-commit install          # Set up hooks
+pre-commit run --all-files  # Run all checks
 ```
 
 > 🤝 [Contributing guide →](CONTRIBUTING.md) | [Development standards →](docs/Development-Standards.md)


### PR DESCRIPTION
## Summary
Fixes https://github.com/ulises-jeremias/dotfiles/issues/230
Replaces contributor docs that mention `pipx install pre-commit` with `uv`/`uvx` instructions.

## Changes
- Changes top comment in `.pre-commit-config.yaml`
- Changes the [Setting up your development environment](https://github.com/ulises-jeremias/dotfiles/blob/main/CONTRIBUTING.md#setting-up-your-development-environment) section in `CONTRIBUTING.md`
- Changes the [Contributing](https://github.com/ulises-jeremias/dotfiles#-contributing) snippet in `README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor and setup instructions to use `uv` instead of `pipx` for installing and running `pre-commit`.
  * Added OS-specific `uv` installation guidance.
  * Updated the `pre-commit` installation guidance to use `uv tool install pre-commit` and included a one-shot `uvx pre-commit run --all-files` command.
  * Refreshed related setup instructions referenced in the project’s pre-commit configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->