### PR TITLE
chore(coderabbit): add path filters for bulk theme/rice assets

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  path_filters:
+    # Deleted sticky-rice assets/configs are bulk noise; runtime code is elsewhere.
+    - "!home/dot_local/share/dots/rices/**"
+    # Theme pack JSON is data, not logic (still visible in the GitHub PR diff).
+    - "!home/dot_local/share/dots/themes/**/theme.json"
+    - "!home/dot_local/share/dots/themes/**/preview.*"
+    - "!home/dot_local/share/dots/wallpapers/**"


### PR DESCRIPTION
## Summary
- Add `.coderabbit.yaml` path filters so bulk wallpaper/theme/rice asset diffs do not consume CodeRabbit's 100-file review budget
- Needed so #253 can receive an actual review pass (config is read from the base branch)

## Test plan
- [ ] MegaLinter green
- [ ] After merge, re-request `@coderabbitai review` on #253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review settings to exclude selected asset, theme, preview, and wallpaper files from review scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->