### PR TITLE
fix: restore pipx python-upgrade pacman hook

### DIFF
--- a/home/.chezmoiscripts/linux/run_onchange_before_install-001-pacman-hooks.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_before_install-001-pacman-hooks.sh.tmpl
@@ -4,10 +4,19 @@
 #!/usr/bin/env bash
 #
 # Install pacman hooks for system maintenance
+# - uv-tools-reinstall.hook: Reinstalls uv tool packages after Python updates
 # - pipx-reinstall.hook: Reinstalls pipx packages after Python updates
 #
-# This prevents uv tool packages from breaking when Arch updates Python
-# (e.g., 3.13 → 3.14) by automatically running `uv tool upgrade --all`
+# This prevents Python-managed tools from breaking when Arch updates Python
+# (e.g., 3.13 → 3.14) by automatically running `uv tool upgrade --all` and
+# `pipx reinstall-all` respectively.
+#
+# Why both hooks are kept: although these dotfiles standardize on `uv` for
+# Python tool management, the pipx hook is intentionally retained so users can
+# still install any other tool they want via pipx (e.g. apps not yet packaged
+# for uv, or tools the user prefers under pipx). The hook is a no-op if pipx
+# is not installed or has no injected packages, so keeping it costs nothing
+# while preserving flexibility.
 
 set -euo pipefail
 
@@ -43,16 +52,27 @@ else
   echo "✓ $HOOK_NAME installed"
 fi
 
-echo "✅ Pacman hooks configured successfully!"
-echo "📦 uv tools packages will now automatically reinstall after Python updates"
-
-OLD_HOOK_NAME="pipx-reinstall.hook"
-
-if [ -f "$HOOKS_TARGET_DIR/$OLD_HOOK_NAME" ]; then
-  echo "Removing obsolete $OLD_HOOK_NAME..."
-  {{ $sudo }}rm "$HOOKS_TARGET_DIR/$OLD_HOOK_NAME"
-  echo "$OLD_HOOK_NAME removed"
+# Install pipx-reinstall hook
+HOOK_NAME="pipx-reinstall.hook"
+if [ -f "$HOOKS_TARGET_DIR/$HOOK_NAME" ]; then
+  # Check if hook content is the same (idempotent)
+  if cmp -s "$HOOKS_SOURCE_DIR/$HOOK_NAME" "$HOOKS_TARGET_DIR/$HOOK_NAME" 2>/dev/null; then
+    echo "✓ $HOOK_NAME already installed and up to date"
+  else
+    echo "Updating $HOOK_NAME..."
+    {{ $sudo }}cp "$HOOKS_SOURCE_DIR/$HOOK_NAME" "$HOOKS_TARGET_DIR/$HOOK_NAME"
+    {{ $sudo }}chmod 644 "$HOOKS_TARGET_DIR/$HOOK_NAME"
+    echo "✓ $HOOK_NAME updated"
+  fi
+else
+  echo "Installing $HOOK_NAME..."
+  {{ $sudo }}cp "$HOOKS_SOURCE_DIR/$HOOK_NAME" "$HOOKS_TARGET_DIR/$HOOK_NAME"
+  {{ $sudo }}chmod 644 "$HOOKS_TARGET_DIR/$HOOK_NAME"
+  echo "✓ $HOOK_NAME installed"
 fi
+
+echo "✅ Pacman hooks configured successfully!"
+echo "📦 uv tools and pipx packages will now automatically reinstall after Python updates"
 
 {{      end -}}
 

--- a/home/dot_local/share/chezmoi-system/hooks/pipx-reinstall.hook
+++ b/home/dot_local/share/chezmoi-system/hooks/pipx-reinstall.hook
@@ -1,0 +1,10 @@
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Package
+Target = python
+
+[Action]
+Description = Reinstalling pipx packages for new Python version...
+When = PostTransaction
+Exec = /usr/bin/env bash -c 'for u in $(getent passwd | awk -F: '\''/\/bin\/(bash|zsh|fish)$/ && $3 >= 1000 {print $1}'\''); do h=$(getent passwd "$u" | cut -d: -f6); pipx_bin=$(command -v pipx 2>/dev/null); if [ -z "$pipx_bin" ]; then pipx_bin="$h/.local/bin/pipx"; fi; if [ -x "$pipx_bin" ] && [ -d "$h/.local/pipx/venvs" ]; then runuser -u "$u" -- env HOME="$h" PATH="$h/.local/bin:/usr/local/bin:/usr/bin:/bin" "$pipx_bin" reinstall-all --python /usr/bin/python3 2>&1 || true; fi; done || true'

--- a/home/dot_local/share/chezmoi-system/hooks/uv-tools-reinstall.hook
+++ b/home/dot_local/share/chezmoi-system/hooks/uv-tools-reinstall.hook
@@ -7,4 +7,4 @@ Target = python
 [Action]
 Description = Reinstalling uv packages for new Python version...
 When = PostTransaction
-Exec = /usr/bin/env bash -c 'if command -v uv &>/dev/null; then uv tool upgrade --all || true;  fi'
+Exec = /usr/bin/env bash -c 'for u in $(getent passwd | awk -F: '\''/\/bin\/(bash|zsh|fish)$/ && $3 >= 1000 {print $1}'\''); do h=$(getent passwd "$u" | cut -d: -f6); uv_bin=$(command -v uv 2>/dev/null); if [ -z "$uv_bin" ]; then uv_bin="$h/.local/bin/uv"; fi; if [ -x "$uv_bin" ] && [ -d "$h/.local/share/uv/tools" ]; then runuser -u "$u" -- env HOME="$h" PATH="$h/.local/bin:/usr/local/bin:/usr/bin:/bin" "$uv_bin" tool upgrade --all 2>&1 || true; fi; done || true'


### PR DESCRIPTION
## Summary

Follow-up to #245.

The merge of #245 accidentally left `main` without `pipx-reinstall.hook`, and the pacman hook installer still treated it as obsolete. That contradicted the final review decision: keep both hooks.

## Changes

- Restore `home/dot_local/share/chezmoi-system/hooks/pipx-reinstall.hook`.
- Keep `uv-tools-reinstall.hook`.
- Install both hooks from `run_onchange_before_install-001-pacman-hooks.sh.tmpl`.
- Remove the destructive cleanup block that deleted `pipx-reinstall.hook` from `/etc/pacman.d/hooks`.
- Keep the comment explaining why `pipx` is intentionally retained even though the dotfiles standardize on `uv`.
- Run both hooks in each owning user environment so they target user tool dirs, not root's empty pacman hook context.

## Validation

- [x] Confirmed `pipx-reinstall.hook` exists in the branch.
- [x] Confirmed installer references both hooks.
- [x] Confirmed there is no `OLD_HOOK_NAME` / destructive cleanup block.
- [x] `bash -n` parse check for both hook `Exec` lines.

Fixes the follow-up regression from #245.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic reinstallation of `pipx` packages after Python updates.
  * Improved `uv` tool upgrades for local users, including tools installed outside the current environment.
  * Added support for maintaining both `uv` and `pipx` package hooks during system updates.

* **Bug Fixes**
  * Improved reliability when locating user-installed `uv` and `pipx` tools.
  * Prevented package reinstallation failures from interrupting system updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->