### PR TITLE
docs: add Discord community badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@
   <a href="https://archlinux.org/">
     <img src="https://img.shields.io/badge/Arch%20Linux-1793D1?style=for-the-badge&amp;logo=arch-linux&amp;logoColor=white&amp;labelColor=191114" alt="Arch Linux"/>
   </a>
+  <a href="https://discord.gg/dwFTsR7fK2">
+    <img src="https://img.shields.io/discord/1527933660764831825?style=for-the-badge&amp;label=Discord&amp;logo=discord&amp;logoColor=white&amp;labelColor=191114" alt="Discord"/>
+  </a>
 </p>
 
 <div align="center">


### PR DESCRIPTION
## Summary
- Add Discord community badge linking to https://discord.gg/dwFTsR7fK2
- Place it with existing README badges (or under the title when none exist), matching each README's badge style

## Test plan
- [ ] Confirm badge renders on GitHub README preview
- [ ] Confirm click opens Discord invite
- [ ] Confirm member count shield loads (server ID 1527933660764831825)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Discord community link and badge to the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->