### PR TITLE
fix(appearance): CodeRabbit follow-ups after #250

### DIFF
--- a/.chezmoiremove
+++ b/.chezmoiremove
@@ -3,5 +3,6 @@
 .local/state/dots/wallpaper/path.txt
 .cache/dots/smart-colors/wallpaper
 .local/share/dots/rices/*/apply.sh
+.local/share/dots/rices/*/config.sh
 .local/share/dots/rices/.current_rice
 .cache/dots/current_rice

--- a/docs/adrs/002-rice-system.md
+++ b/docs/adrs/002-rice-system.md
@@ -16,6 +16,7 @@ Desktop theming is a core HorneroConfig feature. The earlier shell-centric desig
 - **State**:
   - Rice id: `~/.local/state/dots/rice/current` only
   - Wallpaper: `~/.local/state/dots/wallpaper/path`
+  - Palette: `~/.cache/dots/smart-colors/scheme.json`
   - Scheme prefs: `~/.local/state/dots/scheme/state.json` synced via `dots-color-scheme sync-state`
 - **CLI**: `dots appearance …` (+ `dots rice …` alias), `dots appearance doctor`
 

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/AppearancePane.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/AppearancePane.qml
@@ -738,6 +738,10 @@ Item {
         target: Rice
 
         function onApplyFinished(ok: bool): void {
+            if (!ok) {
+                root.deferredMode = "";
+                return;
+            }
             if (root.deferredMode)
                 root._flushDeferredMode();
         }

--- a/home/dot_config/quickshell/services/Rice.qml
+++ b/home/dot_config/quickshell/services/Rice.qml
@@ -73,6 +73,9 @@ Singleton {
     }
 
     function _enqueue(job: var): void {
+        const tail = _queue.length ? _queue[_queue.length - 1] : null;
+        if (tail && tail.kind === job.kind && tail.riceId === job.riceId && tail.wallpaper === job.wallpaper)
+            return;
         _queue = _queue.concat([job]);
         _pump();
     }
@@ -359,8 +362,10 @@ find -L "$DOTS_BG_DIR" -maxdepth 1 \\( -type f -o -type l \\) \\( \
         command: ["dots-color-scheme", "sync-state"]
 
         onExited: (exitCode, exitStatus) => {
-            if (exitCode !== 0)
-                console.warn("Rice.qml: sync-state failed (exit", exitCode, ")");
+            if (exitCode !== 0) {
+                root._finishJob(false, `sync-state failed (exit ${exitCode})`);
+                return;
+            }
             touchSchemeProc.running = true;
             if (root._persistRiceOnSuccess && root._pendingRiceId) {
                 if (configLoader.pendingConfig && Object.keys(configLoader.pendingConfig).length)

--- a/home/dot_local/bin/executable_dots-appearance
+++ b/home/dot_local/bin/executable_dots-appearance
@@ -19,316 +19,329 @@ cmd="${1:-}"
 shift 2>/dev/null || true
 
 json_escape() {
-	python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1"
+  python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1"
 }
 
 cmd_list() {
-	local script="${HOME}/.local/lib/dots/list-rices.py"
-	if [[ -f $script ]]; then
-		python3 "$script" "$RICES_DIR"
-	else
-		echo "[]"
-	fi
+  local script="${HOME}/.local/lib/dots/list-rices.py"
+  if [[ -f $script ]]; then
+    python3 "$script" "$RICES_DIR"
+  else
+    echo "[]"
+  fi
 }
 
 _ipc_rice_current() {
-	local id=""
-	id="$(quickshell ipc call rice current 2>/dev/null || true)"
-	id="${id//$'\r'/}"
-	id="${id//$'\n'/}"
-	# Ignore QS error payloads when the target is unavailable (stale process / reload).
-	[[ -n $id ]] || return 1
-	[[ $id == *" "* ]] && return 1
-	[[ -d "$RICES_DIR/$id" ]] || return 1
-	printf '%s\n' "$id"
+  local id=""
+  id="$(quickshell ipc call rice current 2>/dev/null || true)"
+  id="${id//$'\r'/}"
+  id="${id//$'\n'/}"
+  # Ignore QS error payloads when the target is unavailable (stale process / reload).
+  [[ -n $id ]] || return 1
+  [[ $id == *" "* ]] && return 1
+  [[ -d "$RICES_DIR/$id" ]] || return 1
+  printf '%s\n' "$id"
 }
 
 cmd_current() {
-	local id=""
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		id="$(_ipc_rice_current || true)"
-	fi
-	if [[ -z ${id:-} ]] && declare -f dots_read_current_rice >/dev/null 2>&1; then
-		id="$(dots_read_current_rice)"
-	fi
-	if [[ ${1:-} == "--json" ]]; then
-		printf '{"id":%s}\n' "$(json_escape "${id:-}")"
-	else
-		printf '%s\n' "${id:-}"
-	fi
+  local id=""
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    id="$(_ipc_rice_current || true)"
+  fi
+  if [[ -z ${id:-} ]] && declare -f dots_read_current_rice >/dev/null 2>&1; then
+    id="$(dots_read_current_rice)"
+  fi
+  if [[ ${1:-} == "--json" ]]; then
+    printf '{"id":%s}\n' "$(json_escape "${id:-}")"
+  else
+    printf '%s\n' "${id:-}"
+  fi
 }
 
 _shell_apply() {
-	local id="$1"
-	local wallpaper="${2:-}"
-	# shellcheck source=/dev/null
-	source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
-	# shellcheck source=/dev/null
-	source "$HOME/.local/lib/dots/apply-appearance.sh"
-	dots_apply_appearance "$id" "$wallpaper"
+  local id="$1"
+  local wallpaper="${2:-}"
+  # shellcheck source=/dev/null
+  source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
+  # shellcheck source=/dev/null
+  source "$HOME/.local/lib/dots/apply-appearance.sh"
+  dots_apply_appearance "$id" "$wallpaper"
 }
 
 cmd_apply() {
-	local id="${1:-}"
-	local wallpaper=""
-	shift 2>/dev/null || true
-	while [[ $# -gt 0 ]]; do
-		case "${1:-}" in
-		--wallpaper)
-			wallpaper="${2:-}"
-			shift 2
-			;;
-		*)
-			echo "dots-appearance apply: unknown argument: $1" >&2
-			exit 1
-			;;
-		esac
-	done
+  local id="${1:-}"
+  local wallpaper=""
+  shift 2>/dev/null || true
+  while [[ $# -gt 0 ]]; do
+    case "${1:-}" in
+      --wallpaper)
+        [[ -n ${2:-} ]] || {
+          echo "dots-appearance apply: --wallpaper requires a path" >&2
+          exit 1
+        }
+        wallpaper="$2"
+        shift 2
+        ;;
+      *)
+        echo "dots-appearance apply: unknown argument: $1" >&2
+        exit 1
+        ;;
+    esac
+  done
 
-	[[ -n $id ]] || {
-		echo "Usage: dots-appearance apply <id> [--wallpaper <path>]" >&2
-		exit 1
-	}
+  [[ -n $id ]] || {
+    echo "Usage: dots-appearance apply <id> [--wallpaper <path>]" >&2
+    exit 1
+  }
 
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		local ipc_out=""
-		if ipc_out="$(quickshell ipc call rice apply "$id" "${wallpaper:-}" 2>&1)"; then
-			case "$ipc_out" in
-			"Target not found."* | *"Target not found"*)
-				echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
-				;;
-			*)
-				# Wait for the queued QS job; persist happens inside Rice after success.
-				local _i busy last_error
-				for _i in $(seq 1 120); do
-					busy="$(quickshell ipc call rice isBusy 2>/dev/null || echo 0)"
-					[[ $busy == "1" ]] || break
-					sleep 0.5
-				done
-				last_error="$(quickshell ipc call rice lastError 2>/dev/null || true)"
-				last_error="${last_error//$'\r'/}"
-				last_error="${last_error//$'\n'/}"
-				if [[ -n $last_error ]]; then
-					echo "Error: appearance apply failed: $last_error" >&2
-					exit 1
-				fi
-				exit 0
-				;;
-			esac
-		else
-			echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
-		fi
-	fi
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    local ipc_out=""
+    if ipc_out="$(quickshell ipc call rice apply "$id" "${wallpaper:-}" 2>&1)"; then
+      case "$ipc_out" in
+        "Target not found."* | *"Target not found"*)
+          echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
+          ;;
+        *)
+          # Wait for the queued QS job; persist happens inside Rice after success.
+          local _i busy="" last_error
+          for _i in $(seq 1 120); do
+            if ! busy="$(quickshell ipc call rice isBusy 2>/dev/null)"; then
+              echo "Error: failed to poll rice isBusy via Quickshell IPC" >&2
+              exit 1
+            fi
+            busy="${busy//$'\r'/}"
+            busy="${busy//$'\n'/}"
+            [[ $busy == "1" ]] || break
+            sleep 0.5
+          done
+          if [[ $busy == "1" ]]; then
+            echo "Error: appearance apply timed out waiting for Quickshell" >&2
+            exit 1
+          fi
+          last_error="$(quickshell ipc call rice lastError 2>/dev/null || true)"
+          last_error="${last_error//$'\r'/}"
+          last_error="${last_error//$'\n'/}"
+          if [[ -n $last_error ]]; then
+            echo "Error: appearance apply failed: $last_error" >&2
+            exit 1
+          fi
+          exit 0
+          ;;
+      esac
+    else
+      echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
+    fi
+  fi
 
-	_shell_apply "$id" "$wallpaper"
+  _shell_apply "$id" "$wallpaper"
 }
 
 cmd_preview() {
-	local id="${1:-}"
-	[[ -n $id ]] || {
-		echo "Usage: dots-appearance preview <id>" >&2
-		exit 1
-	}
-	local config_path="${RICES_DIR}/${id}/config.json"
-	[[ -f $config_path ]] || {
-		echo "Appearance not found: $id" >&2
-		exit 1
-	}
-	cat "$config_path"
+  local id="${1:-}"
+  [[ -n $id ]] || {
+    echo "Usage: dots-appearance preview <id>" >&2
+    exit 1
+  }
+  local config_path="${RICES_DIR}/${id}/config.json"
+  [[ -f $config_path ]] || {
+    echo "Appearance not found: $id" >&2
+    exit 1
+  }
+  cat "$config_path"
 }
 
 cmd_set_wallpaper() {
-	local wallpaper="${1:-}"
-	[[ -n $wallpaper ]] || {
-		echo "Usage: dots-appearance set-wallpaper <path>" >&2
-		exit 1
-	}
-	dots-wallpaper-set "$wallpaper"
+  local wallpaper="${1:-}"
+  [[ -n $wallpaper ]] || {
+    echo "Usage: dots-appearance set-wallpaper <path>" >&2
+    exit 1
+  }
+  dots-wallpaper-set "$wallpaper"
 }
 
 cmd_set_variant() {
-	dots-color-scheme variant "${1:-}"
+  dots-color-scheme variant "${1:-}"
 }
 
 cmd_set_mode() {
-	dots-color-scheme mode "${1:-}"
+  dots-color-scheme mode "${1:-}"
 }
 
 cmd_sync() {
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		quickshell ipc call rice reload || true
-	fi
-	dots-color-scheme sync-state >/dev/null 2>&1 || true
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    quickshell ipc call rice reload || true
+  fi
+  dots-color-scheme sync-state >/dev/null 2>&1 || true
 }
 
 cmd_doctor() {
-	local ok=0
-	local qs_rice="" canon=""
-	local scheme_flavour="" state_flavour="" scheme_mode="" state_mode=""
-	local pointer="" resolved="" wal_target=""
+  local ok=0
+  local qs_rice="" canon=""
+  local scheme_flavour="" state_flavour="" scheme_mode="" state_mode=""
+  local pointer="" resolved="" wal_target=""
 
-	# Drop leftover legacy pointers if helpers are available.
-	if declare -f dots_purge_legacy_rice_pointers >/dev/null 2>&1; then
-		dots_purge_legacy_rice_pointers
-	else
-		rm -f "$HOME/.local/share/dots/rices/.current_rice" \
-			"$HOME/.cache/dots/current_rice" 2>/dev/null || true
-	fi
+  # Drop leftover legacy pointers if helpers are available.
+  if declare -f dots_purge_legacy_rice_pointers >/dev/null 2>&1; then
+    dots_purge_legacy_rice_pointers
+  else
+    rm -f "$HOME/.local/share/dots/rices/.current_rice" \
+      "$HOME/.cache/dots/current_rice" 2>/dev/null || true
+  fi
 
-	canon="${DOTS_RICE_CANONICAL_FILE:-$HOME/.local/state/dots/rice/current}"
-	[[ -f $canon ]] && qs_rice="$(head -n 1 "$canon" | tr -d '\r')"
+  canon="${DOTS_RICE_CANONICAL_FILE:-$HOME/.local/state/dots/rice/current}"
+  [[ -f $canon ]] && qs_rice="$(head -n 1 "$canon" | tr -d '\r')"
 
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		local ipc_rice
-		ipc_rice="$(_ipc_rice_current || true)"
-		[[ -n $ipc_rice ]] && qs_rice="$ipc_rice"
-	fi
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    local ipc_rice
+    ipc_rice="$(_ipc_rice_current || true)"
+    [[ -n $ipc_rice ]] && qs_rice="$ipc_rice"
+  fi
 
-	local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
-	local state_file="${HOME}/.local/state/dots/scheme/state.json"
-	if [[ -f $scheme_file ]]; then
-		scheme_flavour="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('flavour',''))" 2>/dev/null || true)"
-		scheme_mode="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('mode',''))" 2>/dev/null || true)"
-	fi
-	if [[ -f $state_file ]]; then
-		state_flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
-		state_mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
-	fi
+  local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
+  local state_file="${HOME}/.local/state/dots/scheme/state.json"
+  if [[ -f $scheme_file ]]; then
+    scheme_flavour="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('flavour',''))" 2>/dev/null || true)"
+    scheme_mode="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('mode',''))" 2>/dev/null || true)"
+  fi
+  if [[ -f $state_file ]]; then
+    state_flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
+    state_mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
+  fi
 
-	pointer="${DOTS_WALLPAPER_POINTER_FILE:-$HOME/.local/state/dots/wallpaper/path}"
-	local pointer_val=""
-	[[ -f $pointer ]] && pointer_val="$(head -n 1 "$pointer" | tr -d '\r')"
-	if command -v dots-wallpaper-current >/dev/null 2>&1; then
-		resolved="$(dots-wallpaper-current 2>/dev/null || true)"
-	fi
-	wal_target="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
+  pointer="${DOTS_WALLPAPER_POINTER_FILE:-$HOME/.local/state/dots/wallpaper/path}"
+  local pointer_val=""
+  [[ -f $pointer ]] && pointer_val="$(head -n 1 "$pointer" | tr -d '\r')"
+  if command -v dots-wallpaper-current >/dev/null 2>&1; then
+    resolved="$(dots-wallpaper-current 2>/dev/null || true)"
+  fi
+  wal_target="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
 
-	echo "=== dots-appearance doctor ==="
-	echo "rice.current   : ${qs_rice:-"(missing)"}"
-	echo "scheme.flavour : ${scheme_flavour:-"(missing)"}"
-	echo "state.flavour  : ${state_flavour:-"(missing)"}"
-	echo "scheme.mode    : ${scheme_mode:-"(missing)"}"
-	echo "state.mode     : ${state_mode:-"(missing)"}"
-	local hyprlock_conf="${HOME}/.cache/dots/smart-colors/colors-hyprlock.conf"
-	local hyprlock_bytes=0
-	[[ -f $hyprlock_conf ]] && hyprlock_bytes="$(wc -c <"$hyprlock_conf" | tr -d ' ')"
-	local gtk_theme_ini="" gtk_prefer_dark="" gtk_color_scheme=""
-	if [[ -f ${HOME}/.config/gtk-3.0/settings.ini ]]; then
-		gtk_theme_ini="$(grep -E '^gtk-theme-name=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-		gtk_prefer_dark="$(grep -E '^gtk-application-prefer-dark-theme=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-	fi
-	if command -v gsettings >/dev/null 2>&1; then
-		gtk_color_scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'\"" || true)"
-	fi
+  echo "=== dots-appearance doctor ==="
+  echo "rice.current   : ${qs_rice:-"(missing)"}"
+  echo "scheme.flavour : ${scheme_flavour:-"(missing)"}"
+  echo "state.flavour  : ${state_flavour:-"(missing)"}"
+  echo "scheme.mode    : ${scheme_mode:-"(missing)"}"
+  echo "state.mode     : ${state_mode:-"(missing)"}"
+  local hyprlock_conf="${HOME}/.cache/dots/smart-colors/colors-hyprlock.conf"
+  local hyprlock_bytes=0
+  [[ -f $hyprlock_conf ]] && hyprlock_bytes="$(wc -c <"$hyprlock_conf" | tr -d ' ')"
+  local gtk_theme_ini="" gtk_prefer_dark="" gtk_color_scheme=""
+  if [[ -f ${HOME}/.config/gtk-3.0/settings.ini ]]; then
+    gtk_theme_ini="$(grep -E '^gtk-theme-name=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+    gtk_prefer_dark="$(grep -E '^gtk-application-prefer-dark-theme=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+  fi
+  if command -v gsettings >/dev/null 2>&1; then
+    gtk_color_scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'\"" || true)"
+  fi
 
-	echo "wallpaper.ptr  : ${pointer_val:-"(missing)"}"
-	echo "wallpaper.res  : ${resolved:-"(missing)"}"
-	echo "wal.target     : ${wal_target:-"(missing)"}"
-	echo "hyprlock.conf  : ${hyprlock_bytes} bytes"
-	echo "gtk.theme.ini  : ${gtk_theme_ini:-"(missing)"}"
-	echo "gtk.preferDark : ${gtk_prefer_dark:-"(missing)"}"
-	echo "gtk.colorScheme: ${gtk_color_scheme:-"(missing)"}"
+  echo "wallpaper.ptr  : ${pointer_val:-"(missing)"}"
+  echo "wallpaper.res  : ${resolved:-"(missing)"}"
+  echo "wal.target     : ${wal_target:-"(missing)"}"
+  echo "hyprlock.conf  : ${hyprlock_bytes} bytes"
+  echo "gtk.theme.ini  : ${gtk_theme_ini:-"(missing)"}"
+  echo "gtk.preferDark : ${gtk_prefer_dark:-"(missing)"}"
+  echo "gtk.colorScheme: ${gtk_color_scheme:-"(missing)"}"
 
-	if [[ -z $qs_rice ]]; then
-		echo "FAIL: rice current pointer missing" >&2
-		ok=1
-	elif [[ ! -f "$HOME/.local/share/dots/rices/$qs_rice/config.json" ]]; then
-		echo "FAIL: rice config.json missing for $qs_rice" >&2
-		ok=1
-	fi
-	if [[ -e $HOME/.local/share/dots/rices/.current_rice || -e $HOME/.cache/dots/current_rice ]]; then
-		echo "FAIL: legacy rice pointer still present" >&2
-		ok=1
-	fi
-	if [[ -n $scheme_flavour && -n $state_flavour && $scheme_flavour != "$state_flavour" ]]; then
-		echo "FAIL: scheme flavour != state flavour ($scheme_flavour vs $state_flavour)" >&2
-		ok=1
-	fi
-	if [[ -n $scheme_mode && -n $state_mode && $scheme_mode != "$state_mode" ]]; then
-		echo "FAIL: scheme mode != state mode ($scheme_mode vs $state_mode)" >&2
-		ok=1
-	fi
-	if [[ -n $pointer_val && ! -f $pointer_val ]]; then
-		echo "FAIL: wallpaper pointer does not exist: $pointer_val" >&2
-		ok=1
-	fi
-	if [[ -n $pointer_val && -n $resolved && $pointer_val != "$resolved" ]]; then
-		local ptr_real res_real
-		ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
-		res_real="$(readlink -f "$resolved" 2>/dev/null || true)"
-		if [[ -n $ptr_real && -n $res_real && $ptr_real != "$res_real" ]]; then
-			echo "FAIL: pointer != dots-wallpaper-current ($pointer_val vs $resolved)" >&2
-			ok=1
-		fi
-	fi
-	if [[ -n $pointer_val && -f $pointer_val ]]; then
-		local ptr_real wal_real
-		ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
-		wal_real="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
-		if [[ -z $wal_real ]]; then
-			echo "FAIL: ~/.cache/wal/wal missing or broken" >&2
-			ok=1
-		elif [[ -n $ptr_real && $ptr_real != "$wal_real" ]]; then
-			echo "FAIL: wal target != wallpaper pointer ($wal_real vs $ptr_real)" >&2
-			ok=1
-		fi
-	fi
-	if [[ ! -f $hyprlock_conf || ${hyprlock_bytes:-0} -eq 0 ]]; then
-		echo "FAIL: colors-hyprlock.conf missing or empty" >&2
-		ok=1
-	fi
-	if [[ -f ${HOME}/.local/state/dots/wallpaper/path.txt ]]; then
-		echo "FAIL: orphan wallpaper/path.txt present (use wallpaper/path)" >&2
-		ok=1
-	fi
-	if [[ -f ${HOME}/.cache/dots/smart-colors/wallpaper ]]; then
-		echo "FAIL: orphan smart-colors/wallpaper cache present" >&2
-		ok=1
-	fi
-	if [[ -n $state_mode && -n $gtk_prefer_dark ]]; then
-		if [[ $state_mode == "dark" && $gtk_prefer_dark == "false" ]]; then
-			echo "FAIL: GTK prefer-dark=false while live mode is dark" >&2
-			ok=1
-		elif [[ $state_mode == "light" && $gtk_prefer_dark == "true" ]]; then
-			echo "FAIL: GTK prefer-dark=true while live mode is light" >&2
-			ok=1
-		fi
-	fi
-	if [[ -n $state_mode && -n $gtk_color_scheme ]]; then
-		if [[ $state_mode == "dark" && $gtk_color_scheme != "prefer-dark" ]]; then
-			echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is dark" >&2
-			ok=1
-		elif [[ $state_mode == "light" && $gtk_color_scheme != "prefer-light" ]]; then
-			echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is light" >&2
-			ok=1
-		fi
-	fi
-	if [[ -n $wal_target && -f $wal_target ]]; then
-		if ! file -b --mime-type "$wal_target" 2>/dev/null | grep -q '^image/'; then
-			echo "WARN: wal target is not an image: $wal_target" >&2
-		fi
-	fi
+  if [[ -z $qs_rice ]]; then
+    echo "FAIL: rice current pointer missing" >&2
+    ok=1
+  elif [[ ! -f "$HOME/.local/share/dots/rices/$qs_rice/config.json" ]]; then
+    echo "FAIL: rice config.json missing for $qs_rice" >&2
+    ok=1
+  fi
+  if [[ -e $HOME/.local/share/dots/rices/.current_rice || -e $HOME/.cache/dots/current_rice ]]; then
+    echo "FAIL: legacy rice pointer still present" >&2
+    ok=1
+  fi
+  if [[ -n $scheme_flavour && -n $state_flavour && $scheme_flavour != "$state_flavour" ]]; then
+    echo "FAIL: scheme flavour != state flavour ($scheme_flavour vs $state_flavour)" >&2
+    ok=1
+  fi
+  if [[ -n $scheme_mode && -n $state_mode && $scheme_mode != "$state_mode" ]]; then
+    echo "FAIL: scheme mode != state mode ($scheme_mode vs $state_mode)" >&2
+    ok=1
+  fi
+  if [[ -n $pointer_val && ! -f $pointer_val ]]; then
+    echo "FAIL: wallpaper pointer does not exist: $pointer_val" >&2
+    ok=1
+  fi
+  if [[ -n $pointer_val && -n $resolved && $pointer_val != "$resolved" ]]; then
+    local ptr_real res_real
+    ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
+    res_real="$(readlink -f "$resolved" 2>/dev/null || true)"
+    if [[ -n $ptr_real && -n $res_real && $ptr_real != "$res_real" ]]; then
+      echo "FAIL: pointer != dots-wallpaper-current ($pointer_val vs $resolved)" >&2
+      ok=1
+    fi
+  fi
+  if [[ -n $pointer_val && -f $pointer_val ]]; then
+    local ptr_real wal_real
+    ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
+    wal_real="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
+    if [[ -z $wal_real ]]; then
+      echo "FAIL: ~/.cache/wal/wal missing or broken" >&2
+      ok=1
+    elif [[ -n $ptr_real && $ptr_real != "$wal_real" ]]; then
+      echo "FAIL: wal target != wallpaper pointer ($wal_real vs $ptr_real)" >&2
+      ok=1
+    fi
+  fi
+  if [[ ! -f $hyprlock_conf || ${hyprlock_bytes:-0} -eq 0 ]]; then
+    echo "FAIL: colors-hyprlock.conf missing or empty" >&2
+    ok=1
+  fi
+  if [[ -f ${HOME}/.local/state/dots/wallpaper/path.txt ]]; then
+    echo "FAIL: orphan wallpaper/path.txt present (use wallpaper/path)" >&2
+    ok=1
+  fi
+  if [[ -f ${HOME}/.cache/dots/smart-colors/wallpaper ]]; then
+    echo "FAIL: orphan smart-colors/wallpaper cache present" >&2
+    ok=1
+  fi
+  if [[ -n $state_mode && -n $gtk_prefer_dark ]]; then
+    if [[ $state_mode == "dark" && $gtk_prefer_dark == "false" ]]; then
+      echo "FAIL: GTK prefer-dark=false while live mode is dark" >&2
+      ok=1
+    elif [[ $state_mode == "light" && $gtk_prefer_dark == "true" ]]; then
+      echo "FAIL: GTK prefer-dark=true while live mode is light" >&2
+      ok=1
+    fi
+  fi
+  if [[ -n $state_mode && -n $gtk_color_scheme ]]; then
+    if [[ $state_mode == "dark" && $gtk_color_scheme != "prefer-dark" ]]; then
+      echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is dark" >&2
+      ok=1
+    elif [[ $state_mode == "light" && $gtk_color_scheme != "prefer-light" ]]; then
+      echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is light" >&2
+      ok=1
+    fi
+  fi
+  if [[ -n $wal_target && -f $wal_target ]]; then
+    if ! file -b --mime-type "$wal_target" 2>/dev/null | grep -q '^image/'; then
+      echo "WARN: wal target is not an image: $wal_target" >&2
+    fi
+  fi
 
-	if [[ $ok -eq 0 ]]; then
-		echo "OK: appearance state is consistent"
-	else
-		echo "DONE: inconsistencies detected (exit $ok)"
-	fi
-	return "$ok"
+  if [[ $ok -eq 0 ]]; then
+    echo "OK: appearance state is consistent"
+  else
+    echo "DONE: inconsistencies detected (exit $ok)"
+  fi
+  return "$ok"
 }
 
 case "${cmd:-}" in
-list) cmd_list ;;
-current) cmd_current "${1:-}" ;;
-apply) cmd_apply "$@" ;;
-preview) cmd_preview "${1:-}" ;;
-set-variant) cmd_set_variant "${1:-}" ;;
-set-mode) cmd_set_mode "${1:-}" ;;
-set-wallpaper) cmd_set_wallpaper "${1:-}" ;;
-sync) cmd_sync ;;
-doctor) cmd_doctor ;;
-*)
-	cat <<'EOF' >&2
+  list) cmd_list ;;
+  current) cmd_current "${1:-}" ;;
+  apply) cmd_apply "$@" ;;
+  preview) cmd_preview "${1:-}" ;;
+  set-variant) cmd_set_variant "${1:-}" ;;
+  set-mode) cmd_set_mode "${1:-}" ;;
+  set-wallpaper) cmd_set_wallpaper "${1:-}" ;;
+  sync) cmd_sync ;;
+  doctor) cmd_doctor ;;
+  *)
+    cat <<'EOF' >&2
 Usage: dots-appearance <command> [args]
 
 Commands:
@@ -342,6 +355,6 @@ Commands:
   sync
   doctor
 EOF
-	exit 1
-	;;
+    exit 1
+    ;;
 esac

--- a/home/dot_local/bin/executable_dots-appearance
+++ b/home/dot_local/bin/executable_dots-appearance
@@ -19,329 +19,329 @@ cmd="${1:-}"
 shift 2>/dev/null || true
 
 json_escape() {
-  python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1"
+	python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1"
 }
 
 cmd_list() {
-  local script="${HOME}/.local/lib/dots/list-rices.py"
-  if [[ -f $script ]]; then
-    python3 "$script" "$RICES_DIR"
-  else
-    echo "[]"
-  fi
+	local script="${HOME}/.local/lib/dots/list-rices.py"
+	if [[ -f $script ]]; then
+		python3 "$script" "$RICES_DIR"
+	else
+		echo "[]"
+	fi
 }
 
 _ipc_rice_current() {
-  local id=""
-  id="$(quickshell ipc call rice current 2>/dev/null || true)"
-  id="${id//$'\r'/}"
-  id="${id//$'\n'/}"
-  # Ignore QS error payloads when the target is unavailable (stale process / reload).
-  [[ -n $id ]] || return 1
-  [[ $id == *" "* ]] && return 1
-  [[ -d "$RICES_DIR/$id" ]] || return 1
-  printf '%s\n' "$id"
+	local id=""
+	id="$(quickshell ipc call rice current 2>/dev/null || true)"
+	id="${id//$'\r'/}"
+	id="${id//$'\n'/}"
+	# Ignore QS error payloads when the target is unavailable (stale process / reload).
+	[[ -n $id ]] || return 1
+	[[ $id == *" "* ]] && return 1
+	[[ -d "$RICES_DIR/$id" ]] || return 1
+	printf '%s\n' "$id"
 }
 
 cmd_current() {
-  local id=""
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    id="$(_ipc_rice_current || true)"
-  fi
-  if [[ -z ${id:-} ]] && declare -f dots_read_current_rice >/dev/null 2>&1; then
-    id="$(dots_read_current_rice)"
-  fi
-  if [[ ${1:-} == "--json" ]]; then
-    printf '{"id":%s}\n' "$(json_escape "${id:-}")"
-  else
-    printf '%s\n' "${id:-}"
-  fi
+	local id=""
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		id="$(_ipc_rice_current || true)"
+	fi
+	if [[ -z ${id:-} ]] && declare -f dots_read_current_rice >/dev/null 2>&1; then
+		id="$(dots_read_current_rice)"
+	fi
+	if [[ ${1:-} == "--json" ]]; then
+		printf '{"id":%s}\n' "$(json_escape "${id:-}")"
+	else
+		printf '%s\n' "${id:-}"
+	fi
 }
 
 _shell_apply() {
-  local id="$1"
-  local wallpaper="${2:-}"
-  # shellcheck source=/dev/null
-  source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
-  # shellcheck source=/dev/null
-  source "$HOME/.local/lib/dots/apply-appearance.sh"
-  dots_apply_appearance "$id" "$wallpaper"
+	local id="$1"
+	local wallpaper="${2:-}"
+	# shellcheck source=/dev/null
+	source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
+	# shellcheck source=/dev/null
+	source "$HOME/.local/lib/dots/apply-appearance.sh"
+	dots_apply_appearance "$id" "$wallpaper"
 }
 
 cmd_apply() {
-  local id="${1:-}"
-  local wallpaper=""
-  shift 2>/dev/null || true
-  while [[ $# -gt 0 ]]; do
-    case "${1:-}" in
-      --wallpaper)
-        [[ -n ${2:-} ]] || {
-          echo "dots-appearance apply: --wallpaper requires a path" >&2
-          exit 1
-        }
-        wallpaper="$2"
-        shift 2
-        ;;
-      *)
-        echo "dots-appearance apply: unknown argument: $1" >&2
-        exit 1
-        ;;
-    esac
-  done
+	local id="${1:-}"
+	local wallpaper=""
+	shift 2>/dev/null || true
+	while [[ $# -gt 0 ]]; do
+		case "${1:-}" in
+		--wallpaper)
+			[[ -n ${2:-} ]] || {
+				echo "dots-appearance apply: --wallpaper requires a path" >&2
+				exit 1
+			}
+			wallpaper="$2"
+			shift 2
+			;;
+		*)
+			echo "dots-appearance apply: unknown argument: $1" >&2
+			exit 1
+			;;
+		esac
+	done
 
-  [[ -n $id ]] || {
-    echo "Usage: dots-appearance apply <id> [--wallpaper <path>]" >&2
-    exit 1
-  }
+	[[ -n $id ]] || {
+		echo "Usage: dots-appearance apply <id> [--wallpaper <path>]" >&2
+		exit 1
+	}
 
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    local ipc_out=""
-    if ipc_out="$(quickshell ipc call rice apply "$id" "${wallpaper:-}" 2>&1)"; then
-      case "$ipc_out" in
-        "Target not found."* | *"Target not found"*)
-          echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
-          ;;
-        *)
-          # Wait for the queued QS job; persist happens inside Rice after success.
-          local _i busy="" last_error
-          for _i in $(seq 1 120); do
-            if ! busy="$(quickshell ipc call rice isBusy 2>/dev/null)"; then
-              echo "Error: failed to poll rice isBusy via Quickshell IPC" >&2
-              exit 1
-            fi
-            busy="${busy//$'\r'/}"
-            busy="${busy//$'\n'/}"
-            [[ $busy == "1" ]] || break
-            sleep 0.5
-          done
-          if [[ $busy == "1" ]]; then
-            echo "Error: appearance apply timed out waiting for Quickshell" >&2
-            exit 1
-          fi
-          last_error="$(quickshell ipc call rice lastError 2>/dev/null || true)"
-          last_error="${last_error//$'\r'/}"
-          last_error="${last_error//$'\n'/}"
-          if [[ -n $last_error ]]; then
-            echo "Error: appearance apply failed: $last_error" >&2
-            exit 1
-          fi
-          exit 0
-          ;;
-      esac
-    else
-      echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
-    fi
-  fi
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		local ipc_out=""
+		if ipc_out="$(quickshell ipc call rice apply "$id" "${wallpaper:-}" 2>&1)"; then
+			case "$ipc_out" in
+			"Target not found."* | *"Target not found"*)
+				echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
+				;;
+			*)
+				# Wait for the queued QS job; persist happens inside Rice after success.
+				local _i busy="" last_error
+				for _i in $(seq 1 120); do
+					if ! busy="$(quickshell ipc call rice isBusy 2>/dev/null)"; then
+						echo "Error: failed to poll rice isBusy via Quickshell IPC" >&2
+						exit 1
+					fi
+					busy="${busy//$'\r'/}"
+					busy="${busy//$'\n'/}"
+					[[ $busy == "1" ]] || break
+					sleep 0.5
+				done
+				if [[ $busy == "1" ]]; then
+					echo "Error: appearance apply timed out waiting for Quickshell" >&2
+					exit 1
+				fi
+				last_error="$(quickshell ipc call rice lastError 2>/dev/null || true)"
+				last_error="${last_error//$'\r'/}"
+				last_error="${last_error//$'\n'/}"
+				if [[ -n $last_error ]]; then
+					echo "Error: appearance apply failed: $last_error" >&2
+					exit 1
+				fi
+				exit 0
+				;;
+			esac
+		else
+			echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
+		fi
+	fi
 
-  _shell_apply "$id" "$wallpaper"
+	_shell_apply "$id" "$wallpaper"
 }
 
 cmd_preview() {
-  local id="${1:-}"
-  [[ -n $id ]] || {
-    echo "Usage: dots-appearance preview <id>" >&2
-    exit 1
-  }
-  local config_path="${RICES_DIR}/${id}/config.json"
-  [[ -f $config_path ]] || {
-    echo "Appearance not found: $id" >&2
-    exit 1
-  }
-  cat "$config_path"
+	local id="${1:-}"
+	[[ -n $id ]] || {
+		echo "Usage: dots-appearance preview <id>" >&2
+		exit 1
+	}
+	local config_path="${RICES_DIR}/${id}/config.json"
+	[[ -f $config_path ]] || {
+		echo "Appearance not found: $id" >&2
+		exit 1
+	}
+	cat "$config_path"
 }
 
 cmd_set_wallpaper() {
-  local wallpaper="${1:-}"
-  [[ -n $wallpaper ]] || {
-    echo "Usage: dots-appearance set-wallpaper <path>" >&2
-    exit 1
-  }
-  dots-wallpaper-set "$wallpaper"
+	local wallpaper="${1:-}"
+	[[ -n $wallpaper ]] || {
+		echo "Usage: dots-appearance set-wallpaper <path>" >&2
+		exit 1
+	}
+	dots-wallpaper-set "$wallpaper"
 }
 
 cmd_set_variant() {
-  dots-color-scheme variant "${1:-}"
+	dots-color-scheme variant "${1:-}"
 }
 
 cmd_set_mode() {
-  dots-color-scheme mode "${1:-}"
+	dots-color-scheme mode "${1:-}"
 }
 
 cmd_sync() {
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    quickshell ipc call rice reload || true
-  fi
-  dots-color-scheme sync-state >/dev/null 2>&1 || true
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		quickshell ipc call rice reload || true
+	fi
+	dots-color-scheme sync-state >/dev/null 2>&1 || true
 }
 
 cmd_doctor() {
-  local ok=0
-  local qs_rice="" canon=""
-  local scheme_flavour="" state_flavour="" scheme_mode="" state_mode=""
-  local pointer="" resolved="" wal_target=""
+	local ok=0
+	local qs_rice="" canon=""
+	local scheme_flavour="" state_flavour="" scheme_mode="" state_mode=""
+	local pointer="" resolved="" wal_target=""
 
-  # Drop leftover legacy pointers if helpers are available.
-  if declare -f dots_purge_legacy_rice_pointers >/dev/null 2>&1; then
-    dots_purge_legacy_rice_pointers
-  else
-    rm -f "$HOME/.local/share/dots/rices/.current_rice" \
-      "$HOME/.cache/dots/current_rice" 2>/dev/null || true
-  fi
+	# Drop leftover legacy pointers if helpers are available.
+	if declare -f dots_purge_legacy_rice_pointers >/dev/null 2>&1; then
+		dots_purge_legacy_rice_pointers
+	else
+		rm -f "$HOME/.local/share/dots/rices/.current_rice" \
+			"$HOME/.cache/dots/current_rice" 2>/dev/null || true
+	fi
 
-  canon="${DOTS_RICE_CANONICAL_FILE:-$HOME/.local/state/dots/rice/current}"
-  [[ -f $canon ]] && qs_rice="$(head -n 1 "$canon" | tr -d '\r')"
+	canon="${DOTS_RICE_CANONICAL_FILE:-$HOME/.local/state/dots/rice/current}"
+	[[ -f $canon ]] && qs_rice="$(head -n 1 "$canon" | tr -d '\r')"
 
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    local ipc_rice
-    ipc_rice="$(_ipc_rice_current || true)"
-    [[ -n $ipc_rice ]] && qs_rice="$ipc_rice"
-  fi
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		local ipc_rice
+		ipc_rice="$(_ipc_rice_current || true)"
+		[[ -n $ipc_rice ]] && qs_rice="$ipc_rice"
+	fi
 
-  local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
-  local state_file="${HOME}/.local/state/dots/scheme/state.json"
-  if [[ -f $scheme_file ]]; then
-    scheme_flavour="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('flavour',''))" 2>/dev/null || true)"
-    scheme_mode="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('mode',''))" 2>/dev/null || true)"
-  fi
-  if [[ -f $state_file ]]; then
-    state_flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
-    state_mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
-  fi
+	local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
+	local state_file="${HOME}/.local/state/dots/scheme/state.json"
+	if [[ -f $scheme_file ]]; then
+		scheme_flavour="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('flavour',''))" 2>/dev/null || true)"
+		scheme_mode="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('mode',''))" 2>/dev/null || true)"
+	fi
+	if [[ -f $state_file ]]; then
+		state_flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
+		state_mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
+	fi
 
-  pointer="${DOTS_WALLPAPER_POINTER_FILE:-$HOME/.local/state/dots/wallpaper/path}"
-  local pointer_val=""
-  [[ -f $pointer ]] && pointer_val="$(head -n 1 "$pointer" | tr -d '\r')"
-  if command -v dots-wallpaper-current >/dev/null 2>&1; then
-    resolved="$(dots-wallpaper-current 2>/dev/null || true)"
-  fi
-  wal_target="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
+	pointer="${DOTS_WALLPAPER_POINTER_FILE:-$HOME/.local/state/dots/wallpaper/path}"
+	local pointer_val=""
+	[[ -f $pointer ]] && pointer_val="$(head -n 1 "$pointer" | tr -d '\r')"
+	if command -v dots-wallpaper-current >/dev/null 2>&1; then
+		resolved="$(dots-wallpaper-current 2>/dev/null || true)"
+	fi
+	wal_target="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
 
-  echo "=== dots-appearance doctor ==="
-  echo "rice.current   : ${qs_rice:-"(missing)"}"
-  echo "scheme.flavour : ${scheme_flavour:-"(missing)"}"
-  echo "state.flavour  : ${state_flavour:-"(missing)"}"
-  echo "scheme.mode    : ${scheme_mode:-"(missing)"}"
-  echo "state.mode     : ${state_mode:-"(missing)"}"
-  local hyprlock_conf="${HOME}/.cache/dots/smart-colors/colors-hyprlock.conf"
-  local hyprlock_bytes=0
-  [[ -f $hyprlock_conf ]] && hyprlock_bytes="$(wc -c <"$hyprlock_conf" | tr -d ' ')"
-  local gtk_theme_ini="" gtk_prefer_dark="" gtk_color_scheme=""
-  if [[ -f ${HOME}/.config/gtk-3.0/settings.ini ]]; then
-    gtk_theme_ini="$(grep -E '^gtk-theme-name=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-    gtk_prefer_dark="$(grep -E '^gtk-application-prefer-dark-theme=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-  fi
-  if command -v gsettings >/dev/null 2>&1; then
-    gtk_color_scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'\"" || true)"
-  fi
+	echo "=== dots-appearance doctor ==="
+	echo "rice.current   : ${qs_rice:-"(missing)"}"
+	echo "scheme.flavour : ${scheme_flavour:-"(missing)"}"
+	echo "state.flavour  : ${state_flavour:-"(missing)"}"
+	echo "scheme.mode    : ${scheme_mode:-"(missing)"}"
+	echo "state.mode     : ${state_mode:-"(missing)"}"
+	local hyprlock_conf="${HOME}/.cache/dots/smart-colors/colors-hyprlock.conf"
+	local hyprlock_bytes=0
+	[[ -f $hyprlock_conf ]] && hyprlock_bytes="$(wc -c <"$hyprlock_conf" | tr -d ' ')"
+	local gtk_theme_ini="" gtk_prefer_dark="" gtk_color_scheme=""
+	if [[ -f ${HOME}/.config/gtk-3.0/settings.ini ]]; then
+		gtk_theme_ini="$(grep -E '^gtk-theme-name=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+		gtk_prefer_dark="$(grep -E '^gtk-application-prefer-dark-theme=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+	fi
+	if command -v gsettings >/dev/null 2>&1; then
+		gtk_color_scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'\"" || true)"
+	fi
 
-  echo "wallpaper.ptr  : ${pointer_val:-"(missing)"}"
-  echo "wallpaper.res  : ${resolved:-"(missing)"}"
-  echo "wal.target     : ${wal_target:-"(missing)"}"
-  echo "hyprlock.conf  : ${hyprlock_bytes} bytes"
-  echo "gtk.theme.ini  : ${gtk_theme_ini:-"(missing)"}"
-  echo "gtk.preferDark : ${gtk_prefer_dark:-"(missing)"}"
-  echo "gtk.colorScheme: ${gtk_color_scheme:-"(missing)"}"
+	echo "wallpaper.ptr  : ${pointer_val:-"(missing)"}"
+	echo "wallpaper.res  : ${resolved:-"(missing)"}"
+	echo "wal.target     : ${wal_target:-"(missing)"}"
+	echo "hyprlock.conf  : ${hyprlock_bytes} bytes"
+	echo "gtk.theme.ini  : ${gtk_theme_ini:-"(missing)"}"
+	echo "gtk.preferDark : ${gtk_prefer_dark:-"(missing)"}"
+	echo "gtk.colorScheme: ${gtk_color_scheme:-"(missing)"}"
 
-  if [[ -z $qs_rice ]]; then
-    echo "FAIL: rice current pointer missing" >&2
-    ok=1
-  elif [[ ! -f "$HOME/.local/share/dots/rices/$qs_rice/config.json" ]]; then
-    echo "FAIL: rice config.json missing for $qs_rice" >&2
-    ok=1
-  fi
-  if [[ -e $HOME/.local/share/dots/rices/.current_rice || -e $HOME/.cache/dots/current_rice ]]; then
-    echo "FAIL: legacy rice pointer still present" >&2
-    ok=1
-  fi
-  if [[ -n $scheme_flavour && -n $state_flavour && $scheme_flavour != "$state_flavour" ]]; then
-    echo "FAIL: scheme flavour != state flavour ($scheme_flavour vs $state_flavour)" >&2
-    ok=1
-  fi
-  if [[ -n $scheme_mode && -n $state_mode && $scheme_mode != "$state_mode" ]]; then
-    echo "FAIL: scheme mode != state mode ($scheme_mode vs $state_mode)" >&2
-    ok=1
-  fi
-  if [[ -n $pointer_val && ! -f $pointer_val ]]; then
-    echo "FAIL: wallpaper pointer does not exist: $pointer_val" >&2
-    ok=1
-  fi
-  if [[ -n $pointer_val && -n $resolved && $pointer_val != "$resolved" ]]; then
-    local ptr_real res_real
-    ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
-    res_real="$(readlink -f "$resolved" 2>/dev/null || true)"
-    if [[ -n $ptr_real && -n $res_real && $ptr_real != "$res_real" ]]; then
-      echo "FAIL: pointer != dots-wallpaper-current ($pointer_val vs $resolved)" >&2
-      ok=1
-    fi
-  fi
-  if [[ -n $pointer_val && -f $pointer_val ]]; then
-    local ptr_real wal_real
-    ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
-    wal_real="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
-    if [[ -z $wal_real ]]; then
-      echo "FAIL: ~/.cache/wal/wal missing or broken" >&2
-      ok=1
-    elif [[ -n $ptr_real && $ptr_real != "$wal_real" ]]; then
-      echo "FAIL: wal target != wallpaper pointer ($wal_real vs $ptr_real)" >&2
-      ok=1
-    fi
-  fi
-  if [[ ! -f $hyprlock_conf || ${hyprlock_bytes:-0} -eq 0 ]]; then
-    echo "FAIL: colors-hyprlock.conf missing or empty" >&2
-    ok=1
-  fi
-  if [[ -f ${HOME}/.local/state/dots/wallpaper/path.txt ]]; then
-    echo "FAIL: orphan wallpaper/path.txt present (use wallpaper/path)" >&2
-    ok=1
-  fi
-  if [[ -f ${HOME}/.cache/dots/smart-colors/wallpaper ]]; then
-    echo "FAIL: orphan smart-colors/wallpaper cache present" >&2
-    ok=1
-  fi
-  if [[ -n $state_mode && -n $gtk_prefer_dark ]]; then
-    if [[ $state_mode == "dark" && $gtk_prefer_dark == "false" ]]; then
-      echo "FAIL: GTK prefer-dark=false while live mode is dark" >&2
-      ok=1
-    elif [[ $state_mode == "light" && $gtk_prefer_dark == "true" ]]; then
-      echo "FAIL: GTK prefer-dark=true while live mode is light" >&2
-      ok=1
-    fi
-  fi
-  if [[ -n $state_mode && -n $gtk_color_scheme ]]; then
-    if [[ $state_mode == "dark" && $gtk_color_scheme != "prefer-dark" ]]; then
-      echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is dark" >&2
-      ok=1
-    elif [[ $state_mode == "light" && $gtk_color_scheme != "prefer-light" ]]; then
-      echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is light" >&2
-      ok=1
-    fi
-  fi
-  if [[ -n $wal_target && -f $wal_target ]]; then
-    if ! file -b --mime-type "$wal_target" 2>/dev/null | grep -q '^image/'; then
-      echo "WARN: wal target is not an image: $wal_target" >&2
-    fi
-  fi
+	if [[ -z $qs_rice ]]; then
+		echo "FAIL: rice current pointer missing" >&2
+		ok=1
+	elif [[ ! -f "$HOME/.local/share/dots/rices/$qs_rice/config.json" ]]; then
+		echo "FAIL: rice config.json missing for $qs_rice" >&2
+		ok=1
+	fi
+	if [[ -e $HOME/.local/share/dots/rices/.current_rice || -e $HOME/.cache/dots/current_rice ]]; then
+		echo "FAIL: legacy rice pointer still present" >&2
+		ok=1
+	fi
+	if [[ -n $scheme_flavour && -n $state_flavour && $scheme_flavour != "$state_flavour" ]]; then
+		echo "FAIL: scheme flavour != state flavour ($scheme_flavour vs $state_flavour)" >&2
+		ok=1
+	fi
+	if [[ -n $scheme_mode && -n $state_mode && $scheme_mode != "$state_mode" ]]; then
+		echo "FAIL: scheme mode != state mode ($scheme_mode vs $state_mode)" >&2
+		ok=1
+	fi
+	if [[ -n $pointer_val && ! -f $pointer_val ]]; then
+		echo "FAIL: wallpaper pointer does not exist: $pointer_val" >&2
+		ok=1
+	fi
+	if [[ -n $pointer_val && -n $resolved && $pointer_val != "$resolved" ]]; then
+		local ptr_real res_real
+		ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
+		res_real="$(readlink -f "$resolved" 2>/dev/null || true)"
+		if [[ -n $ptr_real && -n $res_real && $ptr_real != "$res_real" ]]; then
+			echo "FAIL: pointer != dots-wallpaper-current ($pointer_val vs $resolved)" >&2
+			ok=1
+		fi
+	fi
+	if [[ -n $pointer_val && -f $pointer_val ]]; then
+		local ptr_real wal_real
+		ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
+		wal_real="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
+		if [[ -z $wal_real ]]; then
+			echo "FAIL: ~/.cache/wal/wal missing or broken" >&2
+			ok=1
+		elif [[ -n $ptr_real && $ptr_real != "$wal_real" ]]; then
+			echo "FAIL: wal target != wallpaper pointer ($wal_real vs $ptr_real)" >&2
+			ok=1
+		fi
+	fi
+	if [[ ! -f $hyprlock_conf || ${hyprlock_bytes:-0} -eq 0 ]]; then
+		echo "FAIL: colors-hyprlock.conf missing or empty" >&2
+		ok=1
+	fi
+	if [[ -f ${HOME}/.local/state/dots/wallpaper/path.txt ]]; then
+		echo "FAIL: orphan wallpaper/path.txt present (use wallpaper/path)" >&2
+		ok=1
+	fi
+	if [[ -f ${HOME}/.cache/dots/smart-colors/wallpaper ]]; then
+		echo "FAIL: orphan smart-colors/wallpaper cache present" >&2
+		ok=1
+	fi
+	if [[ -n $state_mode && -n $gtk_prefer_dark ]]; then
+		if [[ $state_mode == "dark" && $gtk_prefer_dark == "false" ]]; then
+			echo "FAIL: GTK prefer-dark=false while live mode is dark" >&2
+			ok=1
+		elif [[ $state_mode == "light" && $gtk_prefer_dark == "true" ]]; then
+			echo "FAIL: GTK prefer-dark=true while live mode is light" >&2
+			ok=1
+		fi
+	fi
+	if [[ -n $state_mode && -n $gtk_color_scheme ]]; then
+		if [[ $state_mode == "dark" && $gtk_color_scheme != "prefer-dark" ]]; then
+			echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is dark" >&2
+			ok=1
+		elif [[ $state_mode == "light" && $gtk_color_scheme != "prefer-light" ]]; then
+			echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is light" >&2
+			ok=1
+		fi
+	fi
+	if [[ -n $wal_target && -f $wal_target ]]; then
+		if ! file -b --mime-type "$wal_target" 2>/dev/null | grep -q '^image/'; then
+			echo "WARN: wal target is not an image: $wal_target" >&2
+		fi
+	fi
 
-  if [[ $ok -eq 0 ]]; then
-    echo "OK: appearance state is consistent"
-  else
-    echo "DONE: inconsistencies detected (exit $ok)"
-  fi
-  return "$ok"
+	if [[ $ok -eq 0 ]]; then
+		echo "OK: appearance state is consistent"
+	else
+		echo "DONE: inconsistencies detected (exit $ok)"
+	fi
+	return "$ok"
 }
 
 case "${cmd:-}" in
-  list) cmd_list ;;
-  current) cmd_current "${1:-}" ;;
-  apply) cmd_apply "$@" ;;
-  preview) cmd_preview "${1:-}" ;;
-  set-variant) cmd_set_variant "${1:-}" ;;
-  set-mode) cmd_set_mode "${1:-}" ;;
-  set-wallpaper) cmd_set_wallpaper "${1:-}" ;;
-  sync) cmd_sync ;;
-  doctor) cmd_doctor ;;
-  *)
-    cat <<'EOF' >&2
+list) cmd_list ;;
+current) cmd_current "${1:-}" ;;
+apply) cmd_apply "$@" ;;
+preview) cmd_preview "${1:-}" ;;
+set-variant) cmd_set_variant "${1:-}" ;;
+set-mode) cmd_set_mode "${1:-}" ;;
+set-wallpaper) cmd_set_wallpaper "${1:-}" ;;
+sync) cmd_sync ;;
+doctor) cmd_doctor ;;
+*)
+	cat <<'EOF' >&2
 Usage: dots-appearance <command> [args]
 
 Commands:
@@ -355,6 +355,6 @@ Commands:
   sync
   doctor
 EOF
-    exit 1
-    ;;
+	exit 1
+	;;
 esac

--- a/home/dot_local/bin/executable_dots-appearance
+++ b/home/dot_local/bin/executable_dots-appearance
@@ -19,301 +19,316 @@ cmd="${1:-}"
 shift 2>/dev/null || true
 
 json_escape() {
-	python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1"
+  python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1"
 }
 
 cmd_list() {
-	local script="${HOME}/.local/lib/dots/list-rices.py"
-	if [[ -f $script ]]; then
-		python3 "$script" "$RICES_DIR"
-	else
-		echo "[]"
-	fi
+  local script="${HOME}/.local/lib/dots/list-rices.py"
+  if [[ -f $script ]]; then
+    python3 "$script" "$RICES_DIR"
+  else
+    echo "[]"
+  fi
 }
 
 _ipc_rice_current() {
-	local id=""
-	id="$(quickshell ipc call rice current 2>/dev/null || true)"
-	id="${id//$'\r'/}"
-	id="${id//$'\n'/}"
-	# Ignore QS error payloads when the target is unavailable (stale process / reload).
-	case "$id" in
-	"" | "Target not found." | *"not found"* | *"error"* | *"Error"*) return 1 ;;
-	esac
-	printf '%s\n' "$id"
+  local id=""
+  id="$(quickshell ipc call rice current 2>/dev/null || true)"
+  id="${id//$'\r'/}"
+  id="${id//$'\n'/}"
+  # Ignore QS error payloads when the target is unavailable (stale process / reload).
+  [[ -n $id ]] || return 1
+  [[ $id == *" "* ]] && return 1
+  [[ -d "$RICES_DIR/$id" ]] || return 1
+  printf '%s\n' "$id"
 }
 
 cmd_current() {
-	local id=""
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		id="$(_ipc_rice_current || true)"
-	fi
-	if [[ -z ${id:-} ]] && declare -f dots_read_current_rice >/dev/null 2>&1; then
-		id="$(dots_read_current_rice)"
-	fi
-	if [[ ${1:-} == "--json" ]]; then
-		printf '{"id":%s}\n' "$(json_escape "${id:-}")"
-	else
-		printf '%s\n' "${id:-}"
-	fi
+  local id=""
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    id="$(_ipc_rice_current || true)"
+  fi
+  if [[ -z ${id:-} ]] && declare -f dots_read_current_rice >/dev/null 2>&1; then
+    id="$(dots_read_current_rice)"
+  fi
+  if [[ ${1:-} == "--json" ]]; then
+    printf '{"id":%s}\n' "$(json_escape "${id:-}")"
+  else
+    printf '%s\n' "${id:-}"
+  fi
 }
 
 _shell_apply() {
-	local id="$1"
-	local wallpaper="${2:-}"
-	# shellcheck source=/dev/null
-	source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
-	# shellcheck source=/dev/null
-	source "$HOME/.local/lib/dots/apply-appearance.sh"
-	dots_apply_appearance "$id" "$wallpaper"
+  local id="$1"
+  local wallpaper="${2:-}"
+  # shellcheck source=/dev/null
+  source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
+  # shellcheck source=/dev/null
+  source "$HOME/.local/lib/dots/apply-appearance.sh"
+  dots_apply_appearance "$id" "$wallpaper"
 }
 
 cmd_apply() {
-	local id="${1:-}"
-	local wallpaper=""
-	shift 2>/dev/null || true
-	while [[ $# -gt 0 ]]; do
-		case "${1:-}" in
-		--wallpaper)
-			wallpaper="${2:-}"
-			shift 2
-			;;
-		*) shift ;;
-		esac
-	done
+  local id="${1:-}"
+  local wallpaper=""
+  shift 2>/dev/null || true
+  while [[ $# -gt 0 ]]; do
+    case "${1:-}" in
+      --wallpaper)
+        wallpaper="${2:-}"
+        shift 2
+        ;;
+      *)
+        echo "dots-appearance apply: unknown argument: $1" >&2
+        exit 1
+        ;;
+    esac
+  done
 
-	[[ -n $id ]] || {
-		echo "Usage: dots-appearance apply <id> [--wallpaper <path>]" >&2
-		exit 1
-	}
+  [[ -n $id ]] || {
+    echo "Usage: dots-appearance apply <id> [--wallpaper <path>]" >&2
+    exit 1
+  }
 
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		local ipc_out=""
-		if ipc_out="$(quickshell ipc call rice apply "$id" "${wallpaper:-}" 2>&1)"; then
-			case "$ipc_out" in
-			*"not found"* | *"Error"* | *"error"*)
-				echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
-				;;
-			*)
-				# Rice id is persisted by Quickshell only after a successful apply.
-				# Do not write rice/current here — that raced ahead of wal/M3.
-				exit 0
-				;;
-			esac
-		else
-			echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
-		fi
-	fi
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    local ipc_out=""
+    if ipc_out="$(quickshell ipc call rice apply "$id" "${wallpaper:-}" 2>&1)"; then
+      case "$ipc_out" in
+        "Target not found."* | *"Target not found"*)
+          echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
+          ;;
+        *)
+          # Wait for the queued QS job; persist happens inside Rice after success.
+          local _i busy last_error
+          for _i in $(seq 1 120); do
+            busy="$(quickshell ipc call rice isBusy 2>/dev/null || echo 0)"
+            [[ $busy == "1" ]] || break
+            sleep 0.5
+          done
+          last_error="$(quickshell ipc call rice lastError 2>/dev/null || true)"
+          last_error="${last_error//$'\r'/}"
+          last_error="${last_error//$'\n'/}"
+          if [[ -n $last_error ]]; then
+            echo "Error: appearance apply failed: $last_error" >&2
+            exit 1
+          fi
+          exit 0
+          ;;
+      esac
+    else
+      echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
+    fi
+  fi
 
-	_shell_apply "$id" "$wallpaper"
+  _shell_apply "$id" "$wallpaper"
 }
 
 cmd_preview() {
-	local id="${1:-}"
-	[[ -n $id ]] || {
-		echo "Usage: dots-appearance preview <id>" >&2
-		exit 1
-	}
-	local config_path="${RICES_DIR}/${id}/config.json"
-	[[ -f $config_path ]] || {
-		echo "Appearance not found: $id" >&2
-		exit 1
-	}
-	cat "$config_path"
+  local id="${1:-}"
+  [[ -n $id ]] || {
+    echo "Usage: dots-appearance preview <id>" >&2
+    exit 1
+  }
+  local config_path="${RICES_DIR}/${id}/config.json"
+  [[ -f $config_path ]] || {
+    echo "Appearance not found: $id" >&2
+    exit 1
+  }
+  cat "$config_path"
 }
 
 cmd_set_wallpaper() {
-	local wallpaper="${1:-}"
-	[[ -n $wallpaper ]] || {
-		echo "Usage: dots-appearance set-wallpaper <path>" >&2
-		exit 1
-	}
-	dots-wallpaper-set "$wallpaper"
+  local wallpaper="${1:-}"
+  [[ -n $wallpaper ]] || {
+    echo "Usage: dots-appearance set-wallpaper <path>" >&2
+    exit 1
+  }
+  dots-wallpaper-set "$wallpaper"
 }
 
 cmd_set_variant() {
-	dots-color-scheme variant "${1:-}"
+  dots-color-scheme variant "${1:-}"
 }
 
 cmd_set_mode() {
-	dots-color-scheme mode "${1:-}"
+  dots-color-scheme mode "${1:-}"
 }
 
 cmd_sync() {
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		quickshell ipc call rice reload || true
-	fi
-	dots-color-scheme sync-state >/dev/null 2>&1 || true
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    quickshell ipc call rice reload || true
+  fi
+  dots-color-scheme sync-state >/dev/null 2>&1 || true
 }
 
 cmd_doctor() {
-	local ok=0
-	local qs_rice="" canon=""
-	local scheme_flavour="" state_flavour="" scheme_mode="" state_mode=""
-	local pointer="" resolved="" wal_target=""
+  local ok=0
+  local qs_rice="" canon=""
+  local scheme_flavour="" state_flavour="" scheme_mode="" state_mode=""
+  local pointer="" resolved="" wal_target=""
 
-	# Drop leftover legacy pointers if helpers are available.
-	if declare -f dots_purge_legacy_rice_pointers >/dev/null 2>&1; then
-		dots_purge_legacy_rice_pointers
-	else
-		rm -f "$HOME/.local/share/dots/rices/.current_rice" \
-			"$HOME/.cache/dots/current_rice" 2>/dev/null || true
-	fi
+  # Drop leftover legacy pointers if helpers are available.
+  if declare -f dots_purge_legacy_rice_pointers >/dev/null 2>&1; then
+    dots_purge_legacy_rice_pointers
+  else
+    rm -f "$HOME/.local/share/dots/rices/.current_rice" \
+      "$HOME/.cache/dots/current_rice" 2>/dev/null || true
+  fi
 
-	canon="${DOTS_RICE_CANONICAL_FILE:-$HOME/.local/state/dots/rice/current}"
-	[[ -f $canon ]] && qs_rice="$(head -n 1 "$canon" | tr -d '\r')"
+  canon="${DOTS_RICE_CANONICAL_FILE:-$HOME/.local/state/dots/rice/current}"
+  [[ -f $canon ]] && qs_rice="$(head -n 1 "$canon" | tr -d '\r')"
 
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		local ipc_rice
-		ipc_rice="$(_ipc_rice_current || true)"
-		[[ -n $ipc_rice ]] && qs_rice="$ipc_rice"
-	fi
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    local ipc_rice
+    ipc_rice="$(_ipc_rice_current || true)"
+    [[ -n $ipc_rice ]] && qs_rice="$ipc_rice"
+  fi
 
-	local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
-	local state_file="${HOME}/.local/state/dots/scheme/state.json"
-	if [[ -f $scheme_file ]]; then
-		scheme_flavour="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('flavour',''))" 2>/dev/null || true)"
-		scheme_mode="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('mode',''))" 2>/dev/null || true)"
-	fi
-	if [[ -f $state_file ]]; then
-		state_flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
-		state_mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
-	fi
+  local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
+  local state_file="${HOME}/.local/state/dots/scheme/state.json"
+  if [[ -f $scheme_file ]]; then
+    scheme_flavour="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('flavour',''))" 2>/dev/null || true)"
+    scheme_mode="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('mode',''))" 2>/dev/null || true)"
+  fi
+  if [[ -f $state_file ]]; then
+    state_flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
+    state_mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
+  fi
 
-	pointer="${DOTS_WALLPAPER_POINTER_FILE:-$HOME/.local/state/dots/wallpaper/path}"
-	local pointer_val=""
-	[[ -f $pointer ]] && pointer_val="$(head -n 1 "$pointer" | tr -d '\r')"
-	if command -v dots-wallpaper-current >/dev/null 2>&1; then
-		resolved="$(dots-wallpaper-current 2>/dev/null || true)"
-	fi
-	wal_target="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
+  pointer="${DOTS_WALLPAPER_POINTER_FILE:-$HOME/.local/state/dots/wallpaper/path}"
+  local pointer_val=""
+  [[ -f $pointer ]] && pointer_val="$(head -n 1 "$pointer" | tr -d '\r')"
+  if command -v dots-wallpaper-current >/dev/null 2>&1; then
+    resolved="$(dots-wallpaper-current 2>/dev/null || true)"
+  fi
+  wal_target="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
 
-	echo "=== dots-appearance doctor ==="
-	echo "rice.current   : ${qs_rice:-"(missing)"}"
-	echo "scheme.flavour : ${scheme_flavour:-"(missing)"}"
-	echo "state.flavour  : ${state_flavour:-"(missing)"}"
-	echo "scheme.mode    : ${scheme_mode:-"(missing)"}"
-	echo "state.mode     : ${state_mode:-"(missing)"}"
-	local hyprlock_conf="${HOME}/.cache/dots/smart-colors/colors-hyprlock.conf"
-	local hyprlock_bytes=0
-	[[ -f $hyprlock_conf ]] && hyprlock_bytes="$(wc -c <"$hyprlock_conf" | tr -d ' ')"
-	local gtk_theme_ini="" gtk_prefer_dark="" gtk_color_scheme=""
-	if [[ -f ${HOME}/.config/gtk-3.0/settings.ini ]]; then
-		gtk_theme_ini="$(grep -E '^gtk-theme-name=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-		gtk_prefer_dark="$(grep -E '^gtk-application-prefer-dark-theme=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-	fi
-	if command -v gsettings >/dev/null 2>&1; then
-		gtk_color_scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'\"" || true)"
-	fi
+  echo "=== dots-appearance doctor ==="
+  echo "rice.current   : ${qs_rice:-"(missing)"}"
+  echo "scheme.flavour : ${scheme_flavour:-"(missing)"}"
+  echo "state.flavour  : ${state_flavour:-"(missing)"}"
+  echo "scheme.mode    : ${scheme_mode:-"(missing)"}"
+  echo "state.mode     : ${state_mode:-"(missing)"}"
+  local hyprlock_conf="${HOME}/.cache/dots/smart-colors/colors-hyprlock.conf"
+  local hyprlock_bytes=0
+  [[ -f $hyprlock_conf ]] && hyprlock_bytes="$(wc -c <"$hyprlock_conf" | tr -d ' ')"
+  local gtk_theme_ini="" gtk_prefer_dark="" gtk_color_scheme=""
+  if [[ -f ${HOME}/.config/gtk-3.0/settings.ini ]]; then
+    gtk_theme_ini="$(grep -E '^gtk-theme-name=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+    gtk_prefer_dark="$(grep -E '^gtk-application-prefer-dark-theme=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+  fi
+  if command -v gsettings >/dev/null 2>&1; then
+    gtk_color_scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'\"" || true)"
+  fi
 
-	echo "wallpaper.ptr  : ${pointer_val:-"(missing)"}"
-	echo "wallpaper.res  : ${resolved:-"(missing)"}"
-	echo "wal.target     : ${wal_target:-"(missing)"}"
-	echo "hyprlock.conf  : ${hyprlock_bytes} bytes"
-	echo "gtk.theme.ini  : ${gtk_theme_ini:-"(missing)"}"
-	echo "gtk.preferDark : ${gtk_prefer_dark:-"(missing)"}"
-	echo "gtk.colorScheme: ${gtk_color_scheme:-"(missing)"}"
+  echo "wallpaper.ptr  : ${pointer_val:-"(missing)"}"
+  echo "wallpaper.res  : ${resolved:-"(missing)"}"
+  echo "wal.target     : ${wal_target:-"(missing)"}"
+  echo "hyprlock.conf  : ${hyprlock_bytes} bytes"
+  echo "gtk.theme.ini  : ${gtk_theme_ini:-"(missing)"}"
+  echo "gtk.preferDark : ${gtk_prefer_dark:-"(missing)"}"
+  echo "gtk.colorScheme: ${gtk_color_scheme:-"(missing)"}"
 
-	if [[ -z $qs_rice ]]; then
-		echo "FAIL: rice current pointer missing" >&2
-		ok=1
-	elif [[ ! -f "$HOME/.local/share/dots/rices/$qs_rice/config.json" ]]; then
-		echo "FAIL: rice config.json missing for $qs_rice" >&2
-		ok=1
-	fi
-	if [[ -e $HOME/.local/share/dots/rices/.current_rice || -e $HOME/.cache/dots/current_rice ]]; then
-		echo "FAIL: legacy rice pointer still present" >&2
-		ok=1
-	fi
-	if [[ -n $scheme_flavour && -n $state_flavour && $scheme_flavour != "$state_flavour" ]]; then
-		echo "FAIL: scheme flavour != state flavour ($scheme_flavour vs $state_flavour)" >&2
-		ok=1
-	fi
-	if [[ -n $scheme_mode && -n $state_mode && $scheme_mode != "$state_mode" ]]; then
-		echo "FAIL: scheme mode != state mode ($scheme_mode vs $state_mode)" >&2
-		ok=1
-	fi
-	if [[ -n $pointer_val && ! -f $pointer_val ]]; then
-		echo "FAIL: wallpaper pointer does not exist: $pointer_val" >&2
-		ok=1
-	fi
-	if [[ -n $pointer_val && -n $resolved && $pointer_val != "$resolved" ]]; then
-		local ptr_real res_real
-		ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
-		res_real="$(readlink -f "$resolved" 2>/dev/null || true)"
-		if [[ -n $ptr_real && -n $res_real && $ptr_real != "$res_real" ]]; then
-			echo "FAIL: pointer != dots-wallpaper-current ($pointer_val vs $resolved)" >&2
-			ok=1
-		fi
-	fi
-	if [[ -n $pointer_val && -f $pointer_val ]]; then
-		local ptr_real wal_real
-		ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
-		wal_real="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
-		if [[ -z $wal_real ]]; then
-			echo "FAIL: ~/.cache/wal/wal missing or broken" >&2
-			ok=1
-		elif [[ -n $ptr_real && $ptr_real != "$wal_real" ]]; then
-			echo "FAIL: wal target != wallpaper pointer ($wal_real vs $ptr_real)" >&2
-			ok=1
-		fi
-	fi
-	if [[ ! -f $hyprlock_conf || ${hyprlock_bytes:-0} -eq 0 ]]; then
-		echo "FAIL: colors-hyprlock.conf missing or empty" >&2
-		ok=1
-	fi
-	if [[ -f ${HOME}/.local/state/dots/wallpaper/path.txt ]]; then
-		echo "FAIL: orphan wallpaper/path.txt present (use wallpaper/path)" >&2
-		ok=1
-	fi
-	if [[ -f ${HOME}/.cache/dots/smart-colors/wallpaper ]]; then
-		echo "FAIL: orphan smart-colors/wallpaper cache present" >&2
-		ok=1
-	fi
-	if [[ -n $state_mode && -n $gtk_prefer_dark ]]; then
-		if [[ $state_mode == "dark" && $gtk_prefer_dark == "false" ]]; then
-			echo "FAIL: GTK prefer-dark=false while live mode is dark" >&2
-			ok=1
-		elif [[ $state_mode == "light" && $gtk_prefer_dark == "true" ]]; then
-			echo "FAIL: GTK prefer-dark=true while live mode is light" >&2
-			ok=1
-		fi
-	fi
-	if [[ -n $state_mode && -n $gtk_color_scheme ]]; then
-		if [[ $state_mode == "dark" && $gtk_color_scheme != "prefer-dark" ]]; then
-			echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is dark" >&2
-			ok=1
-		elif [[ $state_mode == "light" && $gtk_color_scheme != "prefer-light" ]]; then
-			echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is light" >&2
-			ok=1
-		fi
-	fi
-	if [[ -n $wal_target && -f $wal_target ]]; then
-		if ! file -b --mime-type "$wal_target" 2>/dev/null | grep -q '^image/'; then
-			echo "WARN: wal target is not an image: $wal_target" >&2
-		fi
-	fi
+  if [[ -z $qs_rice ]]; then
+    echo "FAIL: rice current pointer missing" >&2
+    ok=1
+  elif [[ ! -f "$HOME/.local/share/dots/rices/$qs_rice/config.json" ]]; then
+    echo "FAIL: rice config.json missing for $qs_rice" >&2
+    ok=1
+  fi
+  if [[ -e $HOME/.local/share/dots/rices/.current_rice || -e $HOME/.cache/dots/current_rice ]]; then
+    echo "FAIL: legacy rice pointer still present" >&2
+    ok=1
+  fi
+  if [[ -n $scheme_flavour && -n $state_flavour && $scheme_flavour != "$state_flavour" ]]; then
+    echo "FAIL: scheme flavour != state flavour ($scheme_flavour vs $state_flavour)" >&2
+    ok=1
+  fi
+  if [[ -n $scheme_mode && -n $state_mode && $scheme_mode != "$state_mode" ]]; then
+    echo "FAIL: scheme mode != state mode ($scheme_mode vs $state_mode)" >&2
+    ok=1
+  fi
+  if [[ -n $pointer_val && ! -f $pointer_val ]]; then
+    echo "FAIL: wallpaper pointer does not exist: $pointer_val" >&2
+    ok=1
+  fi
+  if [[ -n $pointer_val && -n $resolved && $pointer_val != "$resolved" ]]; then
+    local ptr_real res_real
+    ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
+    res_real="$(readlink -f "$resolved" 2>/dev/null || true)"
+    if [[ -n $ptr_real && -n $res_real && $ptr_real != "$res_real" ]]; then
+      echo "FAIL: pointer != dots-wallpaper-current ($pointer_val vs $resolved)" >&2
+      ok=1
+    fi
+  fi
+  if [[ -n $pointer_val && -f $pointer_val ]]; then
+    local ptr_real wal_real
+    ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
+    wal_real="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
+    if [[ -z $wal_real ]]; then
+      echo "FAIL: ~/.cache/wal/wal missing or broken" >&2
+      ok=1
+    elif [[ -n $ptr_real && $ptr_real != "$wal_real" ]]; then
+      echo "FAIL: wal target != wallpaper pointer ($wal_real vs $ptr_real)" >&2
+      ok=1
+    fi
+  fi
+  if [[ ! -f $hyprlock_conf || ${hyprlock_bytes:-0} -eq 0 ]]; then
+    echo "FAIL: colors-hyprlock.conf missing or empty" >&2
+    ok=1
+  fi
+  if [[ -f ${HOME}/.local/state/dots/wallpaper/path.txt ]]; then
+    echo "FAIL: orphan wallpaper/path.txt present (use wallpaper/path)" >&2
+    ok=1
+  fi
+  if [[ -f ${HOME}/.cache/dots/smart-colors/wallpaper ]]; then
+    echo "FAIL: orphan smart-colors/wallpaper cache present" >&2
+    ok=1
+  fi
+  if [[ -n $state_mode && -n $gtk_prefer_dark ]]; then
+    if [[ $state_mode == "dark" && $gtk_prefer_dark == "false" ]]; then
+      echo "FAIL: GTK prefer-dark=false while live mode is dark" >&2
+      ok=1
+    elif [[ $state_mode == "light" && $gtk_prefer_dark == "true" ]]; then
+      echo "FAIL: GTK prefer-dark=true while live mode is light" >&2
+      ok=1
+    fi
+  fi
+  if [[ -n $state_mode && -n $gtk_color_scheme ]]; then
+    if [[ $state_mode == "dark" && $gtk_color_scheme != "prefer-dark" ]]; then
+      echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is dark" >&2
+      ok=1
+    elif [[ $state_mode == "light" && $gtk_color_scheme != "prefer-light" ]]; then
+      echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is light" >&2
+      ok=1
+    fi
+  fi
+  if [[ -n $wal_target && -f $wal_target ]]; then
+    if ! file -b --mime-type "$wal_target" 2>/dev/null | grep -q '^image/'; then
+      echo "WARN: wal target is not an image: $wal_target" >&2
+    fi
+  fi
 
-	if [[ $ok -eq 0 ]]; then
-		echo "OK: appearance state is consistent"
-	else
-		echo "DONE: inconsistencies detected (exit $ok)"
-	fi
-	return "$ok"
+  if [[ $ok -eq 0 ]]; then
+    echo "OK: appearance state is consistent"
+  else
+    echo "DONE: inconsistencies detected (exit $ok)"
+  fi
+  return "$ok"
 }
 
 case "${cmd:-}" in
-list) cmd_list ;;
-current) cmd_current "${1:-}" ;;
-apply) cmd_apply "$@" ;;
-preview) cmd_preview "${1:-}" ;;
-set-variant) cmd_set_variant "${1:-}" ;;
-set-mode) cmd_set_mode "${1:-}" ;;
-set-wallpaper) cmd_set_wallpaper "${1:-}" ;;
-sync) cmd_sync ;;
-doctor) cmd_doctor ;;
-*)
-	cat <<'EOF' >&2
+  list) cmd_list ;;
+  current) cmd_current "${1:-}" ;;
+  apply) cmd_apply "$@" ;;
+  preview) cmd_preview "${1:-}" ;;
+  set-variant) cmd_set_variant "${1:-}" ;;
+  set-mode) cmd_set_mode "${1:-}" ;;
+  set-wallpaper) cmd_set_wallpaper "${1:-}" ;;
+  sync) cmd_sync ;;
+  doctor) cmd_doctor ;;
+  *)
+    cat <<'EOF' >&2
 Usage: dots-appearance <command> [args]
 
 Commands:
@@ -327,6 +342,6 @@ Commands:
   sync
   doctor
 EOF
-	exit 1
-	;;
+    exit 1
+    ;;
 esac

--- a/home/dot_local/bin/executable_dots-appearance
+++ b/home/dot_local/bin/executable_dots-appearance
@@ -19,316 +19,316 @@ cmd="${1:-}"
 shift 2>/dev/null || true
 
 json_escape() {
-  python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1"
+	python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1"
 }
 
 cmd_list() {
-  local script="${HOME}/.local/lib/dots/list-rices.py"
-  if [[ -f $script ]]; then
-    python3 "$script" "$RICES_DIR"
-  else
-    echo "[]"
-  fi
+	local script="${HOME}/.local/lib/dots/list-rices.py"
+	if [[ -f $script ]]; then
+		python3 "$script" "$RICES_DIR"
+	else
+		echo "[]"
+	fi
 }
 
 _ipc_rice_current() {
-  local id=""
-  id="$(quickshell ipc call rice current 2>/dev/null || true)"
-  id="${id//$'\r'/}"
-  id="${id//$'\n'/}"
-  # Ignore QS error payloads when the target is unavailable (stale process / reload).
-  [[ -n $id ]] || return 1
-  [[ $id == *" "* ]] && return 1
-  [[ -d "$RICES_DIR/$id" ]] || return 1
-  printf '%s\n' "$id"
+	local id=""
+	id="$(quickshell ipc call rice current 2>/dev/null || true)"
+	id="${id//$'\r'/}"
+	id="${id//$'\n'/}"
+	# Ignore QS error payloads when the target is unavailable (stale process / reload).
+	[[ -n $id ]] || return 1
+	[[ $id == *" "* ]] && return 1
+	[[ -d "$RICES_DIR/$id" ]] || return 1
+	printf '%s\n' "$id"
 }
 
 cmd_current() {
-  local id=""
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    id="$(_ipc_rice_current || true)"
-  fi
-  if [[ -z ${id:-} ]] && declare -f dots_read_current_rice >/dev/null 2>&1; then
-    id="$(dots_read_current_rice)"
-  fi
-  if [[ ${1:-} == "--json" ]]; then
-    printf '{"id":%s}\n' "$(json_escape "${id:-}")"
-  else
-    printf '%s\n' "${id:-}"
-  fi
+	local id=""
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		id="$(_ipc_rice_current || true)"
+	fi
+	if [[ -z ${id:-} ]] && declare -f dots_read_current_rice >/dev/null 2>&1; then
+		id="$(dots_read_current_rice)"
+	fi
+	if [[ ${1:-} == "--json" ]]; then
+		printf '{"id":%s}\n' "$(json_escape "${id:-}")"
+	else
+		printf '%s\n' "${id:-}"
+	fi
 }
 
 _shell_apply() {
-  local id="$1"
-  local wallpaper="${2:-}"
-  # shellcheck source=/dev/null
-  source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
-  # shellcheck source=/dev/null
-  source "$HOME/.local/lib/dots/apply-appearance.sh"
-  dots_apply_appearance "$id" "$wallpaper"
+	local id="$1"
+	local wallpaper="${2:-}"
+	# shellcheck source=/dev/null
+	source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
+	# shellcheck source=/dev/null
+	source "$HOME/.local/lib/dots/apply-appearance.sh"
+	dots_apply_appearance "$id" "$wallpaper"
 }
 
 cmd_apply() {
-  local id="${1:-}"
-  local wallpaper=""
-  shift 2>/dev/null || true
-  while [[ $# -gt 0 ]]; do
-    case "${1:-}" in
-      --wallpaper)
-        wallpaper="${2:-}"
-        shift 2
-        ;;
-      *)
-        echo "dots-appearance apply: unknown argument: $1" >&2
-        exit 1
-        ;;
-    esac
-  done
+	local id="${1:-}"
+	local wallpaper=""
+	shift 2>/dev/null || true
+	while [[ $# -gt 0 ]]; do
+		case "${1:-}" in
+		--wallpaper)
+			wallpaper="${2:-}"
+			shift 2
+			;;
+		*)
+			echo "dots-appearance apply: unknown argument: $1" >&2
+			exit 1
+			;;
+		esac
+	done
 
-  [[ -n $id ]] || {
-    echo "Usage: dots-appearance apply <id> [--wallpaper <path>]" >&2
-    exit 1
-  }
+	[[ -n $id ]] || {
+		echo "Usage: dots-appearance apply <id> [--wallpaper <path>]" >&2
+		exit 1
+	}
 
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    local ipc_out=""
-    if ipc_out="$(quickshell ipc call rice apply "$id" "${wallpaper:-}" 2>&1)"; then
-      case "$ipc_out" in
-        "Target not found."* | *"Target not found"*)
-          echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
-          ;;
-        *)
-          # Wait for the queued QS job; persist happens inside Rice after success.
-          local _i busy last_error
-          for _i in $(seq 1 120); do
-            busy="$(quickshell ipc call rice isBusy 2>/dev/null || echo 0)"
-            [[ $busy == "1" ]] || break
-            sleep 0.5
-          done
-          last_error="$(quickshell ipc call rice lastError 2>/dev/null || true)"
-          last_error="${last_error//$'\r'/}"
-          last_error="${last_error//$'\n'/}"
-          if [[ -n $last_error ]]; then
-            echo "Error: appearance apply failed: $last_error" >&2
-            exit 1
-          fi
-          exit 0
-          ;;
-      esac
-    else
-      echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
-    fi
-  fi
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		local ipc_out=""
+		if ipc_out="$(quickshell ipc call rice apply "$id" "${wallpaper:-}" 2>&1)"; then
+			case "$ipc_out" in
+			"Target not found."* | *"Target not found"*)
+				echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
+				;;
+			*)
+				# Wait for the queued QS job; persist happens inside Rice after success.
+				local _i busy last_error
+				for _i in $(seq 1 120); do
+					busy="$(quickshell ipc call rice isBusy 2>/dev/null || echo 0)"
+					[[ $busy == "1" ]] || break
+					sleep 0.5
+				done
+				last_error="$(quickshell ipc call rice lastError 2>/dev/null || true)"
+				last_error="${last_error//$'\r'/}"
+				last_error="${last_error//$'\n'/}"
+				if [[ -n $last_error ]]; then
+					echo "Error: appearance apply failed: $last_error" >&2
+					exit 1
+				fi
+				exit 0
+				;;
+			esac
+		else
+			echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
+		fi
+	fi
 
-  _shell_apply "$id" "$wallpaper"
+	_shell_apply "$id" "$wallpaper"
 }
 
 cmd_preview() {
-  local id="${1:-}"
-  [[ -n $id ]] || {
-    echo "Usage: dots-appearance preview <id>" >&2
-    exit 1
-  }
-  local config_path="${RICES_DIR}/${id}/config.json"
-  [[ -f $config_path ]] || {
-    echo "Appearance not found: $id" >&2
-    exit 1
-  }
-  cat "$config_path"
+	local id="${1:-}"
+	[[ -n $id ]] || {
+		echo "Usage: dots-appearance preview <id>" >&2
+		exit 1
+	}
+	local config_path="${RICES_DIR}/${id}/config.json"
+	[[ -f $config_path ]] || {
+		echo "Appearance not found: $id" >&2
+		exit 1
+	}
+	cat "$config_path"
 }
 
 cmd_set_wallpaper() {
-  local wallpaper="${1:-}"
-  [[ -n $wallpaper ]] || {
-    echo "Usage: dots-appearance set-wallpaper <path>" >&2
-    exit 1
-  }
-  dots-wallpaper-set "$wallpaper"
+	local wallpaper="${1:-}"
+	[[ -n $wallpaper ]] || {
+		echo "Usage: dots-appearance set-wallpaper <path>" >&2
+		exit 1
+	}
+	dots-wallpaper-set "$wallpaper"
 }
 
 cmd_set_variant() {
-  dots-color-scheme variant "${1:-}"
+	dots-color-scheme variant "${1:-}"
 }
 
 cmd_set_mode() {
-  dots-color-scheme mode "${1:-}"
+	dots-color-scheme mode "${1:-}"
 }
 
 cmd_sync() {
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    quickshell ipc call rice reload || true
-  fi
-  dots-color-scheme sync-state >/dev/null 2>&1 || true
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		quickshell ipc call rice reload || true
+	fi
+	dots-color-scheme sync-state >/dev/null 2>&1 || true
 }
 
 cmd_doctor() {
-  local ok=0
-  local qs_rice="" canon=""
-  local scheme_flavour="" state_flavour="" scheme_mode="" state_mode=""
-  local pointer="" resolved="" wal_target=""
+	local ok=0
+	local qs_rice="" canon=""
+	local scheme_flavour="" state_flavour="" scheme_mode="" state_mode=""
+	local pointer="" resolved="" wal_target=""
 
-  # Drop leftover legacy pointers if helpers are available.
-  if declare -f dots_purge_legacy_rice_pointers >/dev/null 2>&1; then
-    dots_purge_legacy_rice_pointers
-  else
-    rm -f "$HOME/.local/share/dots/rices/.current_rice" \
-      "$HOME/.cache/dots/current_rice" 2>/dev/null || true
-  fi
+	# Drop leftover legacy pointers if helpers are available.
+	if declare -f dots_purge_legacy_rice_pointers >/dev/null 2>&1; then
+		dots_purge_legacy_rice_pointers
+	else
+		rm -f "$HOME/.local/share/dots/rices/.current_rice" \
+			"$HOME/.cache/dots/current_rice" 2>/dev/null || true
+	fi
 
-  canon="${DOTS_RICE_CANONICAL_FILE:-$HOME/.local/state/dots/rice/current}"
-  [[ -f $canon ]] && qs_rice="$(head -n 1 "$canon" | tr -d '\r')"
+	canon="${DOTS_RICE_CANONICAL_FILE:-$HOME/.local/state/dots/rice/current}"
+	[[ -f $canon ]] && qs_rice="$(head -n 1 "$canon" | tr -d '\r')"
 
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    local ipc_rice
-    ipc_rice="$(_ipc_rice_current || true)"
-    [[ -n $ipc_rice ]] && qs_rice="$ipc_rice"
-  fi
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		local ipc_rice
+		ipc_rice="$(_ipc_rice_current || true)"
+		[[ -n $ipc_rice ]] && qs_rice="$ipc_rice"
+	fi
 
-  local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
-  local state_file="${HOME}/.local/state/dots/scheme/state.json"
-  if [[ -f $scheme_file ]]; then
-    scheme_flavour="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('flavour',''))" 2>/dev/null || true)"
-    scheme_mode="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('mode',''))" 2>/dev/null || true)"
-  fi
-  if [[ -f $state_file ]]; then
-    state_flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
-    state_mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
-  fi
+	local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
+	local state_file="${HOME}/.local/state/dots/scheme/state.json"
+	if [[ -f $scheme_file ]]; then
+		scheme_flavour="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('flavour',''))" 2>/dev/null || true)"
+		scheme_mode="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('mode',''))" 2>/dev/null || true)"
+	fi
+	if [[ -f $state_file ]]; then
+		state_flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
+		state_mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
+	fi
 
-  pointer="${DOTS_WALLPAPER_POINTER_FILE:-$HOME/.local/state/dots/wallpaper/path}"
-  local pointer_val=""
-  [[ -f $pointer ]] && pointer_val="$(head -n 1 "$pointer" | tr -d '\r')"
-  if command -v dots-wallpaper-current >/dev/null 2>&1; then
-    resolved="$(dots-wallpaper-current 2>/dev/null || true)"
-  fi
-  wal_target="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
+	pointer="${DOTS_WALLPAPER_POINTER_FILE:-$HOME/.local/state/dots/wallpaper/path}"
+	local pointer_val=""
+	[[ -f $pointer ]] && pointer_val="$(head -n 1 "$pointer" | tr -d '\r')"
+	if command -v dots-wallpaper-current >/dev/null 2>&1; then
+		resolved="$(dots-wallpaper-current 2>/dev/null || true)"
+	fi
+	wal_target="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
 
-  echo "=== dots-appearance doctor ==="
-  echo "rice.current   : ${qs_rice:-"(missing)"}"
-  echo "scheme.flavour : ${scheme_flavour:-"(missing)"}"
-  echo "state.flavour  : ${state_flavour:-"(missing)"}"
-  echo "scheme.mode    : ${scheme_mode:-"(missing)"}"
-  echo "state.mode     : ${state_mode:-"(missing)"}"
-  local hyprlock_conf="${HOME}/.cache/dots/smart-colors/colors-hyprlock.conf"
-  local hyprlock_bytes=0
-  [[ -f $hyprlock_conf ]] && hyprlock_bytes="$(wc -c <"$hyprlock_conf" | tr -d ' ')"
-  local gtk_theme_ini="" gtk_prefer_dark="" gtk_color_scheme=""
-  if [[ -f ${HOME}/.config/gtk-3.0/settings.ini ]]; then
-    gtk_theme_ini="$(grep -E '^gtk-theme-name=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-    gtk_prefer_dark="$(grep -E '^gtk-application-prefer-dark-theme=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-  fi
-  if command -v gsettings >/dev/null 2>&1; then
-    gtk_color_scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'\"" || true)"
-  fi
+	echo "=== dots-appearance doctor ==="
+	echo "rice.current   : ${qs_rice:-"(missing)"}"
+	echo "scheme.flavour : ${scheme_flavour:-"(missing)"}"
+	echo "state.flavour  : ${state_flavour:-"(missing)"}"
+	echo "scheme.mode    : ${scheme_mode:-"(missing)"}"
+	echo "state.mode     : ${state_mode:-"(missing)"}"
+	local hyprlock_conf="${HOME}/.cache/dots/smart-colors/colors-hyprlock.conf"
+	local hyprlock_bytes=0
+	[[ -f $hyprlock_conf ]] && hyprlock_bytes="$(wc -c <"$hyprlock_conf" | tr -d ' ')"
+	local gtk_theme_ini="" gtk_prefer_dark="" gtk_color_scheme=""
+	if [[ -f ${HOME}/.config/gtk-3.0/settings.ini ]]; then
+		gtk_theme_ini="$(grep -E '^gtk-theme-name=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+		gtk_prefer_dark="$(grep -E '^gtk-application-prefer-dark-theme=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+	fi
+	if command -v gsettings >/dev/null 2>&1; then
+		gtk_color_scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'\"" || true)"
+	fi
 
-  echo "wallpaper.ptr  : ${pointer_val:-"(missing)"}"
-  echo "wallpaper.res  : ${resolved:-"(missing)"}"
-  echo "wal.target     : ${wal_target:-"(missing)"}"
-  echo "hyprlock.conf  : ${hyprlock_bytes} bytes"
-  echo "gtk.theme.ini  : ${gtk_theme_ini:-"(missing)"}"
-  echo "gtk.preferDark : ${gtk_prefer_dark:-"(missing)"}"
-  echo "gtk.colorScheme: ${gtk_color_scheme:-"(missing)"}"
+	echo "wallpaper.ptr  : ${pointer_val:-"(missing)"}"
+	echo "wallpaper.res  : ${resolved:-"(missing)"}"
+	echo "wal.target     : ${wal_target:-"(missing)"}"
+	echo "hyprlock.conf  : ${hyprlock_bytes} bytes"
+	echo "gtk.theme.ini  : ${gtk_theme_ini:-"(missing)"}"
+	echo "gtk.preferDark : ${gtk_prefer_dark:-"(missing)"}"
+	echo "gtk.colorScheme: ${gtk_color_scheme:-"(missing)"}"
 
-  if [[ -z $qs_rice ]]; then
-    echo "FAIL: rice current pointer missing" >&2
-    ok=1
-  elif [[ ! -f "$HOME/.local/share/dots/rices/$qs_rice/config.json" ]]; then
-    echo "FAIL: rice config.json missing for $qs_rice" >&2
-    ok=1
-  fi
-  if [[ -e $HOME/.local/share/dots/rices/.current_rice || -e $HOME/.cache/dots/current_rice ]]; then
-    echo "FAIL: legacy rice pointer still present" >&2
-    ok=1
-  fi
-  if [[ -n $scheme_flavour && -n $state_flavour && $scheme_flavour != "$state_flavour" ]]; then
-    echo "FAIL: scheme flavour != state flavour ($scheme_flavour vs $state_flavour)" >&2
-    ok=1
-  fi
-  if [[ -n $scheme_mode && -n $state_mode && $scheme_mode != "$state_mode" ]]; then
-    echo "FAIL: scheme mode != state mode ($scheme_mode vs $state_mode)" >&2
-    ok=1
-  fi
-  if [[ -n $pointer_val && ! -f $pointer_val ]]; then
-    echo "FAIL: wallpaper pointer does not exist: $pointer_val" >&2
-    ok=1
-  fi
-  if [[ -n $pointer_val && -n $resolved && $pointer_val != "$resolved" ]]; then
-    local ptr_real res_real
-    ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
-    res_real="$(readlink -f "$resolved" 2>/dev/null || true)"
-    if [[ -n $ptr_real && -n $res_real && $ptr_real != "$res_real" ]]; then
-      echo "FAIL: pointer != dots-wallpaper-current ($pointer_val vs $resolved)" >&2
-      ok=1
-    fi
-  fi
-  if [[ -n $pointer_val && -f $pointer_val ]]; then
-    local ptr_real wal_real
-    ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
-    wal_real="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
-    if [[ -z $wal_real ]]; then
-      echo "FAIL: ~/.cache/wal/wal missing or broken" >&2
-      ok=1
-    elif [[ -n $ptr_real && $ptr_real != "$wal_real" ]]; then
-      echo "FAIL: wal target != wallpaper pointer ($wal_real vs $ptr_real)" >&2
-      ok=1
-    fi
-  fi
-  if [[ ! -f $hyprlock_conf || ${hyprlock_bytes:-0} -eq 0 ]]; then
-    echo "FAIL: colors-hyprlock.conf missing or empty" >&2
-    ok=1
-  fi
-  if [[ -f ${HOME}/.local/state/dots/wallpaper/path.txt ]]; then
-    echo "FAIL: orphan wallpaper/path.txt present (use wallpaper/path)" >&2
-    ok=1
-  fi
-  if [[ -f ${HOME}/.cache/dots/smart-colors/wallpaper ]]; then
-    echo "FAIL: orphan smart-colors/wallpaper cache present" >&2
-    ok=1
-  fi
-  if [[ -n $state_mode && -n $gtk_prefer_dark ]]; then
-    if [[ $state_mode == "dark" && $gtk_prefer_dark == "false" ]]; then
-      echo "FAIL: GTK prefer-dark=false while live mode is dark" >&2
-      ok=1
-    elif [[ $state_mode == "light" && $gtk_prefer_dark == "true" ]]; then
-      echo "FAIL: GTK prefer-dark=true while live mode is light" >&2
-      ok=1
-    fi
-  fi
-  if [[ -n $state_mode && -n $gtk_color_scheme ]]; then
-    if [[ $state_mode == "dark" && $gtk_color_scheme != "prefer-dark" ]]; then
-      echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is dark" >&2
-      ok=1
-    elif [[ $state_mode == "light" && $gtk_color_scheme != "prefer-light" ]]; then
-      echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is light" >&2
-      ok=1
-    fi
-  fi
-  if [[ -n $wal_target && -f $wal_target ]]; then
-    if ! file -b --mime-type "$wal_target" 2>/dev/null | grep -q '^image/'; then
-      echo "WARN: wal target is not an image: $wal_target" >&2
-    fi
-  fi
+	if [[ -z $qs_rice ]]; then
+		echo "FAIL: rice current pointer missing" >&2
+		ok=1
+	elif [[ ! -f "$HOME/.local/share/dots/rices/$qs_rice/config.json" ]]; then
+		echo "FAIL: rice config.json missing for $qs_rice" >&2
+		ok=1
+	fi
+	if [[ -e $HOME/.local/share/dots/rices/.current_rice || -e $HOME/.cache/dots/current_rice ]]; then
+		echo "FAIL: legacy rice pointer still present" >&2
+		ok=1
+	fi
+	if [[ -n $scheme_flavour && -n $state_flavour && $scheme_flavour != "$state_flavour" ]]; then
+		echo "FAIL: scheme flavour != state flavour ($scheme_flavour vs $state_flavour)" >&2
+		ok=1
+	fi
+	if [[ -n $scheme_mode && -n $state_mode && $scheme_mode != "$state_mode" ]]; then
+		echo "FAIL: scheme mode != state mode ($scheme_mode vs $state_mode)" >&2
+		ok=1
+	fi
+	if [[ -n $pointer_val && ! -f $pointer_val ]]; then
+		echo "FAIL: wallpaper pointer does not exist: $pointer_val" >&2
+		ok=1
+	fi
+	if [[ -n $pointer_val && -n $resolved && $pointer_val != "$resolved" ]]; then
+		local ptr_real res_real
+		ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
+		res_real="$(readlink -f "$resolved" 2>/dev/null || true)"
+		if [[ -n $ptr_real && -n $res_real && $ptr_real != "$res_real" ]]; then
+			echo "FAIL: pointer != dots-wallpaper-current ($pointer_val vs $resolved)" >&2
+			ok=1
+		fi
+	fi
+	if [[ -n $pointer_val && -f $pointer_val ]]; then
+		local ptr_real wal_real
+		ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
+		wal_real="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
+		if [[ -z $wal_real ]]; then
+			echo "FAIL: ~/.cache/wal/wal missing or broken" >&2
+			ok=1
+		elif [[ -n $ptr_real && $ptr_real != "$wal_real" ]]; then
+			echo "FAIL: wal target != wallpaper pointer ($wal_real vs $ptr_real)" >&2
+			ok=1
+		fi
+	fi
+	if [[ ! -f $hyprlock_conf || ${hyprlock_bytes:-0} -eq 0 ]]; then
+		echo "FAIL: colors-hyprlock.conf missing or empty" >&2
+		ok=1
+	fi
+	if [[ -f ${HOME}/.local/state/dots/wallpaper/path.txt ]]; then
+		echo "FAIL: orphan wallpaper/path.txt present (use wallpaper/path)" >&2
+		ok=1
+	fi
+	if [[ -f ${HOME}/.cache/dots/smart-colors/wallpaper ]]; then
+		echo "FAIL: orphan smart-colors/wallpaper cache present" >&2
+		ok=1
+	fi
+	if [[ -n $state_mode && -n $gtk_prefer_dark ]]; then
+		if [[ $state_mode == "dark" && $gtk_prefer_dark == "false" ]]; then
+			echo "FAIL: GTK prefer-dark=false while live mode is dark" >&2
+			ok=1
+		elif [[ $state_mode == "light" && $gtk_prefer_dark == "true" ]]; then
+			echo "FAIL: GTK prefer-dark=true while live mode is light" >&2
+			ok=1
+		fi
+	fi
+	if [[ -n $state_mode && -n $gtk_color_scheme ]]; then
+		if [[ $state_mode == "dark" && $gtk_color_scheme != "prefer-dark" ]]; then
+			echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is dark" >&2
+			ok=1
+		elif [[ $state_mode == "light" && $gtk_color_scheme != "prefer-light" ]]; then
+			echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is light" >&2
+			ok=1
+		fi
+	fi
+	if [[ -n $wal_target && -f $wal_target ]]; then
+		if ! file -b --mime-type "$wal_target" 2>/dev/null | grep -q '^image/'; then
+			echo "WARN: wal target is not an image: $wal_target" >&2
+		fi
+	fi
 
-  if [[ $ok -eq 0 ]]; then
-    echo "OK: appearance state is consistent"
-  else
-    echo "DONE: inconsistencies detected (exit $ok)"
-  fi
-  return "$ok"
+	if [[ $ok -eq 0 ]]; then
+		echo "OK: appearance state is consistent"
+	else
+		echo "DONE: inconsistencies detected (exit $ok)"
+	fi
+	return "$ok"
 }
 
 case "${cmd:-}" in
-  list) cmd_list ;;
-  current) cmd_current "${1:-}" ;;
-  apply) cmd_apply "$@" ;;
-  preview) cmd_preview "${1:-}" ;;
-  set-variant) cmd_set_variant "${1:-}" ;;
-  set-mode) cmd_set_mode "${1:-}" ;;
-  set-wallpaper) cmd_set_wallpaper "${1:-}" ;;
-  sync) cmd_sync ;;
-  doctor) cmd_doctor ;;
-  *)
-    cat <<'EOF' >&2
+list) cmd_list ;;
+current) cmd_current "${1:-}" ;;
+apply) cmd_apply "$@" ;;
+preview) cmd_preview "${1:-}" ;;
+set-variant) cmd_set_variant "${1:-}" ;;
+set-mode) cmd_set_mode "${1:-}" ;;
+set-wallpaper) cmd_set_wallpaper "${1:-}" ;;
+sync) cmd_sync ;;
+doctor) cmd_doctor ;;
+*)
+	cat <<'EOF' >&2
 Usage: dots-appearance <command> [args]
 
 Commands:
@@ -342,6 +342,6 @@ Commands:
   sync
   doctor
 EOF
-    exit 1
-    ;;
+	exit 1
+	;;
 esac

--- a/home/dot_local/bin/executable_dots-rice
+++ b/home/dot_local/bin/executable_dots-rice
@@ -26,7 +26,7 @@ source "$HOME/.local/lib/dots/rice-state.sh" 2>/dev/null || true
 RICES_DIR="${RICES_DIR:-${DOTS_RICES_DIR:-$HOME/.local/share/dots/rices}}"
 
 show_help() {
-  cat <<'EOF'
+	cat <<'EOF'
 Usage: dots-rice <command> [options]
 
 Commands:
@@ -39,126 +39,126 @@ EOF
 }
 
 cmd_selector() {
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    quickshell ipc call drawers toggle launcher
-    exit 0
-  fi
-  echo "Quickshell not running." >&2
-  cmd_list
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		quickshell ipc call drawers toggle launcher
+		exit 0
+	fi
+	echo "Quickshell not running." >&2
+	cmd_list
 }
 
 cmd_list() {
-  for rice_dir in "$RICES_DIR"/*/; do
-    [[ -d $rice_dir ]] || continue
-    basename "$rice_dir"
-  done
+	for rice_dir in "$RICES_DIR"/*/; do
+		[[ -d $rice_dir ]] || continue
+		basename "$rice_dir"
+	done
 }
 
 cmd_current() {
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    local id
-    id="$(quickshell ipc call rice current 2>/dev/null || true)"
-    id="${id//$'\r'/}"
-    id="${id//$'\n'/}"
-    case "$id" in
-      "" | "Target not found." | *"not found"* | *"error"* | *"Error"*) ;;
-      *)
-        printf '%s\n' "$id"
-        return
-        ;;
-    esac
-  fi
-  if declare -f dots_read_current_rice >/dev/null 2>&1; then
-    dots_read_current_rice
-  else
-    [[ -f ${DOTS_RICE_CANONICAL_FILE:-} ]] && cat "$DOTS_RICE_CANONICAL_FILE" || echo ""
-  fi
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		local id
+		id="$(quickshell ipc call rice current 2>/dev/null || true)"
+		id="${id//$'\r'/}"
+		id="${id//$'\n'/}"
+		case "$id" in
+		"" | "Target not found." | *"not found"* | *"error"* | *"Error"*) ;;
+		*)
+			printf '%s\n' "$id"
+			return
+			;;
+		esac
+	fi
+	if declare -f dots_read_current_rice >/dev/null 2>&1; then
+		dots_read_current_rice
+	else
+		[[ -f ${DOTS_RICE_CANONICAL_FILE:-} ]] && cat "$DOTS_RICE_CANONICAL_FILE" || echo ""
+	fi
 }
 
 _shell_apply() {
-  local rice_name="$1"
-  local wallpaper="${2:-}"
-  # shellcheck source=/dev/null
-  source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
-  # shellcheck source=/dev/null
-  source "$HOME/.local/lib/dots/apply-appearance.sh"
-  dots_apply_appearance "$rice_name" "$wallpaper"
+	local rice_name="$1"
+	local wallpaper="${2:-}"
+	# shellcheck source=/dev/null
+	source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
+	# shellcheck source=/dev/null
+	source "$HOME/.local/lib/dots/apply-appearance.sh"
+	dots_apply_appearance "$rice_name" "$wallpaper"
 }
 
 cmd_apply() {
-  local rice_name="${1:-}"
-  local wallpaper=""
-  shift 2>/dev/null || true
+	local rice_name="${1:-}"
+	local wallpaper=""
+	shift 2>/dev/null || true
 
-  while [[ $# -gt 0 ]]; do
-    case "${1:-}" in
-      --wallpaper)
-        wallpaper="${2:-}"
-        shift 2
-        ;;
-      *)
-        echo "Error: unknown argument: $1" >&2
-        exit 1
-        ;;
-    esac
-  done
+	while [[ $# -gt 0 ]]; do
+		case "${1:-}" in
+		--wallpaper)
+			wallpaper="${2:-}"
+			shift 2
+			;;
+		*)
+			echo "Error: unknown argument: $1" >&2
+			exit 1
+			;;
+		esac
+	done
 
-  [[ -n $rice_name ]] || {
-    echo "Error: rice name required" >&2
-    exit 1
-  }
-  [[ -d "$RICES_DIR/$rice_name" ]] || {
-    echo "Error: rice '$rice_name' not found" >&2
-    exit 1
-  }
+	[[ -n $rice_name ]] || {
+		echo "Error: rice name required" >&2
+		exit 1
+	}
+	[[ -d "$RICES_DIR/$rice_name" ]] || {
+		echo "Error: rice '$rice_name' not found" >&2
+		exit 1
+	}
 
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    local ipc_out=""
-    if ipc_out="$(quickshell ipc call rice apply "$rice_name" "${wallpaper:-}" 2>&1)"; then
-      case "$ipc_out" in
-        "Target not found."* | *"Target not found"*)
-          echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
-          ;;
-        *)
-          local _i busy last_error
-          for _i in $(seq 1 120); do
-            busy="$(quickshell ipc call rice isBusy 2>/dev/null || echo 0)"
-            [[ $busy == "1" ]] || break
-            sleep 0.5
-          done
-          last_error="$(quickshell ipc call rice lastError 2>/dev/null || true)"
-          last_error="${last_error//$'\r'/}"
-          last_error="${last_error//$'\n'/}"
-          if [[ -n $last_error ]]; then
-            echo "Error: rice apply failed: $last_error" >&2
-            exit 1
-          fi
-          exit 0
-          ;;
-      esac
-    else
-      echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
-    fi
-  fi
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		local ipc_out=""
+		if ipc_out="$(quickshell ipc call rice apply "$rice_name" "${wallpaper:-}" 2>&1)"; then
+			case "$ipc_out" in
+			"Target not found."* | *"Target not found"*)
+				echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
+				;;
+			*)
+				local _i busy last_error
+				for _i in $(seq 1 120); do
+					busy="$(quickshell ipc call rice isBusy 2>/dev/null || echo 0)"
+					[[ $busy == "1" ]] || break
+					sleep 0.5
+				done
+				last_error="$(quickshell ipc call rice lastError 2>/dev/null || true)"
+				last_error="${last_error//$'\r'/}"
+				last_error="${last_error//$'\n'/}"
+				if [[ -n $last_error ]]; then
+					echo "Error: rice apply failed: $last_error" >&2
+					exit 1
+				fi
+				exit 0
+				;;
+			esac
+		else
+			echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
+		fi
+	fi
 
-  _shell_apply "$rice_name" "$wallpaper"
+	_shell_apply "$rice_name" "$wallpaper"
 }
 
 case "${1:-help}" in
-  selector)
-    shift
-    cmd_selector "$@"
-    ;;
-  list) cmd_list ;;
-  current) cmd_current ;;
-  apply)
-    shift
-    cmd_apply "$@"
-    ;;
-  help | --help | -h) show_help ;;
-  *)
-    echo "Unknown command: $1" >&2
-    echo "Run 'dots-rice help' for usage" >&2
-    exit 1
-    ;;
+selector)
+	shift
+	cmd_selector "$@"
+	;;
+list) cmd_list ;;
+current) cmd_current ;;
+apply)
+	shift
+	cmd_apply "$@"
+	;;
+help | --help | -h) show_help ;;
+*)
+	echo "Unknown command: $1" >&2
+	echo "Run 'dots-rice help' for usage" >&2
+	exit 1
+	;;
 esac

--- a/home/dot_local/bin/executable_dots-rice
+++ b/home/dot_local/bin/executable_dots-rice
@@ -26,7 +26,7 @@ source "$HOME/.local/lib/dots/rice-state.sh" 2>/dev/null || true
 RICES_DIR="${RICES_DIR:-${DOTS_RICES_DIR:-$HOME/.local/share/dots/rices}}"
 
 show_help() {
-	cat <<'EOF'
+  cat <<'EOF'
 Usage: dots-rice <command> [options]
 
 Commands:
@@ -39,126 +39,139 @@ EOF
 }
 
 cmd_selector() {
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		quickshell ipc call drawers toggle launcher
-		exit 0
-	fi
-	echo "Quickshell not running." >&2
-	cmd_list
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    quickshell ipc call drawers toggle launcher
+    exit 0
+  fi
+  echo "Quickshell not running." >&2
+  cmd_list
 }
 
 cmd_list() {
-	for rice_dir in "$RICES_DIR"/*/; do
-		[[ -d $rice_dir ]] || continue
-		basename "$rice_dir"
-	done
+  for rice_dir in "$RICES_DIR"/*/; do
+    [[ -d $rice_dir ]] || continue
+    basename "$rice_dir"
+  done
 }
 
 cmd_current() {
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		local id
-		id="$(quickshell ipc call rice current 2>/dev/null || true)"
-		id="${id//$'\r'/}"
-		id="${id//$'\n'/}"
-		case "$id" in
-		"" | "Target not found." | *"not found"* | *"error"* | *"Error"*) ;;
-		*)
-			printf '%s\n' "$id"
-			return
-			;;
-		esac
-	fi
-	if declare -f dots_read_current_rice >/dev/null 2>&1; then
-		dots_read_current_rice
-	else
-		[[ -f ${DOTS_RICE_CANONICAL_FILE:-} ]] && cat "$DOTS_RICE_CANONICAL_FILE" || echo ""
-	fi
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    local id
+    id="$(quickshell ipc call rice current 2>/dev/null || true)"
+    id="${id//$'\r'/}"
+    id="${id//$'\n'/}"
+    case "$id" in
+      "" | "Target not found." | *"not found"* | *"error"* | *"Error"*) ;;
+      *)
+        printf '%s\n' "$id"
+        return
+        ;;
+    esac
+  fi
+  if declare -f dots_read_current_rice >/dev/null 2>&1; then
+    dots_read_current_rice
+  else
+    [[ -f ${DOTS_RICE_CANONICAL_FILE:-} ]] && cat "$DOTS_RICE_CANONICAL_FILE" || echo ""
+  fi
 }
 
 _shell_apply() {
-	local rice_name="$1"
-	local wallpaper="${2:-}"
-	# shellcheck source=/dev/null
-	source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
-	# shellcheck source=/dev/null
-	source "$HOME/.local/lib/dots/apply-appearance.sh"
-	dots_apply_appearance "$rice_name" "$wallpaper"
+  local rice_name="$1"
+  local wallpaper="${2:-}"
+  # shellcheck source=/dev/null
+  source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
+  # shellcheck source=/dev/null
+  source "$HOME/.local/lib/dots/apply-appearance.sh"
+  dots_apply_appearance "$rice_name" "$wallpaper"
 }
 
 cmd_apply() {
-	local rice_name="${1:-}"
-	local wallpaper=""
-	shift 2>/dev/null || true
+  local rice_name="${1:-}"
+  local wallpaper=""
+  shift 2>/dev/null || true
 
-	while [[ $# -gt 0 ]]; do
-		case "${1:-}" in
-		--wallpaper)
-			wallpaper="${2:-}"
-			shift 2
-			;;
-		*)
-			echo "Error: unknown argument: $1" >&2
-			exit 1
-			;;
-		esac
-	done
+  while [[ $# -gt 0 ]]; do
+    case "${1:-}" in
+      --wallpaper)
+        [[ -n ${2:-} ]] || {
+          echo "Error: --wallpaper requires a path" >&2
+          exit 1
+        }
+        wallpaper="$2"
+        shift 2
+        ;;
+      *)
+        echo "Error: unknown argument: $1" >&2
+        exit 1
+        ;;
+    esac
+  done
 
-	[[ -n $rice_name ]] || {
-		echo "Error: rice name required" >&2
-		exit 1
-	}
-	[[ -d "$RICES_DIR/$rice_name" ]] || {
-		echo "Error: rice '$rice_name' not found" >&2
-		exit 1
-	}
+  [[ -n $rice_name ]] || {
+    echo "Error: rice name required" >&2
+    exit 1
+  }
+  [[ -d "$RICES_DIR/$rice_name" ]] || {
+    echo "Error: rice '$rice_name' not found" >&2
+    exit 1
+  }
 
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		local ipc_out=""
-		if ipc_out="$(quickshell ipc call rice apply "$rice_name" "${wallpaper:-}" 2>&1)"; then
-			case "$ipc_out" in
-			"Target not found."* | *"Target not found"*)
-				echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
-				;;
-			*)
-				local _i busy last_error
-				for _i in $(seq 1 120); do
-					busy="$(quickshell ipc call rice isBusy 2>/dev/null || echo 0)"
-					[[ $busy == "1" ]] || break
-					sleep 0.5
-				done
-				last_error="$(quickshell ipc call rice lastError 2>/dev/null || true)"
-				last_error="${last_error//$'\r'/}"
-				last_error="${last_error//$'\n'/}"
-				if [[ -n $last_error ]]; then
-					echo "Error: rice apply failed: $last_error" >&2
-					exit 1
-				fi
-				exit 0
-				;;
-			esac
-		else
-			echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
-		fi
-	fi
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    local ipc_out=""
+    if ipc_out="$(quickshell ipc call rice apply "$rice_name" "${wallpaper:-}" 2>&1)"; then
+      case "$ipc_out" in
+        "Target not found."* | *"Target not found"*)
+          echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
+          ;;
+        *)
+          local _i busy="" last_error
+          for _i in $(seq 1 120); do
+            if ! busy="$(quickshell ipc call rice isBusy 2>/dev/null)"; then
+              echo "Error: failed to poll rice isBusy via Quickshell IPC" >&2
+              exit 1
+            fi
+            busy="${busy//$'\r'/}"
+            busy="${busy//$'\n'/}"
+            [[ $busy == "1" ]] || break
+            sleep 0.5
+          done
+          if [[ $busy == "1" ]]; then
+            echo "Error: rice apply timed out waiting for Quickshell" >&2
+            exit 1
+          fi
+          last_error="$(quickshell ipc call rice lastError 2>/dev/null || true)"
+          last_error="${last_error//$'\r'/}"
+          last_error="${last_error//$'\n'/}"
+          if [[ -n $last_error ]]; then
+            echo "Error: rice apply failed: $last_error" >&2
+            exit 1
+          fi
+          exit 0
+          ;;
+      esac
+    else
+      echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
+    fi
+  fi
 
-	_shell_apply "$rice_name" "$wallpaper"
+  _shell_apply "$rice_name" "$wallpaper"
 }
 
 case "${1:-help}" in
-selector)
-	shift
-	cmd_selector "$@"
-	;;
-list) cmd_list ;;
-current) cmd_current ;;
-apply)
-	shift
-	cmd_apply "$@"
-	;;
-help | --help | -h) show_help ;;
-*)
-	echo "Unknown command: $1" >&2
-	echo "Run 'dots-rice help' for usage" >&2
-	exit 1
-	;;
+  selector)
+    shift
+    cmd_selector "$@"
+    ;;
+  list) cmd_list ;;
+  current) cmd_current ;;
+  apply)
+    shift
+    cmd_apply "$@"
+    ;;
+  help | --help | -h) show_help ;;
+  *)
+    echo "Unknown command: $1" >&2
+    echo "Run 'dots-rice help' for usage" >&2
+    exit 1
+    ;;
 esac

--- a/home/dot_local/bin/executable_dots-rice
+++ b/home/dot_local/bin/executable_dots-rice
@@ -26,7 +26,7 @@ source "$HOME/.local/lib/dots/rice-state.sh" 2>/dev/null || true
 RICES_DIR="${RICES_DIR:-${DOTS_RICES_DIR:-$HOME/.local/share/dots/rices}}"
 
 show_help() {
-	cat <<'EOF'
+  cat <<'EOF'
 Usage: dots-rice <command> [options]
 
 Commands:
@@ -39,111 +39,126 @@ EOF
 }
 
 cmd_selector() {
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		quickshell ipc call drawers toggle launcher
-		exit 0
-	fi
-	echo "Quickshell not running." >&2
-	cmd_list
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    quickshell ipc call drawers toggle launcher
+    exit 0
+  fi
+  echo "Quickshell not running." >&2
+  cmd_list
 }
 
 cmd_list() {
-	for rice_dir in "$RICES_DIR"/*/; do
-		[[ -d $rice_dir ]] || continue
-		basename "$rice_dir"
-	done
+  for rice_dir in "$RICES_DIR"/*/; do
+    [[ -d $rice_dir ]] || continue
+    basename "$rice_dir"
+  done
 }
 
 cmd_current() {
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		local id
-		id="$(quickshell ipc call rice current 2>/dev/null || true)"
-		id="${id//$'\r'/}"
-		id="${id//$'\n'/}"
-		case "$id" in
-		"" | "Target not found." | *"not found"* | *"error"* | *"Error"*) ;;
-		*)
-			printf '%s\n' "$id"
-			return
-			;;
-		esac
-	fi
-	if declare -f dots_read_current_rice >/dev/null 2>&1; then
-		dots_read_current_rice
-	else
-		[[ -f ${DOTS_RICE_CANONICAL_FILE:-} ]] && cat "$DOTS_RICE_CANONICAL_FILE" || echo ""
-	fi
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    local id
+    id="$(quickshell ipc call rice current 2>/dev/null || true)"
+    id="${id//$'\r'/}"
+    id="${id//$'\n'/}"
+    case "$id" in
+      "" | "Target not found." | *"not found"* | *"error"* | *"Error"*) ;;
+      *)
+        printf '%s\n' "$id"
+        return
+        ;;
+    esac
+  fi
+  if declare -f dots_read_current_rice >/dev/null 2>&1; then
+    dots_read_current_rice
+  else
+    [[ -f ${DOTS_RICE_CANONICAL_FILE:-} ]] && cat "$DOTS_RICE_CANONICAL_FILE" || echo ""
+  fi
 }
 
 _shell_apply() {
-	local rice_name="$1"
-	local wallpaper="${2:-}"
-	# shellcheck source=/dev/null
-	source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
-	# shellcheck source=/dev/null
-	source "$HOME/.local/lib/dots/apply-appearance.sh"
-	dots_apply_appearance "$rice_name" "$wallpaper"
+  local rice_name="$1"
+  local wallpaper="${2:-}"
+  # shellcheck source=/dev/null
+  source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
+  # shellcheck source=/dev/null
+  source "$HOME/.local/lib/dots/apply-appearance.sh"
+  dots_apply_appearance "$rice_name" "$wallpaper"
 }
 
 cmd_apply() {
-	local rice_name="${1:-}"
-	local wallpaper=""
-	shift 2>/dev/null || true
+  local rice_name="${1:-}"
+  local wallpaper=""
+  shift 2>/dev/null || true
 
-	while [[ $# -gt 0 ]]; do
-		case "${1:-}" in
-		--wallpaper)
-			wallpaper="${2:-}"
-			shift 2
-			;;
-		*) shift ;;
-		esac
-	done
+  while [[ $# -gt 0 ]]; do
+    case "${1:-}" in
+      --wallpaper)
+        wallpaper="${2:-}"
+        shift 2
+        ;;
+      *)
+        echo "Error: unknown argument: $1" >&2
+        exit 1
+        ;;
+    esac
+  done
 
-	[[ -n $rice_name ]] || {
-		echo "Error: rice name required" >&2
-		exit 1
-	}
-	[[ -d "$RICES_DIR/$rice_name" ]] || {
-		echo "Error: rice '$rice_name' not found" >&2
-		exit 1
-	}
+  [[ -n $rice_name ]] || {
+    echo "Error: rice name required" >&2
+    exit 1
+  }
+  [[ -d "$RICES_DIR/$rice_name" ]] || {
+    echo "Error: rice '$rice_name' not found" >&2
+    exit 1
+  }
 
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		local ipc_out=""
-		if ipc_out="$(quickshell ipc call rice apply "$rice_name" "${wallpaper:-}" 2>&1)"; then
-			case "$ipc_out" in
-			*"not found"* | *"Error"* | *"error"*)
-				echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
-				;;
-			*)
-				# Persist happens inside Quickshell after wal/M3 succeed.
-				exit 0
-				;;
-			esac
-		else
-			echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
-		fi
-	fi
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    local ipc_out=""
+    if ipc_out="$(quickshell ipc call rice apply "$rice_name" "${wallpaper:-}" 2>&1)"; then
+      case "$ipc_out" in
+        "Target not found."* | *"Target not found"*)
+          echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
+          ;;
+        *)
+          local _i busy last_error
+          for _i in $(seq 1 120); do
+            busy="$(quickshell ipc call rice isBusy 2>/dev/null || echo 0)"
+            [[ $busy == "1" ]] || break
+            sleep 0.5
+          done
+          last_error="$(quickshell ipc call rice lastError 2>/dev/null || true)"
+          last_error="${last_error//$'\r'/}"
+          last_error="${last_error//$'\n'/}"
+          if [[ -n $last_error ]]; then
+            echo "Error: rice apply failed: $last_error" >&2
+            exit 1
+          fi
+          exit 0
+          ;;
+      esac
+    else
+      echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
+    fi
+  fi
 
-	_shell_apply "$rice_name" "$wallpaper"
+  _shell_apply "$rice_name" "$wallpaper"
 }
 
 case "${1:-help}" in
-selector)
-	shift
-	cmd_selector "$@"
-	;;
-list) cmd_list ;;
-current) cmd_current ;;
-apply)
-	shift
-	cmd_apply "$@"
-	;;
-help | --help | -h) show_help ;;
-*)
-	echo "Unknown command: $1" >&2
-	echo "Run 'dots-rice help' for usage" >&2
-	exit 1
-	;;
+  selector)
+    shift
+    cmd_selector "$@"
+    ;;
+  list) cmd_list ;;
+  current) cmd_current ;;
+  apply)
+    shift
+    cmd_apply "$@"
+    ;;
+  help | --help | -h) show_help ;;
+  *)
+    echo "Unknown command: $1" >&2
+    echo "Run 'dots-rice help' for usage" >&2
+    exit 1
+    ;;
 esac

--- a/home/dot_local/bin/executable_dots-rice
+++ b/home/dot_local/bin/executable_dots-rice
@@ -26,7 +26,7 @@ source "$HOME/.local/lib/dots/rice-state.sh" 2>/dev/null || true
 RICES_DIR="${RICES_DIR:-${DOTS_RICES_DIR:-$HOME/.local/share/dots/rices}}"
 
 show_help() {
-  cat <<'EOF'
+	cat <<'EOF'
 Usage: dots-rice <command> [options]
 
 Commands:
@@ -39,139 +39,139 @@ EOF
 }
 
 cmd_selector() {
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    quickshell ipc call drawers toggle launcher
-    exit 0
-  fi
-  echo "Quickshell not running." >&2
-  cmd_list
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		quickshell ipc call drawers toggle launcher
+		exit 0
+	fi
+	echo "Quickshell not running." >&2
+	cmd_list
 }
 
 cmd_list() {
-  for rice_dir in "$RICES_DIR"/*/; do
-    [[ -d $rice_dir ]] || continue
-    basename "$rice_dir"
-  done
+	for rice_dir in "$RICES_DIR"/*/; do
+		[[ -d $rice_dir ]] || continue
+		basename "$rice_dir"
+	done
 }
 
 cmd_current() {
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    local id
-    id="$(quickshell ipc call rice current 2>/dev/null || true)"
-    id="${id//$'\r'/}"
-    id="${id//$'\n'/}"
-    case "$id" in
-      "" | "Target not found." | *"not found"* | *"error"* | *"Error"*) ;;
-      *)
-        printf '%s\n' "$id"
-        return
-        ;;
-    esac
-  fi
-  if declare -f dots_read_current_rice >/dev/null 2>&1; then
-    dots_read_current_rice
-  else
-    [[ -f ${DOTS_RICE_CANONICAL_FILE:-} ]] && cat "$DOTS_RICE_CANONICAL_FILE" || echo ""
-  fi
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		local id
+		id="$(quickshell ipc call rice current 2>/dev/null || true)"
+		id="${id//$'\r'/}"
+		id="${id//$'\n'/}"
+		case "$id" in
+		"" | "Target not found." | *"not found"* | *"error"* | *"Error"*) ;;
+		*)
+			printf '%s\n' "$id"
+			return
+			;;
+		esac
+	fi
+	if declare -f dots_read_current_rice >/dev/null 2>&1; then
+		dots_read_current_rice
+	else
+		[[ -f ${DOTS_RICE_CANONICAL_FILE:-} ]] && cat "$DOTS_RICE_CANONICAL_FILE" || echo ""
+	fi
 }
 
 _shell_apply() {
-  local rice_name="$1"
-  local wallpaper="${2:-}"
-  # shellcheck source=/dev/null
-  source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
-  # shellcheck source=/dev/null
-  source "$HOME/.local/lib/dots/apply-appearance.sh"
-  dots_apply_appearance "$rice_name" "$wallpaper"
+	local rice_name="$1"
+	local wallpaper="${2:-}"
+	# shellcheck source=/dev/null
+	source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
+	# shellcheck source=/dev/null
+	source "$HOME/.local/lib/dots/apply-appearance.sh"
+	dots_apply_appearance "$rice_name" "$wallpaper"
 }
 
 cmd_apply() {
-  local rice_name="${1:-}"
-  local wallpaper=""
-  shift 2>/dev/null || true
+	local rice_name="${1:-}"
+	local wallpaper=""
+	shift 2>/dev/null || true
 
-  while [[ $# -gt 0 ]]; do
-    case "${1:-}" in
-      --wallpaper)
-        [[ -n ${2:-} ]] || {
-          echo "Error: --wallpaper requires a path" >&2
-          exit 1
-        }
-        wallpaper="$2"
-        shift 2
-        ;;
-      *)
-        echo "Error: unknown argument: $1" >&2
-        exit 1
-        ;;
-    esac
-  done
+	while [[ $# -gt 0 ]]; do
+		case "${1:-}" in
+		--wallpaper)
+			[[ -n ${2:-} ]] || {
+				echo "Error: --wallpaper requires a path" >&2
+				exit 1
+			}
+			wallpaper="$2"
+			shift 2
+			;;
+		*)
+			echo "Error: unknown argument: $1" >&2
+			exit 1
+			;;
+		esac
+	done
 
-  [[ -n $rice_name ]] || {
-    echo "Error: rice name required" >&2
-    exit 1
-  }
-  [[ -d "$RICES_DIR/$rice_name" ]] || {
-    echo "Error: rice '$rice_name' not found" >&2
-    exit 1
-  }
+	[[ -n $rice_name ]] || {
+		echo "Error: rice name required" >&2
+		exit 1
+	}
+	[[ -d "$RICES_DIR/$rice_name" ]] || {
+		echo "Error: rice '$rice_name' not found" >&2
+		exit 1
+	}
 
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    local ipc_out=""
-    if ipc_out="$(quickshell ipc call rice apply "$rice_name" "${wallpaper:-}" 2>&1)"; then
-      case "$ipc_out" in
-        "Target not found."* | *"Target not found"*)
-          echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
-          ;;
-        *)
-          local _i busy="" last_error
-          for _i in $(seq 1 120); do
-            if ! busy="$(quickshell ipc call rice isBusy 2>/dev/null)"; then
-              echo "Error: failed to poll rice isBusy via Quickshell IPC" >&2
-              exit 1
-            fi
-            busy="${busy//$'\r'/}"
-            busy="${busy//$'\n'/}"
-            [[ $busy == "1" ]] || break
-            sleep 0.5
-          done
-          if [[ $busy == "1" ]]; then
-            echo "Error: rice apply timed out waiting for Quickshell" >&2
-            exit 1
-          fi
-          last_error="$(quickshell ipc call rice lastError 2>/dev/null || true)"
-          last_error="${last_error//$'\r'/}"
-          last_error="${last_error//$'\n'/}"
-          if [[ -n $last_error ]]; then
-            echo "Error: rice apply failed: $last_error" >&2
-            exit 1
-          fi
-          exit 0
-          ;;
-      esac
-    else
-      echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
-    fi
-  fi
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		local ipc_out=""
+		if ipc_out="$(quickshell ipc call rice apply "$rice_name" "${wallpaper:-}" 2>&1)"; then
+			case "$ipc_out" in
+			"Target not found."* | *"Target not found"*)
+				echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
+				;;
+			*)
+				local _i busy="" last_error
+				for _i in $(seq 1 120); do
+					if ! busy="$(quickshell ipc call rice isBusy 2>/dev/null)"; then
+						echo "Error: failed to poll rice isBusy via Quickshell IPC" >&2
+						exit 1
+					fi
+					busy="${busy//$'\r'/}"
+					busy="${busy//$'\n'/}"
+					[[ $busy == "1" ]] || break
+					sleep 0.5
+				done
+				if [[ $busy == "1" ]]; then
+					echo "Error: rice apply timed out waiting for Quickshell" >&2
+					exit 1
+				fi
+				last_error="$(quickshell ipc call rice lastError 2>/dev/null || true)"
+				last_error="${last_error//$'\r'/}"
+				last_error="${last_error//$'\n'/}"
+				if [[ -n $last_error ]]; then
+					echo "Error: rice apply failed: $last_error" >&2
+					exit 1
+				fi
+				exit 0
+				;;
+			esac
+		else
+			echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
+		fi
+	fi
 
-  _shell_apply "$rice_name" "$wallpaper"
+	_shell_apply "$rice_name" "$wallpaper"
 }
 
 case "${1:-help}" in
-  selector)
-    shift
-    cmd_selector "$@"
-    ;;
-  list) cmd_list ;;
-  current) cmd_current ;;
-  apply)
-    shift
-    cmd_apply "$@"
-    ;;
-  help | --help | -h) show_help ;;
-  *)
-    echo "Unknown command: $1" >&2
-    echo "Run 'dots-rice help' for usage" >&2
-    exit 1
-    ;;
+selector)
+	shift
+	cmd_selector "$@"
+	;;
+list) cmd_list ;;
+current) cmd_current ;;
+apply)
+	shift
+	cmd_apply "$@"
+	;;
+help | --help | -h) show_help ;;
+*)
+	echo "Unknown command: $1" >&2
+	echo "Run 'dots-rice help' for usage" >&2
+	exit 1
+	;;
 esac

--- a/home/dot_local/lib/dots/gtk-theme-manager.sh
+++ b/home/dot_local/lib/dots/gtk-theme-manager.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 # Source smart colors for theme detection
 if [[ -f "$HOME/.local/lib/dots/smart-colors.sh" ]]; then
-  source "$HOME/.local/lib/dots/smart-colors.sh"
+	source "$HOME/.local/lib/dots/smart-colors.sh"
 fi
 
 # GTK configuration paths
@@ -28,120 +28,120 @@ readonly GTK3_CONFIG="$HOME/.config/gtk-3.0/settings.ini"
 
 # Function to log messages
 log() {
-  local level="$1"
-  shift
-  local message="$*"
-  local timestamp
-  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+	local level="$1"
+	shift
+	local message="$*"
+	local timestamp
+	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-  echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
+	echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
 }
 
 # Function to check if a GTK theme is installed
 is_gtk_theme_installed() {
-  local theme_name="$1"
+	local theme_name="$1"
 
-  # Check in common theme directories
-  local theme_dirs=(
-    "/usr/share/themes"
-    "/usr/local/share/themes"
-    "$HOME/.themes"
-    "$HOME/.local/share/themes"
-  )
+	# Check in common theme directories
+	local theme_dirs=(
+		"/usr/share/themes"
+		"/usr/local/share/themes"
+		"$HOME/.themes"
+		"$HOME/.local/share/themes"
+	)
 
-  for theme_dir in "${theme_dirs[@]}"; do
-    if [[ -d "$theme_dir/$theme_name" ]]; then
-      return 0
-    fi
-  done
+	for theme_dir in "${theme_dirs[@]}"; do
+		if [[ -d "$theme_dir/$theme_name" ]]; then
+			return 0
+		fi
+	done
 
-  return 1
+	return 1
 }
 
 # Function to check if an icon theme is installed
 is_icon_theme_installed() {
-  local icon_theme="$1"
+	local icon_theme="$1"
 
-  # Check in common icon directories
-  local icon_dirs=(
-    "/usr/share/icons"
-    "/usr/local/share/icons"
-    "$HOME/.icons"
-    "$HOME/.local/share/icons"
-  )
+	# Check in common icon directories
+	local icon_dirs=(
+		"/usr/share/icons"
+		"/usr/local/share/icons"
+		"$HOME/.icons"
+		"$HOME/.local/share/icons"
+	)
 
-  for icon_dir in "${icon_dirs[@]}"; do
-    if [[ -d "$icon_dir/$icon_theme" ]]; then
-      return 0
-    fi
-  done
+	for icon_dir in "${icon_dirs[@]}"; do
+		if [[ -d "$icon_dir/$icon_theme" ]]; then
+			return 0
+		fi
+	done
 
-  return 1
+	return 1
 }
 
 # Function to apply GTK theme with fallbacks
 apply_gtk_theme() {
-  local gtk_theme="$1"
-  local icon_theme="${2:-elementary}"
-  local prefer_dark="${3:-false}"
+	local gtk_theme="$1"
+	local icon_theme="${2:-elementary}"
+	local prefer_dark="${3:-false}"
 
-  log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
+	log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
 
-  # Validate theme availability with fallbacks
-  if ! is_gtk_theme_installed "$gtk_theme"; then
-    log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
+	# Validate theme availability with fallbacks
+	if ! is_gtk_theme_installed "$gtk_theme"; then
+		log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
 
-    # Common fallback themes in order of preference
-    local fallback_themes=(
-      "Orchis-Light"
-      "elementary"
-      "Arc-Dark"
-      "Arc"
-      "Breeze"
-      "oxygen-gtk"
-    )
+		# Common fallback themes in order of preference
+		local fallback_themes=(
+			"Orchis-Light"
+			"elementary"
+			"Arc-Dark"
+			"Arc"
+			"Breeze"
+			"oxygen-gtk"
+		)
 
-    for fallback in "${fallback_themes[@]}"; do
-      if is_gtk_theme_installed "$fallback"; then
-        gtk_theme="$fallback"
-        log "INFO" "Using fallback theme: $gtk_theme"
-        break
-      fi
-    done
+		for fallback in "${fallback_themes[@]}"; do
+			if is_gtk_theme_installed "$fallback"; then
+				gtk_theme="$fallback"
+				log "INFO" "Using fallback theme: $gtk_theme"
+				break
+			fi
+		done
 
-    if ! is_gtk_theme_installed "$gtk_theme"; then
-      log "ERROR" "No suitable GTK theme found, keeping current theme"
-      return 1
-    fi
-  fi
+		if ! is_gtk_theme_installed "$gtk_theme"; then
+			log "ERROR" "No suitable GTK theme found, keeping current theme"
+			return 1
+		fi
+	fi
 
-  # Validate icon theme with fallbacks
-  if ! is_icon_theme_installed "$icon_theme"; then
-    log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
+	# Validate icon theme with fallbacks
+	if ! is_icon_theme_installed "$icon_theme"; then
+		log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
 
-    local fallback_icons=(
-      "Numix-Circle"
-      "elementary"
-      "hicolor"
-    )
+		local fallback_icons=(
+			"Numix-Circle"
+			"elementary"
+			"hicolor"
+		)
 
-    for fallback in "${fallback_icons[@]}"; do
-      if is_icon_theme_installed "$fallback"; then
-        icon_theme="$fallback"
-        log "INFO" "Using fallback icon theme: $icon_theme"
-        break
-      fi
-    done
-  fi
+		for fallback in "${fallback_icons[@]}"; do
+			if is_icon_theme_installed "$fallback"; then
+				icon_theme="$fallback"
+				log "INFO" "Using fallback icon theme: $icon_theme"
+				break
+			fi
+		done
+	fi
 
-  # Update GTK2 configuration
-  if [[ -f $GTK2_CONFIG ]]; then
-    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
-    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
-    log "INFO" "Updated GTK2 configuration"
-  else
-    log "WARN" "GTK2 config not found, creating basic configuration"
-    cat >"$GTK2_CONFIG" <<EOF
+	# Update GTK2 configuration
+	if [[ -f $GTK2_CONFIG ]]; then
+		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
+		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
+		log "INFO" "Updated GTK2 configuration"
+	else
+		log "WARN" "GTK2 config not found, creating basic configuration"
+		cat > "$GTK2_CONFIG" << EOF
 # DO NOT EDIT! This file will be overwritten by LXAppearance.
 # Any customization should be done in ~/.gtkrc-2.0.mine instead.
 
@@ -162,18 +162,18 @@ gtk-xft-hinting=1
 gtk-xft-hintstyle="hintslight"
 gtk-xft-rgba="rgb"
 EOF
-  fi
+	fi
 
-  # Update GTK3 configuration
-  if [[ -f $GTK3_CONFIG ]]; then
-    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
-    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
-    sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-    log "INFO" "Updated GTK3 configuration"
-  else
-    log "WARN" "GTK3 config not found, creating configuration"
-    mkdir -p "$(dirname "$GTK3_CONFIG")"
-    cat >"$GTK3_CONFIG" <<EOF
+	# Update GTK3 configuration
+	if [[ -f $GTK3_CONFIG ]]; then
+		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
+		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
+		sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+		log "INFO" "Updated GTK3 configuration"
+	else
+		log "WARN" "GTK3 config not found, creating configuration"
+		mkdir -p "$(dirname "$GTK3_CONFIG")"
+		cat > "$GTK3_CONFIG" << EOF
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 gtk-theme-name=$gtk_theme
@@ -193,319 +193,319 @@ gtk-xft-hintstyle=hintslight
 gtk-xft-rgba=rgb
 gtk-modules=colorreload-gtk-module
 EOF
-  fi
+	fi
 
-  # Notify running GTK applications to reload themes
-  if command -v gsettings >/dev/null 2>&1; then
-    gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2>/dev/null || true
-    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2>/dev/null || true
-    # Older schemas expose this key; portals/libadwaita use color-scheme instead.
-    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
-    log "INFO" "Updated gsettings"
-  fi
+	# Notify running GTK applications to reload themes
+	if command -v gsettings > /dev/null 2>&1; then
+		gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2> /dev/null || true
+		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2> /dev/null || true
+		# Older schemas expose this key; portals/libadwaita use color-scheme instead.
+		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
+		log "INFO" "Updated gsettings"
+	fi
 
-  # Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
-  if [[ $prefer_dark == "true" ]]; then
-    apply_gtk_color_scheme dark
-  else
-    apply_gtk_color_scheme light
-  fi
+	# Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
+	if [[ $prefer_dark == "true" ]]; then
+		apply_gtk_color_scheme dark
+	else
+		apply_gtk_color_scheme light
+	fi
 
-  # XFCE4 settings support removed - using gsettings only
-  # If running XFCE4 session, gsettings should be sufficient
-  # Legacy xfconf-query support can be re-enabled if needed
+	# XFCE4 settings support removed - using gsettings only
+	# If running XFCE4 session, gsettings should be sufficient
+	# Legacy xfconf-query support can be re-enabled if needed
 
-  log "INFO" "GTK theme applied successfully: $gtk_theme"
-  return 0
+	log "INFO" "GTK theme applied successfully: $gtk_theme"
+	return 0
 }
 
 # Sync GTK/libadwaita light-dark preference without changing the theme name.
 # mode: "dark" | "light"
 apply_gtk_color_scheme() {
-  local mode="${1:-dark}"
-  local prefer_dark="true"
-  local color_scheme="prefer-dark"
-  if [[ $mode == "light" ]]; then
-    prefer_dark="false"
-    color_scheme="prefer-light"
-  elif [[ $mode != "dark" ]]; then
-    log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
-    return 1
-  fi
+	local mode="${1:-dark}"
+	local prefer_dark="true"
+	local color_scheme="prefer-dark"
+	if [[ $mode == "light" ]]; then
+		prefer_dark="false"
+		color_scheme="prefer-light"
+	elif [[ $mode != "dark" ]]; then
+		log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
+		return 1
+	fi
 
-  if [[ -f $GTK3_CONFIG ]]; then
-    if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2>/dev/null; then
-      sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-    else
-      printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >>"$GTK3_CONFIG"
-    fi
-  else
-    mkdir -p "$(dirname "$GTK3_CONFIG")" || {
-      log "ERROR" "Failed to create directory for $GTK3_CONFIG"
-      return 1
-    }
-    if ! cat >"$GTK3_CONFIG" <<EOF; then
+	if [[ -f $GTK3_CONFIG ]]; then
+		if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2> /dev/null; then
+			sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+		else
+			printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >> "$GTK3_CONFIG"
+		fi
+	else
+		mkdir -p "$(dirname "$GTK3_CONFIG")" || {
+			log "ERROR" "Failed to create directory for $GTK3_CONFIG"
+			return 1
+		}
+		if ! cat > "$GTK3_CONFIG" << EOF; then
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 EOF
-      log "ERROR" "Failed to write $GTK3_CONFIG"
-      return 1
-    fi
-    log "INFO" "Created GTK3 config for color-scheme sync"
-  fi
+			log "ERROR" "Failed to write $GTK3_CONFIG"
+			return 1
+		fi
+		log "INFO" "Created GTK3 config for color-scheme sync"
+	fi
 
-  if command -v gsettings >/dev/null 2>&1; then
-    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
-    gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" >/dev/null 2>&1 || true
-  fi
-  log "INFO" "GTK color-scheme set to $color_scheme"
-  return 0
+	if command -v gsettings > /dev/null 2>&1; then
+		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
+		gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" > /dev/null 2>&1 || true
+	fi
+	log "INFO" "GTK color-scheme set to $color_scheme"
+	return 0
 }
 
 # Function to detect optimal GTK theme based on wallpaper colors
 detect_optimal_gtk_theme() {
-  local wallpaper_path="$1"
-  local detected_theme="Orchis-Light" # Default
-  local prefer_dark="false"
+	local wallpaper_path="$1"
+	local detected_theme="Orchis-Light" # Default
+	local prefer_dark="false"
 
-  # First, try to use pywal's background color to determine if theme should be dark or light
-  if [[ -f "$HOME/.cache/wal/colors" ]]; then
-    log "INFO" "Analyzing pywal colors for optimal theme selection"
+	# First, try to use pywal's background color to determine if theme should be dark or light
+	if [[ -f "$HOME/.cache/wal/colors" ]]; then
+		log "INFO" "Analyzing pywal colors for optimal theme selection"
 
-    # Read background color from pywal
-    local bg_color
-    bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
+		# Read background color from pywal
+		local bg_color
+		bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
 
-    if [[ -n $bg_color ]]; then
-      # Convert hex to RGB and calculate brightness
-      local r=$((16#${bg_color:0:2}))
-      local g=$((16#${bg_color:2:2}))
-      local b=$((16#${bg_color:4:2}))
-      local brightness=$((r + g + b))
+		if [[ -n $bg_color ]]; then
+			# Convert hex to RGB and calculate brightness
+			local r=$((16#${bg_color:0:2}))
+			local g=$((16#${bg_color:2:2}))
+			local b=$((16#${bg_color:4:2}))
+			local brightness=$((r + g + b))
 
-      # If background is dark (low brightness), suggest dark theme
-      if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
-        log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
-        local dark_themes=(
-          "Orchis-Dark-Compact"
-          "Arc-Dark"
-          "elementary-dark"
-          "Breeze-Dark"
-        )
+			# If background is dark (low brightness), suggest dark theme
+			if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
+				log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
+				local dark_themes=(
+					"Orchis-Dark-Compact"
+					"Arc-Dark"
+					"elementary-dark"
+					"Breeze-Dark"
+				)
 
-        for theme in "${dark_themes[@]}"; do
-          if is_gtk_theme_installed "$theme"; then
-            detected_theme="$theme"
-            prefer_dark="true"
-            break
-          fi
-        done
-      else
-        log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
-        local light_themes=(
-          "Orchis-Light"
-          "Arc"
-          "elementary"
-          "Breeze"
-        )
+				for theme in "${dark_themes[@]}"; do
+					if is_gtk_theme_installed "$theme"; then
+						detected_theme="$theme"
+						prefer_dark="true"
+						break
+					fi
+				done
+			else
+				log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
+				local light_themes=(
+					"Orchis-Light"
+					"Arc"
+					"elementary"
+					"Breeze"
+				)
 
-        for theme in "${light_themes[@]}"; do
-          if is_gtk_theme_installed "$theme"; then
-            detected_theme="$theme"
-            prefer_dark="false"
-            break
-          fi
-        done
-      fi
-    fi
-  elif command -v dots-smart-colors >/dev/null 2>&1; then
-    # Fallback: use smart-colors to analyze current theme
-    log "INFO" "Using smart-colors to analyze current theme"
+				for theme in "${light_themes[@]}"; do
+					if is_gtk_theme_installed "$theme"; then
+						detected_theme="$theme"
+						prefer_dark="false"
+						break
+					fi
+				done
+			fi
+		fi
+	elif command -v dots-smart-colors > /dev/null 2>&1; then
+		# Fallback: use smart-colors to analyze current theme
+		log "INFO" "Using smart-colors to analyze current theme"
 
-    # Check if current theme is light or dark using smart-colors logic
-    if dots-smart-colors --analyze 2>/dev/null | grep -q "light theme\|bright"; then
-      log "INFO" "Light theme detected, suggesting light GTK theme"
-      local light_themes=(
-        "Orchis-Light"
-        "Arc"
-        "elementary"
-        "Breeze"
-      )
+		# Check if current theme is light or dark using smart-colors logic
+		if dots-smart-colors --analyze 2> /dev/null | grep -q "light theme\|bright"; then
+			log "INFO" "Light theme detected, suggesting light GTK theme"
+			local light_themes=(
+				"Orchis-Light"
+				"Arc"
+				"elementary"
+				"Breeze"
+			)
 
-      for theme in "${light_themes[@]}"; do
-        if is_gtk_theme_installed "$theme"; then
-          detected_theme="$theme"
-          prefer_dark="false"
-          break
-        fi
-      done
-    else
-      log "INFO" "Dark theme detected, suggesting dark GTK theme"
-      local dark_themes=(
-        "Orchis-Dark-Compact"
-        "Arc-Dark"
-        "elementary-dark"
-        "Breeze-Dark"
-      )
+			for theme in "${light_themes[@]}"; do
+				if is_gtk_theme_installed "$theme"; then
+					detected_theme="$theme"
+					prefer_dark="false"
+					break
+				fi
+			done
+		else
+			log "INFO" "Dark theme detected, suggesting dark GTK theme"
+			local dark_themes=(
+				"Orchis-Dark-Compact"
+				"Arc-Dark"
+				"elementary-dark"
+				"Breeze-Dark"
+			)
 
-      for theme in "${dark_themes[@]}"; do
-        if is_gtk_theme_installed "$theme"; then
-          detected_theme="$theme"
-          prefer_dark="true"
-          break
-        fi
-      done
-    fi
-  else
-    log "WARN" "No color analysis available, using default light theme"
-  fi
+			for theme in "${dark_themes[@]}"; do
+				if is_gtk_theme_installed "$theme"; then
+					detected_theme="$theme"
+					prefer_dark="true"
+					break
+				fi
+			done
+		fi
+	else
+		log "WARN" "No color analysis available, using default light theme"
+	fi
 
-  log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
-  echo "$detected_theme:$prefer_dark"
+	log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
+	echo "$detected_theme:$prefer_dark"
 }
 
 # Normalize prefer-dark to a real GTK boolean string (true/false).
 normalize_prefer_dark() {
-  case "${1:-auto}" in
-    true | 1 | yes | dark) echo "true" ;;
-    false | 0 | no | light) echo "false" ;;
-    *) echo "auto" ;;
-  esac
+	case "${1:-auto}" in
+		true | 1 | yes | dark) echo "true" ;;
+		false | 0 | no | light) echo "false" ;;
+		*) echo "auto" ;;
+	esac
 }
 
 # Function to apply GTK theme based on current rice configuration
 apply_rice_gtk_theme() {
-  local rice_name="${1:-}"
+	local rice_name="${1:-}"
 
-  if [[ -z $rice_name ]]; then
-    # shellcheck source=/dev/null
-    source "${HOME}/.local/lib/dots/rice-state.sh" 2>/dev/null || true
-    if declare -f dots_read_current_rice >/dev/null 2>&1; then
-      rice_name="$(dots_read_current_rice)"
-    fi
-  fi
+	if [[ -z $rice_name ]]; then
+		# shellcheck source=/dev/null
+		source "${HOME}/.local/lib/dots/rice-state.sh" 2> /dev/null || true
+		if declare -f dots_read_current_rice > /dev/null 2>&1; then
+			rice_name="$(dots_read_current_rice)"
+		fi
+	fi
 
-  if [[ -z $rice_name ]]; then
-    log "WARN" "No rice specified, using default theme detection"
-    local wallpaper=""
-    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-      # shellcheck source=/dev/null
-      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-      wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
-    fi
-    if [[ -z ${wallpaper:-} ]]; then
-      wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)
-    fi
-    if [[ -n $wallpaper && -f $wallpaper ]]; then
-      local theme_info
-      theme_info=$(detect_optimal_gtk_theme "$wallpaper")
-      local gtk_theme="${theme_info%:*}"
-      local prefer_dark
-      prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-      apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
-    else
-      apply_gtk_theme "Orchis-Light" "Numix-Circle" "false"
-    fi
-    return
-  fi
+	if [[ -z $rice_name ]]; then
+		log "WARN" "No rice specified, using default theme detection"
+		local wallpaper=""
+		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+			# shellcheck source=/dev/null
+			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+			wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
+		fi
+		if [[ -z ${wallpaper:-} ]]; then
+			wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2> /dev/null || true)
+		fi
+		if [[ -n $wallpaper && -f $wallpaper ]]; then
+			local theme_info
+			theme_info=$(detect_optimal_gtk_theme "$wallpaper")
+			local gtk_theme="${theme_info%:*}"
+			local prefer_dark
+			prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+			apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
+		else
+			apply_gtk_theme "Orchis-Light" "Numix-Circle" "false"
+		fi
+		return
+	fi
 
-  log "INFO" "Applying GTK theme for rice: $rice_name"
+	log "INFO" "Applying GTK theme for rice: $rice_name"
 
-  local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
-  local rice_json="$HOME/.local/share/dots/rices/$rice_name/config.json"
+	local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
+	local rice_json="$HOME/.local/share/dots/rices/$rice_name/config.json"
 
-  if [[ ! -f $rice_json ]]; then
-    log "ERROR" "Rice config not found for: $rice_name ($rice_json)"
-    return 1
-  fi
+	if [[ ! -f $rice_json ]]; then
+		log "ERROR" "Rice config not found for: $rice_name ($rice_json)"
+		return 1
+	fi
 
-  local meta
-  meta="$(
-    python3 - "$rice_json" <<'PY'
+	local meta
+	meta="$(
+		python3 - "$rice_json" << 'PY'
 import json, sys
 data = json.load(open(sys.argv[1], encoding="utf-8"))
 print(data.get("gtkTheme") or "auto")
 print(data.get("iconTheme") or "Numix-Circle")
 print("true" if data.get("darkMode", True) else "false")
 PY
-  )"
-  gtk_theme="$(sed -n '1p' <<<"$meta")"
-  icon_theme="$(sed -n '2p' <<<"$meta")"
-  prefer_dark="$(sed -n '3p' <<<"$meta")"
+	)"
+	gtk_theme="$(sed -n '1p' <<< "$meta")"
+	icon_theme="$(sed -n '2p' <<< "$meta")"
+	prefer_dark="$(sed -n '3p' <<< "$meta")"
 
-  prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
+	prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
 
-  # If no explicit theme set in rice, detect based on wallpaper
-  if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
-    local wal_wallpaper=""
-    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-      # shellcheck source=/dev/null
-      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-      wal_wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
-    fi
-    if [[ -z ${wal_wallpaper:-} ]]; then
-      wal_wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)
-    fi
+	# If no explicit theme set in rice, detect based on wallpaper
+	if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
+		local wal_wallpaper=""
+		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+			# shellcheck source=/dev/null
+			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+			wal_wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
+		fi
+		if [[ -z ${wal_wallpaper:-} ]]; then
+			wal_wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2> /dev/null || true)
+		fi
 
-    if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
-      local theme_info
-      theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
-      gtk_theme="${theme_info%:*}"
-      if [[ $prefer_dark == "auto" ]]; then
-        prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-      fi
-    else
-      if [[ $prefer_dark == "true" ]]; then
-        gtk_theme="Orchis-Dark"
-      else
-        gtk_theme="Orchis-Light"
-        prefer_dark="false"
-      fi
-    fi
-  fi
+		if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
+			local theme_info
+			theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
+			gtk_theme="${theme_info%:*}"
+			if [[ $prefer_dark == "auto" ]]; then
+				prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+			fi
+		else
+			if [[ $prefer_dark == "true" ]]; then
+				gtk_theme="Orchis-Dark"
+			else
+				gtk_theme="Orchis-Light"
+				prefer_dark="false"
+			fi
+		fi
+	fi
 
-  if [[ $prefer_dark == "auto" ]]; then
-    prefer_dark="false"
-  fi
+	if [[ $prefer_dark == "auto" ]]; then
+		prefer_dark="false"
+	fi
 
-  # Apply the theme
-  apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
+	# Apply the theme
+	apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
 }
 
 # Function to get current GTK theme
 get_current_gtk_theme() {
-  if [[ -f $GTK3_CONFIG ]]; then
-    grep "^gtk-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
-  elif [[ -f $GTK2_CONFIG ]]; then
-    grep "^gtk-theme-name=" "$GTK2_CONFIG" | cut -d'"' -f2
-  else
-    echo "Unknown"
-  fi
+	if [[ -f $GTK3_CONFIG ]]; then
+		grep "^gtk-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
+	elif [[ -f $GTK2_CONFIG ]]; then
+		grep "^gtk-theme-name=" "$GTK2_CONFIG" | cut -d'"' -f2
+	else
+		echo "Unknown"
+	fi
 }
 
 # Function to list installed GTK themes
 list_installed_gtk_themes() {
-  local themes=()
+	local themes=()
 
-  local theme_dirs=(
-    "/usr/share/themes"
-    "/usr/local/share/themes"
-    "$HOME/.themes"
-    "$HOME/.local/share/themes"
-  )
+	local theme_dirs=(
+		"/usr/share/themes"
+		"/usr/local/share/themes"
+		"$HOME/.themes"
+		"$HOME/.local/share/themes"
+	)
 
-  for theme_dir in "${theme_dirs[@]}"; do
-    if [[ -d $theme_dir ]]; then
-      while IFS= read -r -d '' theme_path; do
-        local theme_name
-        theme_name=$(basename "$theme_path")
-        if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
-          themes+=("$theme_name")
-        fi
-      done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
-    fi
-  done
+	for theme_dir in "${theme_dirs[@]}"; do
+		if [[ -d $theme_dir ]]; then
+			while IFS= read -r -d '' theme_path; do
+				local theme_name
+				theme_name=$(basename "$theme_path")
+				if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
+					themes+=("$theme_name")
+				fi
+			done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
+		fi
+	done
 
-  # Remove duplicates and sort
-  printf '%s\n' "${themes[@]}" | sort -u
+	# Remove duplicates and sort
+	printf '%s\n' "${themes[@]}" | sort -u
 }

--- a/home/dot_local/lib/dots/gtk-theme-manager.sh
+++ b/home/dot_local/lib/dots/gtk-theme-manager.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 # Source smart colors for theme detection
 if [[ -f "$HOME/.local/lib/dots/smart-colors.sh" ]]; then
-	source "$HOME/.local/lib/dots/smart-colors.sh"
+  source "$HOME/.local/lib/dots/smart-colors.sh"
 fi
 
 # GTK configuration paths
@@ -28,120 +28,120 @@ readonly GTK3_CONFIG="$HOME/.config/gtk-3.0/settings.ini"
 
 # Function to log messages
 log() {
-	local level="$1"
-	shift
-	local message="$*"
-	local timestamp
-	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+  local level="$1"
+  shift
+  local message="$*"
+  local timestamp
+  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-	echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
+  echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
 }
 
 # Function to check if a GTK theme is installed
 is_gtk_theme_installed() {
-	local theme_name="$1"
+  local theme_name="$1"
 
-	# Check in common theme directories
-	local theme_dirs=(
-		"/usr/share/themes"
-		"/usr/local/share/themes"
-		"$HOME/.themes"
-		"$HOME/.local/share/themes"
-	)
+  # Check in common theme directories
+  local theme_dirs=(
+    "/usr/share/themes"
+    "/usr/local/share/themes"
+    "$HOME/.themes"
+    "$HOME/.local/share/themes"
+  )
 
-	for theme_dir in "${theme_dirs[@]}"; do
-		if [[ -d "$theme_dir/$theme_name" ]]; then
-			return 0
-		fi
-	done
+  for theme_dir in "${theme_dirs[@]}"; do
+    if [[ -d "$theme_dir/$theme_name" ]]; then
+      return 0
+    fi
+  done
 
-	return 1
+  return 1
 }
 
 # Function to check if an icon theme is installed
 is_icon_theme_installed() {
-	local icon_theme="$1"
+  local icon_theme="$1"
 
-	# Check in common icon directories
-	local icon_dirs=(
-		"/usr/share/icons"
-		"/usr/local/share/icons"
-		"$HOME/.icons"
-		"$HOME/.local/share/icons"
-	)
+  # Check in common icon directories
+  local icon_dirs=(
+    "/usr/share/icons"
+    "/usr/local/share/icons"
+    "$HOME/.icons"
+    "$HOME/.local/share/icons"
+  )
 
-	for icon_dir in "${icon_dirs[@]}"; do
-		if [[ -d "$icon_dir/$icon_theme" ]]; then
-			return 0
-		fi
-	done
+  for icon_dir in "${icon_dirs[@]}"; do
+    if [[ -d "$icon_dir/$icon_theme" ]]; then
+      return 0
+    fi
+  done
 
-	return 1
+  return 1
 }
 
 # Function to apply GTK theme with fallbacks
 apply_gtk_theme() {
-	local gtk_theme="$1"
-	local icon_theme="${2:-elementary}"
-	local prefer_dark="${3:-false}"
+  local gtk_theme="$1"
+  local icon_theme="${2:-elementary}"
+  local prefer_dark="${3:-false}"
 
-	log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
+  log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
 
-	# Validate theme availability with fallbacks
-	if ! is_gtk_theme_installed "$gtk_theme"; then
-		log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
+  # Validate theme availability with fallbacks
+  if ! is_gtk_theme_installed "$gtk_theme"; then
+    log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
 
-		# Common fallback themes in order of preference
-		local fallback_themes=(
-			"Orchis-Light"
-			"elementary"
-			"Arc-Dark"
-			"Arc"
-			"Breeze"
-			"oxygen-gtk"
-		)
+    # Common fallback themes in order of preference
+    local fallback_themes=(
+      "Orchis-Light"
+      "elementary"
+      "Arc-Dark"
+      "Arc"
+      "Breeze"
+      "oxygen-gtk"
+    )
 
-		for fallback in "${fallback_themes[@]}"; do
-			if is_gtk_theme_installed "$fallback"; then
-				gtk_theme="$fallback"
-				log "INFO" "Using fallback theme: $gtk_theme"
-				break
-			fi
-		done
+    for fallback in "${fallback_themes[@]}"; do
+      if is_gtk_theme_installed "$fallback"; then
+        gtk_theme="$fallback"
+        log "INFO" "Using fallback theme: $gtk_theme"
+        break
+      fi
+    done
 
-		if ! is_gtk_theme_installed "$gtk_theme"; then
-			log "ERROR" "No suitable GTK theme found, keeping current theme"
-			return 1
-		fi
-	fi
+    if ! is_gtk_theme_installed "$gtk_theme"; then
+      log "ERROR" "No suitable GTK theme found, keeping current theme"
+      return 1
+    fi
+  fi
 
-	# Validate icon theme with fallbacks
-	if ! is_icon_theme_installed "$icon_theme"; then
-		log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
+  # Validate icon theme with fallbacks
+  if ! is_icon_theme_installed "$icon_theme"; then
+    log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
 
-		local fallback_icons=(
-			"Numix-Circle"
-			"elementary"
-			"hicolor"
-		)
+    local fallback_icons=(
+      "Numix-Circle"
+      "elementary"
+      "hicolor"
+    )
 
-		for fallback in "${fallback_icons[@]}"; do
-			if is_icon_theme_installed "$fallback"; then
-				icon_theme="$fallback"
-				log "INFO" "Using fallback icon theme: $icon_theme"
-				break
-			fi
-		done
-	fi
+    for fallback in "${fallback_icons[@]}"; do
+      if is_icon_theme_installed "$fallback"; then
+        icon_theme="$fallback"
+        log "INFO" "Using fallback icon theme: $icon_theme"
+        break
+      fi
+    done
+  fi
 
-	# Update GTK2 configuration
-	if [[ -f $GTK2_CONFIG ]]; then
-		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
-		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
-		log "INFO" "Updated GTK2 configuration"
-	else
-		log "WARN" "GTK2 config not found, creating basic configuration"
-		cat > "$GTK2_CONFIG" << EOF
+  # Update GTK2 configuration
+  if [[ -f $GTK2_CONFIG ]]; then
+    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
+    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
+    log "INFO" "Updated GTK2 configuration"
+  else
+    log "WARN" "GTK2 config not found, creating basic configuration"
+    cat >"$GTK2_CONFIG" <<EOF
 # DO NOT EDIT! This file will be overwritten by LXAppearance.
 # Any customization should be done in ~/.gtkrc-2.0.mine instead.
 
@@ -162,18 +162,18 @@ gtk-xft-hinting=1
 gtk-xft-hintstyle="hintslight"
 gtk-xft-rgba="rgb"
 EOF
-	fi
+  fi
 
-	# Update GTK3 configuration
-	if [[ -f $GTK3_CONFIG ]]; then
-		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
-		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
-		sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-		log "INFO" "Updated GTK3 configuration"
-	else
-		log "WARN" "GTK3 config not found, creating configuration"
-		mkdir -p "$(dirname "$GTK3_CONFIG")"
-		cat > "$GTK3_CONFIG" << EOF
+  # Update GTK3 configuration
+  if [[ -f $GTK3_CONFIG ]]; then
+    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
+    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
+    sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+    log "INFO" "Updated GTK3 configuration"
+  else
+    log "WARN" "GTK3 config not found, creating configuration"
+    mkdir -p "$(dirname "$GTK3_CONFIG")"
+    cat >"$GTK3_CONFIG" <<EOF
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 gtk-theme-name=$gtk_theme
@@ -193,306 +193,313 @@ gtk-xft-hintstyle=hintslight
 gtk-xft-rgba=rgb
 gtk-modules=colorreload-gtk-module
 EOF
-	fi
+  fi
 
-	# Notify running GTK applications to reload themes
-	if command -v gsettings > /dev/null 2>&1; then
-		gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2> /dev/null || true
-		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2> /dev/null || true
-		# Older schemas expose this key; portals/libadwaita use color-scheme instead.
-		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
-		log "INFO" "Updated gsettings"
-	fi
+  # Notify running GTK applications to reload themes
+  if command -v gsettings >/dev/null 2>&1; then
+    gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2>/dev/null || true
+    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2>/dev/null || true
+    # Older schemas expose this key; portals/libadwaita use color-scheme instead.
+    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
+    log "INFO" "Updated gsettings"
+  fi
 
-	# Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
-	if [[ $prefer_dark == "true" ]]; then
-		apply_gtk_color_scheme dark
-	else
-		apply_gtk_color_scheme light
-	fi
+  # Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
+  if [[ $prefer_dark == "true" ]]; then
+    apply_gtk_color_scheme dark
+  else
+    apply_gtk_color_scheme light
+  fi
 
-	# XFCE4 settings support removed - using gsettings only
-	# If running XFCE4 session, gsettings should be sufficient
-	# Legacy xfconf-query support can be re-enabled if needed
+  # XFCE4 settings support removed - using gsettings only
+  # If running XFCE4 session, gsettings should be sufficient
+  # Legacy xfconf-query support can be re-enabled if needed
 
-	log "INFO" "GTK theme applied successfully: $gtk_theme"
-	return 0
+  log "INFO" "GTK theme applied successfully: $gtk_theme"
+  return 0
 }
 
 # Sync GTK/libadwaita light-dark preference without changing the theme name.
 # mode: "dark" | "light"
 apply_gtk_color_scheme() {
-	local mode="${1:-dark}"
-	local prefer_dark="true"
-	local color_scheme="prefer-dark"
-	if [[ $mode == "light" ]]; then
-		prefer_dark="false"
-		color_scheme="prefer-light"
-	elif [[ $mode != "dark" ]]; then
-		log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
-		return 1
-	fi
+  local mode="${1:-dark}"
+  local prefer_dark="true"
+  local color_scheme="prefer-dark"
+  if [[ $mode == "light" ]]; then
+    prefer_dark="false"
+    color_scheme="prefer-light"
+  elif [[ $mode != "dark" ]]; then
+    log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
+    return 1
+  fi
 
-	if [[ -f $GTK3_CONFIG ]]; then
-		if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2> /dev/null; then
-			sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-		else
-			printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >> "$GTK3_CONFIG"
-		fi
-	fi
+  if [[ -f $GTK3_CONFIG ]]; then
+    if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2>/dev/null; then
+      sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+    else
+      printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >>"$GTK3_CONFIG"
+    fi
+  else
+    mkdir -p "$(dirname "$GTK3_CONFIG")"
+    cat >"$GTK3_CONFIG" <<EOF
+[Settings]
+gtk-application-prefer-dark-theme=$prefer_dark
+EOF
+    log "INFO" "Created GTK3 config for color-scheme sync"
+  fi
 
-	if command -v gsettings > /dev/null 2>&1; then
-		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
-		gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" > /dev/null 2>&1 || true
-	fi
-	log "INFO" "GTK color-scheme set to $color_scheme"
-	return 0
+  if command -v gsettings >/dev/null 2>&1; then
+    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
+    gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" >/dev/null 2>&1 || true
+  fi
+  log "INFO" "GTK color-scheme set to $color_scheme"
+  return 0
 }
 
 # Function to detect optimal GTK theme based on wallpaper colors
 detect_optimal_gtk_theme() {
-	local wallpaper_path="$1"
-	local detected_theme="Orchis-Light" # Default
-	local prefer_dark="false"
+  local wallpaper_path="$1"
+  local detected_theme="Orchis-Light" # Default
+  local prefer_dark="false"
 
-	# First, try to use pywal's background color to determine if theme should be dark or light
-	if [[ -f "$HOME/.cache/wal/colors" ]]; then
-		log "INFO" "Analyzing pywal colors for optimal theme selection"
+  # First, try to use pywal's background color to determine if theme should be dark or light
+  if [[ -f "$HOME/.cache/wal/colors" ]]; then
+    log "INFO" "Analyzing pywal colors for optimal theme selection"
 
-		# Read background color from pywal
-		local bg_color
-		bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
+    # Read background color from pywal
+    local bg_color
+    bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
 
-		if [[ -n $bg_color ]]; then
-			# Convert hex to RGB and calculate brightness
-			local r=$((16#${bg_color:0:2}))
-			local g=$((16#${bg_color:2:2}))
-			local b=$((16#${bg_color:4:2}))
-			local brightness=$((r + g + b))
+    if [[ -n $bg_color ]]; then
+      # Convert hex to RGB and calculate brightness
+      local r=$((16#${bg_color:0:2}))
+      local g=$((16#${bg_color:2:2}))
+      local b=$((16#${bg_color:4:2}))
+      local brightness=$((r + g + b))
 
-			# If background is dark (low brightness), suggest dark theme
-			if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
-				log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
-				local dark_themes=(
-					"Orchis-Dark-Compact"
-					"Arc-Dark"
-					"elementary-dark"
-					"Breeze-Dark"
-				)
+      # If background is dark (low brightness), suggest dark theme
+      if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
+        log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
+        local dark_themes=(
+          "Orchis-Dark-Compact"
+          "Arc-Dark"
+          "elementary-dark"
+          "Breeze-Dark"
+        )
 
-				for theme in "${dark_themes[@]}"; do
-					if is_gtk_theme_installed "$theme"; then
-						detected_theme="$theme"
-						prefer_dark="true"
-						break
-					fi
-				done
-			else
-				log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
-				local light_themes=(
-					"Orchis-Light"
-					"Arc"
-					"elementary"
-					"Breeze"
-				)
+        for theme in "${dark_themes[@]}"; do
+          if is_gtk_theme_installed "$theme"; then
+            detected_theme="$theme"
+            prefer_dark="true"
+            break
+          fi
+        done
+      else
+        log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
+        local light_themes=(
+          "Orchis-Light"
+          "Arc"
+          "elementary"
+          "Breeze"
+        )
 
-				for theme in "${light_themes[@]}"; do
-					if is_gtk_theme_installed "$theme"; then
-						detected_theme="$theme"
-						prefer_dark="false"
-						break
-					fi
-				done
-			fi
-		fi
-	elif command -v dots-smart-colors > /dev/null 2>&1; then
-		# Fallback: use smart-colors to analyze current theme
-		log "INFO" "Using smart-colors to analyze current theme"
+        for theme in "${light_themes[@]}"; do
+          if is_gtk_theme_installed "$theme"; then
+            detected_theme="$theme"
+            prefer_dark="false"
+            break
+          fi
+        done
+      fi
+    fi
+  elif command -v dots-smart-colors >/dev/null 2>&1; then
+    # Fallback: use smart-colors to analyze current theme
+    log "INFO" "Using smart-colors to analyze current theme"
 
-		# Check if current theme is light or dark using smart-colors logic
-		if dots-smart-colors --analyze 2> /dev/null | grep -q "light theme\|bright"; then
-			log "INFO" "Light theme detected, suggesting light GTK theme"
-			local light_themes=(
-				"Orchis-Light"
-				"Arc"
-				"elementary"
-				"Breeze"
-			)
+    # Check if current theme is light or dark using smart-colors logic
+    if dots-smart-colors --analyze 2>/dev/null | grep -q "light theme\|bright"; then
+      log "INFO" "Light theme detected, suggesting light GTK theme"
+      local light_themes=(
+        "Orchis-Light"
+        "Arc"
+        "elementary"
+        "Breeze"
+      )
 
-			for theme in "${light_themes[@]}"; do
-				if is_gtk_theme_installed "$theme"; then
-					detected_theme="$theme"
-					prefer_dark="false"
-					break
-				fi
-			done
-		else
-			log "INFO" "Dark theme detected, suggesting dark GTK theme"
-			local dark_themes=(
-				"Orchis-Dark-Compact"
-				"Arc-Dark"
-				"elementary-dark"
-				"Breeze-Dark"
-			)
+      for theme in "${light_themes[@]}"; do
+        if is_gtk_theme_installed "$theme"; then
+          detected_theme="$theme"
+          prefer_dark="false"
+          break
+        fi
+      done
+    else
+      log "INFO" "Dark theme detected, suggesting dark GTK theme"
+      local dark_themes=(
+        "Orchis-Dark-Compact"
+        "Arc-Dark"
+        "elementary-dark"
+        "Breeze-Dark"
+      )
 
-			for theme in "${dark_themes[@]}"; do
-				if is_gtk_theme_installed "$theme"; then
-					detected_theme="$theme"
-					prefer_dark="true"
-					break
-				fi
-			done
-		fi
-	else
-		log "WARN" "No color analysis available, using default light theme"
-	fi
+      for theme in "${dark_themes[@]}"; do
+        if is_gtk_theme_installed "$theme"; then
+          detected_theme="$theme"
+          prefer_dark="true"
+          break
+        fi
+      done
+    fi
+  else
+    log "WARN" "No color analysis available, using default light theme"
+  fi
 
-	log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
-	echo "$detected_theme:$prefer_dark"
+  log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
+  echo "$detected_theme:$prefer_dark"
 }
 
 # Normalize prefer-dark to a real GTK boolean string (true/false).
 normalize_prefer_dark() {
-	case "${1:-auto}" in
-		true | 1 | yes | dark) echo "true" ;;
-		false | 0 | no | light) echo "false" ;;
-		*) echo "auto" ;;
-	esac
+  case "${1:-auto}" in
+    true | 1 | yes | dark) echo "true" ;;
+    false | 0 | no | light) echo "false" ;;
+    *) echo "auto" ;;
+  esac
 }
 
 # Function to apply GTK theme based on current rice configuration
 apply_rice_gtk_theme() {
-	local rice_name="${1:-}"
+  local rice_name="${1:-}"
 
-	if [[ -z $rice_name ]]; then
-		# shellcheck source=/dev/null
-		source "${HOME}/.local/lib/dots/rice-state.sh" 2> /dev/null || true
-		if declare -f dots_read_current_rice > /dev/null 2>&1; then
-			rice_name="$(dots_read_current_rice)"
-		fi
-	fi
+  if [[ -z $rice_name ]]; then
+    # shellcheck source=/dev/null
+    source "${HOME}/.local/lib/dots/rice-state.sh" 2>/dev/null || true
+    if declare -f dots_read_current_rice >/dev/null 2>&1; then
+      rice_name="$(dots_read_current_rice)"
+    fi
+  fi
 
-	if [[ -z $rice_name ]]; then
-		log "WARN" "No rice specified, using default theme detection"
-		local wallpaper=""
-		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-			# shellcheck source=/dev/null
-			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-			wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
-		fi
-		if [[ -z ${wallpaper:-} ]]; then
-			wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2> /dev/null || true)
-		fi
-		if [[ -n $wallpaper && -f $wallpaper ]]; then
-			local theme_info
-			theme_info=$(detect_optimal_gtk_theme "$wallpaper")
-			local gtk_theme="${theme_info%:*}"
-			local prefer_dark
-			prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-			apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
-		else
-			apply_gtk_theme "Orchis-Light" "Numix-Circle" "false"
-		fi
-		return
-	fi
+  if [[ -z $rice_name ]]; then
+    log "WARN" "No rice specified, using default theme detection"
+    local wallpaper=""
+    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+      # shellcheck source=/dev/null
+      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+      wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
+    fi
+    if [[ -z ${wallpaper:-} ]]; then
+      wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)
+    fi
+    if [[ -n $wallpaper && -f $wallpaper ]]; then
+      local theme_info
+      theme_info=$(detect_optimal_gtk_theme "$wallpaper")
+      local gtk_theme="${theme_info%:*}"
+      local prefer_dark
+      prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+      apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
+    else
+      apply_gtk_theme "Orchis-Light" "Numix-Circle" "false"
+    fi
+    return
+  fi
 
-	log "INFO" "Applying GTK theme for rice: $rice_name"
+  log "INFO" "Applying GTK theme for rice: $rice_name"
 
-	local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
-	local rice_json="$HOME/.local/share/dots/rices/$rice_name/config.json"
+  local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
+  local rice_json="$HOME/.local/share/dots/rices/$rice_name/config.json"
 
-	if [[ ! -f $rice_json ]]; then
-		log "ERROR" "Rice config not found for: $rice_name ($rice_json)"
-		return 1
-	fi
+  if [[ ! -f $rice_json ]]; then
+    log "ERROR" "Rice config not found for: $rice_name ($rice_json)"
+    return 1
+  fi
 
-	local meta
-	meta="$(
-		python3 - "$rice_json" << 'PY'
+  local meta
+  meta="$(
+    python3 - "$rice_json" <<'PY'
 import json, sys
 data = json.load(open(sys.argv[1], encoding="utf-8"))
 print(data.get("gtkTheme") or "auto")
 print(data.get("iconTheme") or "Numix-Circle")
 print("true" if data.get("darkMode", True) else "false")
 PY
-	)"
-	gtk_theme="$(sed -n '1p' <<< "$meta")"
-	icon_theme="$(sed -n '2p' <<< "$meta")"
-	prefer_dark="$(sed -n '3p' <<< "$meta")"
+  )"
+  gtk_theme="$(sed -n '1p' <<<"$meta")"
+  icon_theme="$(sed -n '2p' <<<"$meta")"
+  prefer_dark="$(sed -n '3p' <<<"$meta")"
 
-	prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
+  prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
 
-	# If no explicit theme set in rice, detect based on wallpaper
-	if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
-		local wal_wallpaper=""
-		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-			# shellcheck source=/dev/null
-			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-			wal_wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
-		fi
-		if [[ -z ${wal_wallpaper:-} ]]; then
-			wal_wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2> /dev/null || true)
-		fi
+  # If no explicit theme set in rice, detect based on wallpaper
+  if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
+    local wal_wallpaper=""
+    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+      # shellcheck source=/dev/null
+      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+      wal_wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
+    fi
+    if [[ -z ${wal_wallpaper:-} ]]; then
+      wal_wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)
+    fi
 
-		if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
-			local theme_info
-			theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
-			gtk_theme="${theme_info%:*}"
-			if [[ $prefer_dark == "auto" ]]; then
-				prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-			fi
-		else
-			if [[ $prefer_dark == "true" ]]; then
-				gtk_theme="Orchis-Dark"
-			else
-				gtk_theme="Orchis-Light"
-				prefer_dark="false"
-			fi
-		fi
-	fi
+    if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
+      local theme_info
+      theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
+      gtk_theme="${theme_info%:*}"
+      if [[ $prefer_dark == "auto" ]]; then
+        prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+      fi
+    else
+      if [[ $prefer_dark == "true" ]]; then
+        gtk_theme="Orchis-Dark"
+      else
+        gtk_theme="Orchis-Light"
+        prefer_dark="false"
+      fi
+    fi
+  fi
 
-	if [[ $prefer_dark == "auto" ]]; then
-		prefer_dark="false"
-	fi
+  if [[ $prefer_dark == "auto" ]]; then
+    prefer_dark="false"
+  fi
 
-	# Apply the theme
-	apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
+  # Apply the theme
+  apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
 }
 
 # Function to get current GTK theme
 get_current_gtk_theme() {
-	if [[ -f $GTK3_CONFIG ]]; then
-		grep "^gtk-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
-	elif [[ -f $GTK2_CONFIG ]]; then
-		grep "^gtk-theme-name=" "$GTK2_CONFIG" | cut -d'"' -f2
-	else
-		echo "Unknown"
-	fi
+  if [[ -f $GTK3_CONFIG ]]; then
+    grep "^gtk-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
+  elif [[ -f $GTK2_CONFIG ]]; then
+    grep "^gtk-theme-name=" "$GTK2_CONFIG" | cut -d'"' -f2
+  else
+    echo "Unknown"
+  fi
 }
 
 # Function to list installed GTK themes
 list_installed_gtk_themes() {
-	local themes=()
+  local themes=()
 
-	local theme_dirs=(
-		"/usr/share/themes"
-		"/usr/local/share/themes"
-		"$HOME/.themes"
-		"$HOME/.local/share/themes"
-	)
+  local theme_dirs=(
+    "/usr/share/themes"
+    "/usr/local/share/themes"
+    "$HOME/.themes"
+    "$HOME/.local/share/themes"
+  )
 
-	for theme_dir in "${theme_dirs[@]}"; do
-		if [[ -d $theme_dir ]]; then
-			while IFS= read -r -d '' theme_path; do
-				local theme_name
-				theme_name=$(basename "$theme_path")
-				if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
-					themes+=("$theme_name")
-				fi
-			done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
-		fi
-	done
+  for theme_dir in "${theme_dirs[@]}"; do
+    if [[ -d $theme_dir ]]; then
+      while IFS= read -r -d '' theme_path; do
+        local theme_name
+        theme_name=$(basename "$theme_path")
+        if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
+          themes+=("$theme_name")
+        fi
+      done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
+    fi
+  done
 
-	# Remove duplicates and sort
-	printf '%s\n' "${themes[@]}" | sort -u
+  # Remove duplicates and sort
+  printf '%s\n' "${themes[@]}" | sort -u
 }

--- a/home/dot_local/lib/dots/gtk-theme-manager.sh
+++ b/home/dot_local/lib/dots/gtk-theme-manager.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 # Source smart colors for theme detection
 if [[ -f "$HOME/.local/lib/dots/smart-colors.sh" ]]; then
-	source "$HOME/.local/lib/dots/smart-colors.sh"
+  source "$HOME/.local/lib/dots/smart-colors.sh"
 fi
 
 # GTK configuration paths
@@ -28,120 +28,120 @@ readonly GTK3_CONFIG="$HOME/.config/gtk-3.0/settings.ini"
 
 # Function to log messages
 log() {
-	local level="$1"
-	shift
-	local message="$*"
-	local timestamp
-	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+  local level="$1"
+  shift
+  local message="$*"
+  local timestamp
+  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-	echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
+  echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
 }
 
 # Function to check if a GTK theme is installed
 is_gtk_theme_installed() {
-	local theme_name="$1"
+  local theme_name="$1"
 
-	# Check in common theme directories
-	local theme_dirs=(
-		"/usr/share/themes"
-		"/usr/local/share/themes"
-		"$HOME/.themes"
-		"$HOME/.local/share/themes"
-	)
+  # Check in common theme directories
+  local theme_dirs=(
+    "/usr/share/themes"
+    "/usr/local/share/themes"
+    "$HOME/.themes"
+    "$HOME/.local/share/themes"
+  )
 
-	for theme_dir in "${theme_dirs[@]}"; do
-		if [[ -d "$theme_dir/$theme_name" ]]; then
-			return 0
-		fi
-	done
+  for theme_dir in "${theme_dirs[@]}"; do
+    if [[ -d "$theme_dir/$theme_name" ]]; then
+      return 0
+    fi
+  done
 
-	return 1
+  return 1
 }
 
 # Function to check if an icon theme is installed
 is_icon_theme_installed() {
-	local icon_theme="$1"
+  local icon_theme="$1"
 
-	# Check in common icon directories
-	local icon_dirs=(
-		"/usr/share/icons"
-		"/usr/local/share/icons"
-		"$HOME/.icons"
-		"$HOME/.local/share/icons"
-	)
+  # Check in common icon directories
+  local icon_dirs=(
+    "/usr/share/icons"
+    "/usr/local/share/icons"
+    "$HOME/.icons"
+    "$HOME/.local/share/icons"
+  )
 
-	for icon_dir in "${icon_dirs[@]}"; do
-		if [[ -d "$icon_dir/$icon_theme" ]]; then
-			return 0
-		fi
-	done
+  for icon_dir in "${icon_dirs[@]}"; do
+    if [[ -d "$icon_dir/$icon_theme" ]]; then
+      return 0
+    fi
+  done
 
-	return 1
+  return 1
 }
 
 # Function to apply GTK theme with fallbacks
 apply_gtk_theme() {
-	local gtk_theme="$1"
-	local icon_theme="${2:-elementary}"
-	local prefer_dark="${3:-false}"
+  local gtk_theme="$1"
+  local icon_theme="${2:-elementary}"
+  local prefer_dark="${3:-false}"
 
-	log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
+  log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
 
-	# Validate theme availability with fallbacks
-	if ! is_gtk_theme_installed "$gtk_theme"; then
-		log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
+  # Validate theme availability with fallbacks
+  if ! is_gtk_theme_installed "$gtk_theme"; then
+    log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
 
-		# Common fallback themes in order of preference
-		local fallback_themes=(
-			"Orchis-Light"
-			"elementary"
-			"Arc-Dark"
-			"Arc"
-			"Breeze"
-			"oxygen-gtk"
-		)
+    # Common fallback themes in order of preference
+    local fallback_themes=(
+      "Orchis-Light"
+      "elementary"
+      "Arc-Dark"
+      "Arc"
+      "Breeze"
+      "oxygen-gtk"
+    )
 
-		for fallback in "${fallback_themes[@]}"; do
-			if is_gtk_theme_installed "$fallback"; then
-				gtk_theme="$fallback"
-				log "INFO" "Using fallback theme: $gtk_theme"
-				break
-			fi
-		done
+    for fallback in "${fallback_themes[@]}"; do
+      if is_gtk_theme_installed "$fallback"; then
+        gtk_theme="$fallback"
+        log "INFO" "Using fallback theme: $gtk_theme"
+        break
+      fi
+    done
 
-		if ! is_gtk_theme_installed "$gtk_theme"; then
-			log "ERROR" "No suitable GTK theme found, keeping current theme"
-			return 1
-		fi
-	fi
+    if ! is_gtk_theme_installed "$gtk_theme"; then
+      log "ERROR" "No suitable GTK theme found, keeping current theme"
+      return 1
+    fi
+  fi
 
-	# Validate icon theme with fallbacks
-	if ! is_icon_theme_installed "$icon_theme"; then
-		log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
+  # Validate icon theme with fallbacks
+  if ! is_icon_theme_installed "$icon_theme"; then
+    log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
 
-		local fallback_icons=(
-			"Numix-Circle"
-			"elementary"
-			"hicolor"
-		)
+    local fallback_icons=(
+      "Numix-Circle"
+      "elementary"
+      "hicolor"
+    )
 
-		for fallback in "${fallback_icons[@]}"; do
-			if is_icon_theme_installed "$fallback"; then
-				icon_theme="$fallback"
-				log "INFO" "Using fallback icon theme: $icon_theme"
-				break
-			fi
-		done
-	fi
+    for fallback in "${fallback_icons[@]}"; do
+      if is_icon_theme_installed "$fallback"; then
+        icon_theme="$fallback"
+        log "INFO" "Using fallback icon theme: $icon_theme"
+        break
+      fi
+    done
+  fi
 
-	# Update GTK2 configuration
-	if [[ -f $GTK2_CONFIG ]]; then
-		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
-		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
-		log "INFO" "Updated GTK2 configuration"
-	else
-		log "WARN" "GTK2 config not found, creating basic configuration"
-		cat > "$GTK2_CONFIG" << EOF
+  # Update GTK2 configuration
+  if [[ -f $GTK2_CONFIG ]]; then
+    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
+    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
+    log "INFO" "Updated GTK2 configuration"
+  else
+    log "WARN" "GTK2 config not found, creating basic configuration"
+    cat >"$GTK2_CONFIG" <<EOF
 # DO NOT EDIT! This file will be overwritten by LXAppearance.
 # Any customization should be done in ~/.gtkrc-2.0.mine instead.
 
@@ -162,18 +162,18 @@ gtk-xft-hinting=1
 gtk-xft-hintstyle="hintslight"
 gtk-xft-rgba="rgb"
 EOF
-	fi
+  fi
 
-	# Update GTK3 configuration
-	if [[ -f $GTK3_CONFIG ]]; then
-		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
-		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
-		sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-		log "INFO" "Updated GTK3 configuration"
-	else
-		log "WARN" "GTK3 config not found, creating configuration"
-		mkdir -p "$(dirname "$GTK3_CONFIG")"
-		cat > "$GTK3_CONFIG" << EOF
+  # Update GTK3 configuration
+  if [[ -f $GTK3_CONFIG ]]; then
+    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
+    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
+    sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+    log "INFO" "Updated GTK3 configuration"
+  else
+    log "WARN" "GTK3 config not found, creating configuration"
+    mkdir -p "$(dirname "$GTK3_CONFIG")"
+    cat >"$GTK3_CONFIG" <<EOF
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 gtk-theme-name=$gtk_theme
@@ -193,313 +193,319 @@ gtk-xft-hintstyle=hintslight
 gtk-xft-rgba=rgb
 gtk-modules=colorreload-gtk-module
 EOF
-	fi
+  fi
 
-	# Notify running GTK applications to reload themes
-	if command -v gsettings > /dev/null 2>&1; then
-		gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2> /dev/null || true
-		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2> /dev/null || true
-		# Older schemas expose this key; portals/libadwaita use color-scheme instead.
-		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
-		log "INFO" "Updated gsettings"
-	fi
+  # Notify running GTK applications to reload themes
+  if command -v gsettings >/dev/null 2>&1; then
+    gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2>/dev/null || true
+    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2>/dev/null || true
+    # Older schemas expose this key; portals/libadwaita use color-scheme instead.
+    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
+    log "INFO" "Updated gsettings"
+  fi
 
-	# Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
-	if [[ $prefer_dark == "true" ]]; then
-		apply_gtk_color_scheme dark
-	else
-		apply_gtk_color_scheme light
-	fi
+  # Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
+  if [[ $prefer_dark == "true" ]]; then
+    apply_gtk_color_scheme dark
+  else
+    apply_gtk_color_scheme light
+  fi
 
-	# XFCE4 settings support removed - using gsettings only
-	# If running XFCE4 session, gsettings should be sufficient
-	# Legacy xfconf-query support can be re-enabled if needed
+  # XFCE4 settings support removed - using gsettings only
+  # If running XFCE4 session, gsettings should be sufficient
+  # Legacy xfconf-query support can be re-enabled if needed
 
-	log "INFO" "GTK theme applied successfully: $gtk_theme"
-	return 0
+  log "INFO" "GTK theme applied successfully: $gtk_theme"
+  return 0
 }
 
 # Sync GTK/libadwaita light-dark preference without changing the theme name.
 # mode: "dark" | "light"
 apply_gtk_color_scheme() {
-	local mode="${1:-dark}"
-	local prefer_dark="true"
-	local color_scheme="prefer-dark"
-	if [[ $mode == "light" ]]; then
-		prefer_dark="false"
-		color_scheme="prefer-light"
-	elif [[ $mode != "dark" ]]; then
-		log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
-		return 1
-	fi
+  local mode="${1:-dark}"
+  local prefer_dark="true"
+  local color_scheme="prefer-dark"
+  if [[ $mode == "light" ]]; then
+    prefer_dark="false"
+    color_scheme="prefer-light"
+  elif [[ $mode != "dark" ]]; then
+    log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
+    return 1
+  fi
 
-	if [[ -f $GTK3_CONFIG ]]; then
-		if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2> /dev/null; then
-			sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-		else
-			printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >> "$GTK3_CONFIG"
-		fi
-	else
-		mkdir -p "$(dirname "$GTK3_CONFIG")"
-		cat > "$GTK3_CONFIG" << EOF
+  if [[ -f $GTK3_CONFIG ]]; then
+    if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2>/dev/null; then
+      sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+    else
+      printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >>"$GTK3_CONFIG"
+    fi
+  else
+    mkdir -p "$(dirname "$GTK3_CONFIG")" || {
+      log "ERROR" "Failed to create directory for $GTK3_CONFIG"
+      return 1
+    }
+    if ! cat >"$GTK3_CONFIG" <<EOF; then
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 EOF
-		log "INFO" "Created GTK3 config for color-scheme sync"
-	fi
+      log "ERROR" "Failed to write $GTK3_CONFIG"
+      return 1
+    fi
+    log "INFO" "Created GTK3 config for color-scheme sync"
+  fi
 
-	if command -v gsettings > /dev/null 2>&1; then
-		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
-		gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" > /dev/null 2>&1 || true
-	fi
-	log "INFO" "GTK color-scheme set to $color_scheme"
-	return 0
+  if command -v gsettings >/dev/null 2>&1; then
+    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
+    gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" >/dev/null 2>&1 || true
+  fi
+  log "INFO" "GTK color-scheme set to $color_scheme"
+  return 0
 }
 
 # Function to detect optimal GTK theme based on wallpaper colors
 detect_optimal_gtk_theme() {
-	local wallpaper_path="$1"
-	local detected_theme="Orchis-Light" # Default
-	local prefer_dark="false"
+  local wallpaper_path="$1"
+  local detected_theme="Orchis-Light" # Default
+  local prefer_dark="false"
 
-	# First, try to use pywal's background color to determine if theme should be dark or light
-	if [[ -f "$HOME/.cache/wal/colors" ]]; then
-		log "INFO" "Analyzing pywal colors for optimal theme selection"
+  # First, try to use pywal's background color to determine if theme should be dark or light
+  if [[ -f "$HOME/.cache/wal/colors" ]]; then
+    log "INFO" "Analyzing pywal colors for optimal theme selection"
 
-		# Read background color from pywal
-		local bg_color
-		bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
+    # Read background color from pywal
+    local bg_color
+    bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
 
-		if [[ -n $bg_color ]]; then
-			# Convert hex to RGB and calculate brightness
-			local r=$((16#${bg_color:0:2}))
-			local g=$((16#${bg_color:2:2}))
-			local b=$((16#${bg_color:4:2}))
-			local brightness=$((r + g + b))
+    if [[ -n $bg_color ]]; then
+      # Convert hex to RGB and calculate brightness
+      local r=$((16#${bg_color:0:2}))
+      local g=$((16#${bg_color:2:2}))
+      local b=$((16#${bg_color:4:2}))
+      local brightness=$((r + g + b))
 
-			# If background is dark (low brightness), suggest dark theme
-			if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
-				log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
-				local dark_themes=(
-					"Orchis-Dark-Compact"
-					"Arc-Dark"
-					"elementary-dark"
-					"Breeze-Dark"
-				)
+      # If background is dark (low brightness), suggest dark theme
+      if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
+        log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
+        local dark_themes=(
+          "Orchis-Dark-Compact"
+          "Arc-Dark"
+          "elementary-dark"
+          "Breeze-Dark"
+        )
 
-				for theme in "${dark_themes[@]}"; do
-					if is_gtk_theme_installed "$theme"; then
-						detected_theme="$theme"
-						prefer_dark="true"
-						break
-					fi
-				done
-			else
-				log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
-				local light_themes=(
-					"Orchis-Light"
-					"Arc"
-					"elementary"
-					"Breeze"
-				)
+        for theme in "${dark_themes[@]}"; do
+          if is_gtk_theme_installed "$theme"; then
+            detected_theme="$theme"
+            prefer_dark="true"
+            break
+          fi
+        done
+      else
+        log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
+        local light_themes=(
+          "Orchis-Light"
+          "Arc"
+          "elementary"
+          "Breeze"
+        )
 
-				for theme in "${light_themes[@]}"; do
-					if is_gtk_theme_installed "$theme"; then
-						detected_theme="$theme"
-						prefer_dark="false"
-						break
-					fi
-				done
-			fi
-		fi
-	elif command -v dots-smart-colors > /dev/null 2>&1; then
-		# Fallback: use smart-colors to analyze current theme
-		log "INFO" "Using smart-colors to analyze current theme"
+        for theme in "${light_themes[@]}"; do
+          if is_gtk_theme_installed "$theme"; then
+            detected_theme="$theme"
+            prefer_dark="false"
+            break
+          fi
+        done
+      fi
+    fi
+  elif command -v dots-smart-colors >/dev/null 2>&1; then
+    # Fallback: use smart-colors to analyze current theme
+    log "INFO" "Using smart-colors to analyze current theme"
 
-		# Check if current theme is light or dark using smart-colors logic
-		if dots-smart-colors --analyze 2> /dev/null | grep -q "light theme\|bright"; then
-			log "INFO" "Light theme detected, suggesting light GTK theme"
-			local light_themes=(
-				"Orchis-Light"
-				"Arc"
-				"elementary"
-				"Breeze"
-			)
+    # Check if current theme is light or dark using smart-colors logic
+    if dots-smart-colors --analyze 2>/dev/null | grep -q "light theme\|bright"; then
+      log "INFO" "Light theme detected, suggesting light GTK theme"
+      local light_themes=(
+        "Orchis-Light"
+        "Arc"
+        "elementary"
+        "Breeze"
+      )
 
-			for theme in "${light_themes[@]}"; do
-				if is_gtk_theme_installed "$theme"; then
-					detected_theme="$theme"
-					prefer_dark="false"
-					break
-				fi
-			done
-		else
-			log "INFO" "Dark theme detected, suggesting dark GTK theme"
-			local dark_themes=(
-				"Orchis-Dark-Compact"
-				"Arc-Dark"
-				"elementary-dark"
-				"Breeze-Dark"
-			)
+      for theme in "${light_themes[@]}"; do
+        if is_gtk_theme_installed "$theme"; then
+          detected_theme="$theme"
+          prefer_dark="false"
+          break
+        fi
+      done
+    else
+      log "INFO" "Dark theme detected, suggesting dark GTK theme"
+      local dark_themes=(
+        "Orchis-Dark-Compact"
+        "Arc-Dark"
+        "elementary-dark"
+        "Breeze-Dark"
+      )
 
-			for theme in "${dark_themes[@]}"; do
-				if is_gtk_theme_installed "$theme"; then
-					detected_theme="$theme"
-					prefer_dark="true"
-					break
-				fi
-			done
-		fi
-	else
-		log "WARN" "No color analysis available, using default light theme"
-	fi
+      for theme in "${dark_themes[@]}"; do
+        if is_gtk_theme_installed "$theme"; then
+          detected_theme="$theme"
+          prefer_dark="true"
+          break
+        fi
+      done
+    fi
+  else
+    log "WARN" "No color analysis available, using default light theme"
+  fi
 
-	log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
-	echo "$detected_theme:$prefer_dark"
+  log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
+  echo "$detected_theme:$prefer_dark"
 }
 
 # Normalize prefer-dark to a real GTK boolean string (true/false).
 normalize_prefer_dark() {
-	case "${1:-auto}" in
-		true | 1 | yes | dark) echo "true" ;;
-		false | 0 | no | light) echo "false" ;;
-		*) echo "auto" ;;
-	esac
+  case "${1:-auto}" in
+    true | 1 | yes | dark) echo "true" ;;
+    false | 0 | no | light) echo "false" ;;
+    *) echo "auto" ;;
+  esac
 }
 
 # Function to apply GTK theme based on current rice configuration
 apply_rice_gtk_theme() {
-	local rice_name="${1:-}"
+  local rice_name="${1:-}"
 
-	if [[ -z $rice_name ]]; then
-		# shellcheck source=/dev/null
-		source "${HOME}/.local/lib/dots/rice-state.sh" 2> /dev/null || true
-		if declare -f dots_read_current_rice > /dev/null 2>&1; then
-			rice_name="$(dots_read_current_rice)"
-		fi
-	fi
+  if [[ -z $rice_name ]]; then
+    # shellcheck source=/dev/null
+    source "${HOME}/.local/lib/dots/rice-state.sh" 2>/dev/null || true
+    if declare -f dots_read_current_rice >/dev/null 2>&1; then
+      rice_name="$(dots_read_current_rice)"
+    fi
+  fi
 
-	if [[ -z $rice_name ]]; then
-		log "WARN" "No rice specified, using default theme detection"
-		local wallpaper=""
-		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-			# shellcheck source=/dev/null
-			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-			wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
-		fi
-		if [[ -z ${wallpaper:-} ]]; then
-			wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2> /dev/null || true)
-		fi
-		if [[ -n $wallpaper && -f $wallpaper ]]; then
-			local theme_info
-			theme_info=$(detect_optimal_gtk_theme "$wallpaper")
-			local gtk_theme="${theme_info%:*}"
-			local prefer_dark
-			prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-			apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
-		else
-			apply_gtk_theme "Orchis-Light" "Numix-Circle" "false"
-		fi
-		return
-	fi
+  if [[ -z $rice_name ]]; then
+    log "WARN" "No rice specified, using default theme detection"
+    local wallpaper=""
+    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+      # shellcheck source=/dev/null
+      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+      wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
+    fi
+    if [[ -z ${wallpaper:-} ]]; then
+      wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)
+    fi
+    if [[ -n $wallpaper && -f $wallpaper ]]; then
+      local theme_info
+      theme_info=$(detect_optimal_gtk_theme "$wallpaper")
+      local gtk_theme="${theme_info%:*}"
+      local prefer_dark
+      prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+      apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
+    else
+      apply_gtk_theme "Orchis-Light" "Numix-Circle" "false"
+    fi
+    return
+  fi
 
-	log "INFO" "Applying GTK theme for rice: $rice_name"
+  log "INFO" "Applying GTK theme for rice: $rice_name"
 
-	local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
-	local rice_json="$HOME/.local/share/dots/rices/$rice_name/config.json"
+  local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
+  local rice_json="$HOME/.local/share/dots/rices/$rice_name/config.json"
 
-	if [[ ! -f $rice_json ]]; then
-		log "ERROR" "Rice config not found for: $rice_name ($rice_json)"
-		return 1
-	fi
+  if [[ ! -f $rice_json ]]; then
+    log "ERROR" "Rice config not found for: $rice_name ($rice_json)"
+    return 1
+  fi
 
-	local meta
-	meta="$(
-		python3 - "$rice_json" << 'PY'
+  local meta
+  meta="$(
+    python3 - "$rice_json" <<'PY'
 import json, sys
 data = json.load(open(sys.argv[1], encoding="utf-8"))
 print(data.get("gtkTheme") or "auto")
 print(data.get("iconTheme") or "Numix-Circle")
 print("true" if data.get("darkMode", True) else "false")
 PY
-	)"
-	gtk_theme="$(sed -n '1p' <<< "$meta")"
-	icon_theme="$(sed -n '2p' <<< "$meta")"
-	prefer_dark="$(sed -n '3p' <<< "$meta")"
+  )"
+  gtk_theme="$(sed -n '1p' <<<"$meta")"
+  icon_theme="$(sed -n '2p' <<<"$meta")"
+  prefer_dark="$(sed -n '3p' <<<"$meta")"
 
-	prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
+  prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
 
-	# If no explicit theme set in rice, detect based on wallpaper
-	if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
-		local wal_wallpaper=""
-		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-			# shellcheck source=/dev/null
-			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-			wal_wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
-		fi
-		if [[ -z ${wal_wallpaper:-} ]]; then
-			wal_wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2> /dev/null || true)
-		fi
+  # If no explicit theme set in rice, detect based on wallpaper
+  if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
+    local wal_wallpaper=""
+    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+      # shellcheck source=/dev/null
+      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+      wal_wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
+    fi
+    if [[ -z ${wal_wallpaper:-} ]]; then
+      wal_wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)
+    fi
 
-		if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
-			local theme_info
-			theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
-			gtk_theme="${theme_info%:*}"
-			if [[ $prefer_dark == "auto" ]]; then
-				prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-			fi
-		else
-			if [[ $prefer_dark == "true" ]]; then
-				gtk_theme="Orchis-Dark"
-			else
-				gtk_theme="Orchis-Light"
-				prefer_dark="false"
-			fi
-		fi
-	fi
+    if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
+      local theme_info
+      theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
+      gtk_theme="${theme_info%:*}"
+      if [[ $prefer_dark == "auto" ]]; then
+        prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+      fi
+    else
+      if [[ $prefer_dark == "true" ]]; then
+        gtk_theme="Orchis-Dark"
+      else
+        gtk_theme="Orchis-Light"
+        prefer_dark="false"
+      fi
+    fi
+  fi
 
-	if [[ $prefer_dark == "auto" ]]; then
-		prefer_dark="false"
-	fi
+  if [[ $prefer_dark == "auto" ]]; then
+    prefer_dark="false"
+  fi
 
-	# Apply the theme
-	apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
+  # Apply the theme
+  apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
 }
 
 # Function to get current GTK theme
 get_current_gtk_theme() {
-	if [[ -f $GTK3_CONFIG ]]; then
-		grep "^gtk-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
-	elif [[ -f $GTK2_CONFIG ]]; then
-		grep "^gtk-theme-name=" "$GTK2_CONFIG" | cut -d'"' -f2
-	else
-		echo "Unknown"
-	fi
+  if [[ -f $GTK3_CONFIG ]]; then
+    grep "^gtk-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
+  elif [[ -f $GTK2_CONFIG ]]; then
+    grep "^gtk-theme-name=" "$GTK2_CONFIG" | cut -d'"' -f2
+  else
+    echo "Unknown"
+  fi
 }
 
 # Function to list installed GTK themes
 list_installed_gtk_themes() {
-	local themes=()
+  local themes=()
 
-	local theme_dirs=(
-		"/usr/share/themes"
-		"/usr/local/share/themes"
-		"$HOME/.themes"
-		"$HOME/.local/share/themes"
-	)
+  local theme_dirs=(
+    "/usr/share/themes"
+    "/usr/local/share/themes"
+    "$HOME/.themes"
+    "$HOME/.local/share/themes"
+  )
 
-	for theme_dir in "${theme_dirs[@]}"; do
-		if [[ -d $theme_dir ]]; then
-			while IFS= read -r -d '' theme_path; do
-				local theme_name
-				theme_name=$(basename "$theme_path")
-				if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
-					themes+=("$theme_name")
-				fi
-			done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
-		fi
-	done
+  for theme_dir in "${theme_dirs[@]}"; do
+    if [[ -d $theme_dir ]]; then
+      while IFS= read -r -d '' theme_path; do
+        local theme_name
+        theme_name=$(basename "$theme_path")
+        if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
+          themes+=("$theme_name")
+        fi
+      done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
+    fi
+  done
 
-	# Remove duplicates and sort
-	printf '%s\n' "${themes[@]}" | sort -u
+  # Remove duplicates and sort
+  printf '%s\n' "${themes[@]}" | sort -u
 }

--- a/home/dot_local/lib/dots/gtk-theme-manager.sh
+++ b/home/dot_local/lib/dots/gtk-theme-manager.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 # Source smart colors for theme detection
 if [[ -f "$HOME/.local/lib/dots/smart-colors.sh" ]]; then
-  source "$HOME/.local/lib/dots/smart-colors.sh"
+	source "$HOME/.local/lib/dots/smart-colors.sh"
 fi
 
 # GTK configuration paths
@@ -28,120 +28,120 @@ readonly GTK3_CONFIG="$HOME/.config/gtk-3.0/settings.ini"
 
 # Function to log messages
 log() {
-  local level="$1"
-  shift
-  local message="$*"
-  local timestamp
-  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+	local level="$1"
+	shift
+	local message="$*"
+	local timestamp
+	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-  echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
+	echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
 }
 
 # Function to check if a GTK theme is installed
 is_gtk_theme_installed() {
-  local theme_name="$1"
+	local theme_name="$1"
 
-  # Check in common theme directories
-  local theme_dirs=(
-    "/usr/share/themes"
-    "/usr/local/share/themes"
-    "$HOME/.themes"
-    "$HOME/.local/share/themes"
-  )
+	# Check in common theme directories
+	local theme_dirs=(
+		"/usr/share/themes"
+		"/usr/local/share/themes"
+		"$HOME/.themes"
+		"$HOME/.local/share/themes"
+	)
 
-  for theme_dir in "${theme_dirs[@]}"; do
-    if [[ -d "$theme_dir/$theme_name" ]]; then
-      return 0
-    fi
-  done
+	for theme_dir in "${theme_dirs[@]}"; do
+		if [[ -d "$theme_dir/$theme_name" ]]; then
+			return 0
+		fi
+	done
 
-  return 1
+	return 1
 }
 
 # Function to check if an icon theme is installed
 is_icon_theme_installed() {
-  local icon_theme="$1"
+	local icon_theme="$1"
 
-  # Check in common icon directories
-  local icon_dirs=(
-    "/usr/share/icons"
-    "/usr/local/share/icons"
-    "$HOME/.icons"
-    "$HOME/.local/share/icons"
-  )
+	# Check in common icon directories
+	local icon_dirs=(
+		"/usr/share/icons"
+		"/usr/local/share/icons"
+		"$HOME/.icons"
+		"$HOME/.local/share/icons"
+	)
 
-  for icon_dir in "${icon_dirs[@]}"; do
-    if [[ -d "$icon_dir/$icon_theme" ]]; then
-      return 0
-    fi
-  done
+	for icon_dir in "${icon_dirs[@]}"; do
+		if [[ -d "$icon_dir/$icon_theme" ]]; then
+			return 0
+		fi
+	done
 
-  return 1
+	return 1
 }
 
 # Function to apply GTK theme with fallbacks
 apply_gtk_theme() {
-  local gtk_theme="$1"
-  local icon_theme="${2:-elementary}"
-  local prefer_dark="${3:-false}"
+	local gtk_theme="$1"
+	local icon_theme="${2:-elementary}"
+	local prefer_dark="${3:-false}"
 
-  log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
+	log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
 
-  # Validate theme availability with fallbacks
-  if ! is_gtk_theme_installed "$gtk_theme"; then
-    log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
+	# Validate theme availability with fallbacks
+	if ! is_gtk_theme_installed "$gtk_theme"; then
+		log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
 
-    # Common fallback themes in order of preference
-    local fallback_themes=(
-      "Orchis-Light"
-      "elementary"
-      "Arc-Dark"
-      "Arc"
-      "Breeze"
-      "oxygen-gtk"
-    )
+		# Common fallback themes in order of preference
+		local fallback_themes=(
+			"Orchis-Light"
+			"elementary"
+			"Arc-Dark"
+			"Arc"
+			"Breeze"
+			"oxygen-gtk"
+		)
 
-    for fallback in "${fallback_themes[@]}"; do
-      if is_gtk_theme_installed "$fallback"; then
-        gtk_theme="$fallback"
-        log "INFO" "Using fallback theme: $gtk_theme"
-        break
-      fi
-    done
+		for fallback in "${fallback_themes[@]}"; do
+			if is_gtk_theme_installed "$fallback"; then
+				gtk_theme="$fallback"
+				log "INFO" "Using fallback theme: $gtk_theme"
+				break
+			fi
+		done
 
-    if ! is_gtk_theme_installed "$gtk_theme"; then
-      log "ERROR" "No suitable GTK theme found, keeping current theme"
-      return 1
-    fi
-  fi
+		if ! is_gtk_theme_installed "$gtk_theme"; then
+			log "ERROR" "No suitable GTK theme found, keeping current theme"
+			return 1
+		fi
+	fi
 
-  # Validate icon theme with fallbacks
-  if ! is_icon_theme_installed "$icon_theme"; then
-    log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
+	# Validate icon theme with fallbacks
+	if ! is_icon_theme_installed "$icon_theme"; then
+		log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
 
-    local fallback_icons=(
-      "Numix-Circle"
-      "elementary"
-      "hicolor"
-    )
+		local fallback_icons=(
+			"Numix-Circle"
+			"elementary"
+			"hicolor"
+		)
 
-    for fallback in "${fallback_icons[@]}"; do
-      if is_icon_theme_installed "$fallback"; then
-        icon_theme="$fallback"
-        log "INFO" "Using fallback icon theme: $icon_theme"
-        break
-      fi
-    done
-  fi
+		for fallback in "${fallback_icons[@]}"; do
+			if is_icon_theme_installed "$fallback"; then
+				icon_theme="$fallback"
+				log "INFO" "Using fallback icon theme: $icon_theme"
+				break
+			fi
+		done
+	fi
 
-  # Update GTK2 configuration
-  if [[ -f $GTK2_CONFIG ]]; then
-    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
-    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
-    log "INFO" "Updated GTK2 configuration"
-  else
-    log "WARN" "GTK2 config not found, creating basic configuration"
-    cat >"$GTK2_CONFIG" <<EOF
+	# Update GTK2 configuration
+	if [[ -f $GTK2_CONFIG ]]; then
+		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
+		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
+		log "INFO" "Updated GTK2 configuration"
+	else
+		log "WARN" "GTK2 config not found, creating basic configuration"
+		cat > "$GTK2_CONFIG" << EOF
 # DO NOT EDIT! This file will be overwritten by LXAppearance.
 # Any customization should be done in ~/.gtkrc-2.0.mine instead.
 
@@ -162,18 +162,18 @@ gtk-xft-hinting=1
 gtk-xft-hintstyle="hintslight"
 gtk-xft-rgba="rgb"
 EOF
-  fi
+	fi
 
-  # Update GTK3 configuration
-  if [[ -f $GTK3_CONFIG ]]; then
-    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
-    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
-    sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-    log "INFO" "Updated GTK3 configuration"
-  else
-    log "WARN" "GTK3 config not found, creating configuration"
-    mkdir -p "$(dirname "$GTK3_CONFIG")"
-    cat >"$GTK3_CONFIG" <<EOF
+	# Update GTK3 configuration
+	if [[ -f $GTK3_CONFIG ]]; then
+		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
+		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
+		sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+		log "INFO" "Updated GTK3 configuration"
+	else
+		log "WARN" "GTK3 config not found, creating configuration"
+		mkdir -p "$(dirname "$GTK3_CONFIG")"
+		cat > "$GTK3_CONFIG" << EOF
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 gtk-theme-name=$gtk_theme
@@ -193,313 +193,313 @@ gtk-xft-hintstyle=hintslight
 gtk-xft-rgba=rgb
 gtk-modules=colorreload-gtk-module
 EOF
-  fi
+	fi
 
-  # Notify running GTK applications to reload themes
-  if command -v gsettings >/dev/null 2>&1; then
-    gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2>/dev/null || true
-    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2>/dev/null || true
-    # Older schemas expose this key; portals/libadwaita use color-scheme instead.
-    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
-    log "INFO" "Updated gsettings"
-  fi
+	# Notify running GTK applications to reload themes
+	if command -v gsettings > /dev/null 2>&1; then
+		gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2> /dev/null || true
+		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2> /dev/null || true
+		# Older schemas expose this key; portals/libadwaita use color-scheme instead.
+		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
+		log "INFO" "Updated gsettings"
+	fi
 
-  # Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
-  if [[ $prefer_dark == "true" ]]; then
-    apply_gtk_color_scheme dark
-  else
-    apply_gtk_color_scheme light
-  fi
+	# Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
+	if [[ $prefer_dark == "true" ]]; then
+		apply_gtk_color_scheme dark
+	else
+		apply_gtk_color_scheme light
+	fi
 
-  # XFCE4 settings support removed - using gsettings only
-  # If running XFCE4 session, gsettings should be sufficient
-  # Legacy xfconf-query support can be re-enabled if needed
+	# XFCE4 settings support removed - using gsettings only
+	# If running XFCE4 session, gsettings should be sufficient
+	# Legacy xfconf-query support can be re-enabled if needed
 
-  log "INFO" "GTK theme applied successfully: $gtk_theme"
-  return 0
+	log "INFO" "GTK theme applied successfully: $gtk_theme"
+	return 0
 }
 
 # Sync GTK/libadwaita light-dark preference without changing the theme name.
 # mode: "dark" | "light"
 apply_gtk_color_scheme() {
-  local mode="${1:-dark}"
-  local prefer_dark="true"
-  local color_scheme="prefer-dark"
-  if [[ $mode == "light" ]]; then
-    prefer_dark="false"
-    color_scheme="prefer-light"
-  elif [[ $mode != "dark" ]]; then
-    log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
-    return 1
-  fi
+	local mode="${1:-dark}"
+	local prefer_dark="true"
+	local color_scheme="prefer-dark"
+	if [[ $mode == "light" ]]; then
+		prefer_dark="false"
+		color_scheme="prefer-light"
+	elif [[ $mode != "dark" ]]; then
+		log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
+		return 1
+	fi
 
-  if [[ -f $GTK3_CONFIG ]]; then
-    if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2>/dev/null; then
-      sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-    else
-      printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >>"$GTK3_CONFIG"
-    fi
-  else
-    mkdir -p "$(dirname "$GTK3_CONFIG")"
-    cat >"$GTK3_CONFIG" <<EOF
+	if [[ -f $GTK3_CONFIG ]]; then
+		if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2> /dev/null; then
+			sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+		else
+			printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >> "$GTK3_CONFIG"
+		fi
+	else
+		mkdir -p "$(dirname "$GTK3_CONFIG")"
+		cat > "$GTK3_CONFIG" << EOF
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 EOF
-    log "INFO" "Created GTK3 config for color-scheme sync"
-  fi
+		log "INFO" "Created GTK3 config for color-scheme sync"
+	fi
 
-  if command -v gsettings >/dev/null 2>&1; then
-    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
-    gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" >/dev/null 2>&1 || true
-  fi
-  log "INFO" "GTK color-scheme set to $color_scheme"
-  return 0
+	if command -v gsettings > /dev/null 2>&1; then
+		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
+		gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" > /dev/null 2>&1 || true
+	fi
+	log "INFO" "GTK color-scheme set to $color_scheme"
+	return 0
 }
 
 # Function to detect optimal GTK theme based on wallpaper colors
 detect_optimal_gtk_theme() {
-  local wallpaper_path="$1"
-  local detected_theme="Orchis-Light" # Default
-  local prefer_dark="false"
+	local wallpaper_path="$1"
+	local detected_theme="Orchis-Light" # Default
+	local prefer_dark="false"
 
-  # First, try to use pywal's background color to determine if theme should be dark or light
-  if [[ -f "$HOME/.cache/wal/colors" ]]; then
-    log "INFO" "Analyzing pywal colors for optimal theme selection"
+	# First, try to use pywal's background color to determine if theme should be dark or light
+	if [[ -f "$HOME/.cache/wal/colors" ]]; then
+		log "INFO" "Analyzing pywal colors for optimal theme selection"
 
-    # Read background color from pywal
-    local bg_color
-    bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
+		# Read background color from pywal
+		local bg_color
+		bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
 
-    if [[ -n $bg_color ]]; then
-      # Convert hex to RGB and calculate brightness
-      local r=$((16#${bg_color:0:2}))
-      local g=$((16#${bg_color:2:2}))
-      local b=$((16#${bg_color:4:2}))
-      local brightness=$((r + g + b))
+		if [[ -n $bg_color ]]; then
+			# Convert hex to RGB and calculate brightness
+			local r=$((16#${bg_color:0:2}))
+			local g=$((16#${bg_color:2:2}))
+			local b=$((16#${bg_color:4:2}))
+			local brightness=$((r + g + b))
 
-      # If background is dark (low brightness), suggest dark theme
-      if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
-        log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
-        local dark_themes=(
-          "Orchis-Dark-Compact"
-          "Arc-Dark"
-          "elementary-dark"
-          "Breeze-Dark"
-        )
+			# If background is dark (low brightness), suggest dark theme
+			if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
+				log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
+				local dark_themes=(
+					"Orchis-Dark-Compact"
+					"Arc-Dark"
+					"elementary-dark"
+					"Breeze-Dark"
+				)
 
-        for theme in "${dark_themes[@]}"; do
-          if is_gtk_theme_installed "$theme"; then
-            detected_theme="$theme"
-            prefer_dark="true"
-            break
-          fi
-        done
-      else
-        log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
-        local light_themes=(
-          "Orchis-Light"
-          "Arc"
-          "elementary"
-          "Breeze"
-        )
+				for theme in "${dark_themes[@]}"; do
+					if is_gtk_theme_installed "$theme"; then
+						detected_theme="$theme"
+						prefer_dark="true"
+						break
+					fi
+				done
+			else
+				log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
+				local light_themes=(
+					"Orchis-Light"
+					"Arc"
+					"elementary"
+					"Breeze"
+				)
 
-        for theme in "${light_themes[@]}"; do
-          if is_gtk_theme_installed "$theme"; then
-            detected_theme="$theme"
-            prefer_dark="false"
-            break
-          fi
-        done
-      fi
-    fi
-  elif command -v dots-smart-colors >/dev/null 2>&1; then
-    # Fallback: use smart-colors to analyze current theme
-    log "INFO" "Using smart-colors to analyze current theme"
+				for theme in "${light_themes[@]}"; do
+					if is_gtk_theme_installed "$theme"; then
+						detected_theme="$theme"
+						prefer_dark="false"
+						break
+					fi
+				done
+			fi
+		fi
+	elif command -v dots-smart-colors > /dev/null 2>&1; then
+		# Fallback: use smart-colors to analyze current theme
+		log "INFO" "Using smart-colors to analyze current theme"
 
-    # Check if current theme is light or dark using smart-colors logic
-    if dots-smart-colors --analyze 2>/dev/null | grep -q "light theme\|bright"; then
-      log "INFO" "Light theme detected, suggesting light GTK theme"
-      local light_themes=(
-        "Orchis-Light"
-        "Arc"
-        "elementary"
-        "Breeze"
-      )
+		# Check if current theme is light or dark using smart-colors logic
+		if dots-smart-colors --analyze 2> /dev/null | grep -q "light theme\|bright"; then
+			log "INFO" "Light theme detected, suggesting light GTK theme"
+			local light_themes=(
+				"Orchis-Light"
+				"Arc"
+				"elementary"
+				"Breeze"
+			)
 
-      for theme in "${light_themes[@]}"; do
-        if is_gtk_theme_installed "$theme"; then
-          detected_theme="$theme"
-          prefer_dark="false"
-          break
-        fi
-      done
-    else
-      log "INFO" "Dark theme detected, suggesting dark GTK theme"
-      local dark_themes=(
-        "Orchis-Dark-Compact"
-        "Arc-Dark"
-        "elementary-dark"
-        "Breeze-Dark"
-      )
+			for theme in "${light_themes[@]}"; do
+				if is_gtk_theme_installed "$theme"; then
+					detected_theme="$theme"
+					prefer_dark="false"
+					break
+				fi
+			done
+		else
+			log "INFO" "Dark theme detected, suggesting dark GTK theme"
+			local dark_themes=(
+				"Orchis-Dark-Compact"
+				"Arc-Dark"
+				"elementary-dark"
+				"Breeze-Dark"
+			)
 
-      for theme in "${dark_themes[@]}"; do
-        if is_gtk_theme_installed "$theme"; then
-          detected_theme="$theme"
-          prefer_dark="true"
-          break
-        fi
-      done
-    fi
-  else
-    log "WARN" "No color analysis available, using default light theme"
-  fi
+			for theme in "${dark_themes[@]}"; do
+				if is_gtk_theme_installed "$theme"; then
+					detected_theme="$theme"
+					prefer_dark="true"
+					break
+				fi
+			done
+		fi
+	else
+		log "WARN" "No color analysis available, using default light theme"
+	fi
 
-  log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
-  echo "$detected_theme:$prefer_dark"
+	log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
+	echo "$detected_theme:$prefer_dark"
 }
 
 # Normalize prefer-dark to a real GTK boolean string (true/false).
 normalize_prefer_dark() {
-  case "${1:-auto}" in
-    true | 1 | yes | dark) echo "true" ;;
-    false | 0 | no | light) echo "false" ;;
-    *) echo "auto" ;;
-  esac
+	case "${1:-auto}" in
+		true | 1 | yes | dark) echo "true" ;;
+		false | 0 | no | light) echo "false" ;;
+		*) echo "auto" ;;
+	esac
 }
 
 # Function to apply GTK theme based on current rice configuration
 apply_rice_gtk_theme() {
-  local rice_name="${1:-}"
+	local rice_name="${1:-}"
 
-  if [[ -z $rice_name ]]; then
-    # shellcheck source=/dev/null
-    source "${HOME}/.local/lib/dots/rice-state.sh" 2>/dev/null || true
-    if declare -f dots_read_current_rice >/dev/null 2>&1; then
-      rice_name="$(dots_read_current_rice)"
-    fi
-  fi
+	if [[ -z $rice_name ]]; then
+		# shellcheck source=/dev/null
+		source "${HOME}/.local/lib/dots/rice-state.sh" 2> /dev/null || true
+		if declare -f dots_read_current_rice > /dev/null 2>&1; then
+			rice_name="$(dots_read_current_rice)"
+		fi
+	fi
 
-  if [[ -z $rice_name ]]; then
-    log "WARN" "No rice specified, using default theme detection"
-    local wallpaper=""
-    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-      # shellcheck source=/dev/null
-      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-      wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
-    fi
-    if [[ -z ${wallpaper:-} ]]; then
-      wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)
-    fi
-    if [[ -n $wallpaper && -f $wallpaper ]]; then
-      local theme_info
-      theme_info=$(detect_optimal_gtk_theme "$wallpaper")
-      local gtk_theme="${theme_info%:*}"
-      local prefer_dark
-      prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-      apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
-    else
-      apply_gtk_theme "Orchis-Light" "Numix-Circle" "false"
-    fi
-    return
-  fi
+	if [[ -z $rice_name ]]; then
+		log "WARN" "No rice specified, using default theme detection"
+		local wallpaper=""
+		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+			# shellcheck source=/dev/null
+			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+			wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
+		fi
+		if [[ -z ${wallpaper:-} ]]; then
+			wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2> /dev/null || true)
+		fi
+		if [[ -n $wallpaper && -f $wallpaper ]]; then
+			local theme_info
+			theme_info=$(detect_optimal_gtk_theme "$wallpaper")
+			local gtk_theme="${theme_info%:*}"
+			local prefer_dark
+			prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+			apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
+		else
+			apply_gtk_theme "Orchis-Light" "Numix-Circle" "false"
+		fi
+		return
+	fi
 
-  log "INFO" "Applying GTK theme for rice: $rice_name"
+	log "INFO" "Applying GTK theme for rice: $rice_name"
 
-  local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
-  local rice_json="$HOME/.local/share/dots/rices/$rice_name/config.json"
+	local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
+	local rice_json="$HOME/.local/share/dots/rices/$rice_name/config.json"
 
-  if [[ ! -f $rice_json ]]; then
-    log "ERROR" "Rice config not found for: $rice_name ($rice_json)"
-    return 1
-  fi
+	if [[ ! -f $rice_json ]]; then
+		log "ERROR" "Rice config not found for: $rice_name ($rice_json)"
+		return 1
+	fi
 
-  local meta
-  meta="$(
-    python3 - "$rice_json" <<'PY'
+	local meta
+	meta="$(
+		python3 - "$rice_json" << 'PY'
 import json, sys
 data = json.load(open(sys.argv[1], encoding="utf-8"))
 print(data.get("gtkTheme") or "auto")
 print(data.get("iconTheme") or "Numix-Circle")
 print("true" if data.get("darkMode", True) else "false")
 PY
-  )"
-  gtk_theme="$(sed -n '1p' <<<"$meta")"
-  icon_theme="$(sed -n '2p' <<<"$meta")"
-  prefer_dark="$(sed -n '3p' <<<"$meta")"
+	)"
+	gtk_theme="$(sed -n '1p' <<< "$meta")"
+	icon_theme="$(sed -n '2p' <<< "$meta")"
+	prefer_dark="$(sed -n '3p' <<< "$meta")"
 
-  prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
+	prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
 
-  # If no explicit theme set in rice, detect based on wallpaper
-  if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
-    local wal_wallpaper=""
-    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-      # shellcheck source=/dev/null
-      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-      wal_wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
-    fi
-    if [[ -z ${wal_wallpaper:-} ]]; then
-      wal_wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)
-    fi
+	# If no explicit theme set in rice, detect based on wallpaper
+	if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
+		local wal_wallpaper=""
+		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+			# shellcheck source=/dev/null
+			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+			wal_wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
+		fi
+		if [[ -z ${wal_wallpaper:-} ]]; then
+			wal_wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2> /dev/null || true)
+		fi
 
-    if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
-      local theme_info
-      theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
-      gtk_theme="${theme_info%:*}"
-      if [[ $prefer_dark == "auto" ]]; then
-        prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-      fi
-    else
-      if [[ $prefer_dark == "true" ]]; then
-        gtk_theme="Orchis-Dark"
-      else
-        gtk_theme="Orchis-Light"
-        prefer_dark="false"
-      fi
-    fi
-  fi
+		if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
+			local theme_info
+			theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
+			gtk_theme="${theme_info%:*}"
+			if [[ $prefer_dark == "auto" ]]; then
+				prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+			fi
+		else
+			if [[ $prefer_dark == "true" ]]; then
+				gtk_theme="Orchis-Dark"
+			else
+				gtk_theme="Orchis-Light"
+				prefer_dark="false"
+			fi
+		fi
+	fi
 
-  if [[ $prefer_dark == "auto" ]]; then
-    prefer_dark="false"
-  fi
+	if [[ $prefer_dark == "auto" ]]; then
+		prefer_dark="false"
+	fi
 
-  # Apply the theme
-  apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
+	# Apply the theme
+	apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
 }
 
 # Function to get current GTK theme
 get_current_gtk_theme() {
-  if [[ -f $GTK3_CONFIG ]]; then
-    grep "^gtk-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
-  elif [[ -f $GTK2_CONFIG ]]; then
-    grep "^gtk-theme-name=" "$GTK2_CONFIG" | cut -d'"' -f2
-  else
-    echo "Unknown"
-  fi
+	if [[ -f $GTK3_CONFIG ]]; then
+		grep "^gtk-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
+	elif [[ -f $GTK2_CONFIG ]]; then
+		grep "^gtk-theme-name=" "$GTK2_CONFIG" | cut -d'"' -f2
+	else
+		echo "Unknown"
+	fi
 }
 
 # Function to list installed GTK themes
 list_installed_gtk_themes() {
-  local themes=()
+	local themes=()
 
-  local theme_dirs=(
-    "/usr/share/themes"
-    "/usr/local/share/themes"
-    "$HOME/.themes"
-    "$HOME/.local/share/themes"
-  )
+	local theme_dirs=(
+		"/usr/share/themes"
+		"/usr/local/share/themes"
+		"$HOME/.themes"
+		"$HOME/.local/share/themes"
+	)
 
-  for theme_dir in "${theme_dirs[@]}"; do
-    if [[ -d $theme_dir ]]; then
-      while IFS= read -r -d '' theme_path; do
-        local theme_name
-        theme_name=$(basename "$theme_path")
-        if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
-          themes+=("$theme_name")
-        fi
-      done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
-    fi
-  done
+	for theme_dir in "${theme_dirs[@]}"; do
+		if [[ -d $theme_dir ]]; then
+			while IFS= read -r -d '' theme_path; do
+				local theme_name
+				theme_name=$(basename "$theme_path")
+				if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
+					themes+=("$theme_name")
+				fi
+			done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
+		fi
+	done
 
-  # Remove duplicates and sort
-  printf '%s\n' "${themes[@]}" | sort -u
+	# Remove duplicates and sort
+	printf '%s\n' "${themes[@]}" | sort -u
 }


### PR DESCRIPTION
## Summary
- Fail closed when `sync-state` fails in Rice; skip flushing deferred mode after a failed apply
- Wait for QS IPC job completion (`isBusy` / `lastError`) in `dots-appearance` / `dots-rice` apply
- Harden IPC rice id parsing, reject unknown `--wallpaper` args, bootstrap missing GTK3 `settings.ini`
- Document palette SoT path in ADR; purge orphan `config.sh` via `.chezmoiremove`

## Test plan
- [ ] CI: MegaLinter + clone-and-install green
- [ ] `dots appearance doctor` still OK on live desktop
- [ ] CodeRabbit / review comments addressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GTK3 color settings are now created automatically when missing.
  * Rice palette state is now documented for improved transparency.
* **Bug Fixes**
  * Rice and appearance changes now report asynchronous failures correctly.
  * Duplicate queued operations are ignored to prevent redundant updates.
  * Invalid rice names and command arguments now produce clear errors.
  * Failed operations no longer trigger deferred appearance changes.
* **Chores**
  * Obsolete rice configuration files are now removed during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->