### PR TITLE
fix(appearance): route all GTK paths through dots-gtk-theme

### DIFF
--- a/docs/Development-Standards.md
+++ b/docs/Development-Standards.md
@@ -35,7 +35,7 @@ source ~/.local/lib/dots/easy-options/easyoptions.sh || exit
 
 **Variables:**
 
-- Local variables: `snake_case` (e.g., `config_file`, `rice_name`)
+- Local variables: `snake_case` (e.g., `config_file`, `theme_id`)
 - Constants: `UPPER_CASE` with `readonly` (e.g., `readonly CONFIG_DIR`)
 - Environment exports: `UPPER_CASE` (e.g., `export WAYBAR_PROFILE`)
 

--- a/docs/System-Architecture.md
+++ b/docs/System-Architecture.md
@@ -100,11 +100,12 @@
 
 **Integration:**
 
-Rices specify their animation profile via `hyprlandAnimations` in `config.json`:
-
-```json
-{ "hyprlandAnimations": "cyberpunk" }
-```
+Optional Hyprland animation profiles live under
+`~/.config/hypr/hyprland.conf.d/animations-*.conf`
+(cyberpunk, cozy, vaporwave, minimal, nature). The active session sources
+`animations.conf` by default. Theme packs do **not** auto-swap Hyprland animation
+profiles (no sticky theme id); pick a profile manually or keep the default.
+Quickshell motion scaling is controlled from Control Center → Appearance → Animations.
 
 ## 4. Legacy Removal Note
 

--- a/docs/Testing-Strategy.md
+++ b/docs/Testing-Strategy.md
@@ -6,10 +6,9 @@ Testing ensures reliability across diverse environments:
 
 - Multiple Linux distributions (Arch, Ubuntu, Fedora)
 - Hyprland window manager (Wayland)
-- Different themes (rices)
-- Multiple hardware configurations
-- Various hardware configurations (laptop, desktop, VM)
-- Light and dark themes
+- Appearance theme packs (apply-once recipes)
+- Multiple hardware configurations (laptop, desktop, VM)
+- Light and dark modes
 - Different monitor setups (single, dual, triple)
 
 ## Playground Environment
@@ -45,6 +44,7 @@ Testing ensures reliability across diverse environments:
 3. **Error handling**: Test with invalid inputs
 4. **Dependencies**: Verify behavior with missing deps
 5. **Integration**: Check interaction with other components
+6. **Appearance contract**: `./scripts/test-appearance-consistency.sh --source`
 
 ### For Visual Changes
 
@@ -54,13 +54,15 @@ Testing ensures reliability across diverse environments:
 4. Multi-monitor behavior
 5. Different screen resolutions
 
-### For Rice Themes
+### For Appearance Theme Packs
 
-1. Apply script executes without errors
-2. All applications receive correct colors
-3. Wallpaper loads correctly
-4. Waybar uses correct configuration
-5. EWW widgets display properly
+1. `theme.json` schema is complete (`schemaVersion`, `id`, `schemeType`, GTK/icons, wallpaper)
+2. Preview asset exists (`preview.jpg` / `.png` / `.webp`)
+3. Apply via CLI and Control Center without errors
+4. Wallpaper loads; `~/.cache/wal/wal` remains a text path file
+5. `dots appearance doctor` reports OK
+6. GTK/icons go through `dots-gtk-theme`
+7. Quickshell Control Center: stage → Apply shows busy/error feedback
 
 ## Testing Checklist
 
@@ -71,27 +73,34 @@ Testing ensures reliability across diverse environments:
 - [ ] Includes error handling
 - [ ] Logs appropriately
 - [ ] Cleans up resources
-- [ ] Works with EasyOptions
+- [ ] Works with EasyOptions (when applicable)
 - [ ] Help text is clear
 
 **For Visual Components:**
 
-- [ ] Works in light theme
-- [ ] Works in dark theme
+- [ ] Works in light mode
+- [ ] Works in dark mode
 - [ ] Colors are readable
 - [ ] Scales to different resolutions
 - [ ] Handles multiple monitors
 - [ ] Integrates with window manager
 
-**For Themes (Rices):**
+**For Theme Packs:**
 
-- [ ] Apply script is idempotent
+- [ ] Apply is idempotent (no sticky current id written)
 - [ ] All assets load correctly
-- [ ] Colors applied consistently
-- [ ] Waybar configuration loads
-- [ ] EWW widgets display
+- [ ] Colors applied consistently via smart-colors / M3
 - [ ] Wallpaper sets correctly
 - [ ] Preview screenshot included
+- [ ] `list-themes.py` exposes `wallpaperPaths` for every listed wallpaper
+
+## Quickshell Appearance UI checklist
+
+- [ ] Theme stage shows **Staged** chip; Apply commits via `ThemePipeline`
+- [ ] Apply disabled while pipeline busy; footer shows Applying… / error
+- [ ] GTK/icon live seed does not overwrite staged selections
+- [ ] Preview shows “Generating palette…” while M3 preview runs
+- [ ] System pane GTK tile opens Appearance (`dots-theme-selector`)
 
 ## Continuous Integration
 
@@ -101,5 +110,6 @@ The project uses GitHub Actions for automated testing:
 - Installation script testing
 - Docker environment verification
 - Documentation link checking
+- Appearance source consistency (`test-appearance-consistency.sh --source`)
 
 See `.github/workflows/` for CI configuration.

--- a/docs/wiki/Dots-Scripts.md
+++ b/docs/wiki/Dots-Scripts.md
@@ -70,7 +70,7 @@ dots keyboard-help --search=workspace
 ### appearance
 
 - Unified appearance API for Quickshell UI and scripts
-- Manages full themes/rices plus variant/mode/wallpaper syncing
+- Manages appearance theme packs plus variant/mode/wallpaper syncing
 
 ```bash
 dots appearance list

--- a/docs/wiki/Lockscreen.md
+++ b/docs/wiki/Lockscreen.md
@@ -201,13 +201,13 @@ theme-pack `tags` (there is no sticky “current theme” id).
 
 ### Available Layouts
 
-| Layout        | Matching tags / path hints      | Description                                     |
-|---------------|---------------------------------|-------------------------------------------------|
-| **Default**   | Any unmatched                   | Clean, centered layout with standard typography |
-| **Cyberpunk** | cyberpunk, neon, futuristic     | Glowing neon elements, tech-inspired fonts      |
-| **Cozy**      | cozy, kawaii, cute, warm, soft  | Soft, rounded elements with pastel accents      |
-| **Vaporwave** | vaporwave, retro, synthwave     | Gradient effects, 80s-inspired typography       |
-| **Minimal**   | minimal, clean                  | Ultra-clean with minimal UI elements            |
+| Layout        | Matching tags / path hints     | Description                                     |
+|---------------|--------------------------------|-------------------------------------------------|
+| **Default**   | Any unmatched                  | Clean, centered layout with standard typography |
+| **Cyberpunk** | cyberpunk, neon, futuristic    | Glowing neon elements, tech-inspired fonts      |
+| **Cozy**      | cozy, kawaii, cute, warm, soft | Soft, rounded elements with pastel accents      |
+| **Vaporwave** | vaporwave, retro, synthwave    | Gradient effects, 80s-inspired typography       |
+| **Minimal**   | minimal, clean                 | Ultra-clean with minimal UI elements            |
 
 ### How It Works
 

--- a/docs/wiki/Lockscreen.md
+++ b/docs/wiki/Lockscreen.md
@@ -161,12 +161,12 @@ dots wal-reload  # Updates wallpaper and lockscreen
 
 ### Appearance
 
-Rice / appearance apply regenerates lockscreen colors via `dots-hyprlock-theme` after scheme generation. Historical note — older docs mentioned per-rice `apply.sh`; that path is no longer maintained. Equivalent hook:
+Theme / wallpaper apply regenerates lockscreen colors via `dots-hyprlock-theme`
+after scheme generation (Quickshell `ThemePipeline` and shell `apply-appearance.sh`).
 
 ```bash
-if command -v dots-lockscreen &>/dev/null; then
-  dots-lockscreen --update="$wallpaper"
-fi
+dots appearance theme apply vapor-dreams
+dots-hyprlock-theme
 ```
 
 ## Hyprlock Configuration
@@ -194,36 +194,38 @@ input-field {
 }
 ```
 
-## Rice-Style-Aware Layouts
+## Style-Aware Layouts
 
-The lockscreen automatically adapts its layout based on your current rice's `style` field in `config.json`. This provides a cohesive aesthetic experience across your entire desktop.
+The lockscreen adapts layout from the **current wallpaper path** and optional
+theme-pack `tags` (there is no sticky “current theme” id).
 
 ### Available Layouts
 
-| Layout        | Rice Styles                 | Description                                     |
-|---------------|-----------------------------|-------------------------------------------------|
-| **Default**   | Any unlisted style          | Clean, centered layout with standard typography |
-| **Cyberpunk** | cyberpunk, neon, futuristic | Glowing neon elements, tech-inspired fonts      |
-| **Cozy**      | cozy, kawaii, cute, warm    | Soft, rounded elements with pastel accents      |
-| **Vaporwave** | vaporwave, retro, synthwave | Gradient effects, 80s-inspired typography       |
-| **Minimal**   | minimal, clean, productive  | Ultra-clean with minimal UI elements            |
+| Layout        | Matching tags / path hints      | Description                                     |
+|---------------|---------------------------------|-------------------------------------------------|
+| **Default**   | Any unmatched                   | Clean, centered layout with standard typography |
+| **Cyberpunk** | cyberpunk, neon, futuristic     | Glowing neon elements, tech-inspired fonts      |
+| **Cozy**      | cozy, kawaii, cute, warm, soft  | Soft, rounded elements with pastel accents      |
+| **Vaporwave** | vaporwave, retro, synthwave     | Gradient effects, 80s-inspired typography       |
+| **Minimal**   | minimal, clean                  | Ultra-clean with minimal UI elements            |
 
 ### How It Works
 
-1. When locking, the script reads `style` from your current rice's `config.json`
-2. Based on the style, it selects the appropriate layout template
-3. Colors are pulled from the smart-colors cache
-4. The hyprlock configuration is generated dynamically
+1. `dots-lockscreen` resolves the wallpaper from `~/.local/state/dots/wallpaper/path`
+2. Path segments (e.g. `…/vapor-dreams/…`) provide a first hint
+3. If the parent folder matches a theme pack id, `tags` from `theme.json` refine the layout
+4. Colors come from the smart-colors / hyprlock cache
 
-### Rice Configuration
-
-To enable style-aware layouts, set `style` in your rice's `config.json`:
+### Theme pack tags
 
 ```json
-{ "style": "cyberpunk" }
+{
+  "id": "neon-city",
+  "tags": ["cyberpunk", "neon", "dark", "city"]
+}
 ```
 
-The style matching is case-insensitive and supports partial matches (e.g., "cozy warm" matches the Cozy layout).
+Matching is case-insensitive and supports partial keyword matches.
 
 ## Comparison with Betterlockscreen
 
@@ -290,6 +292,6 @@ dots lockscreen --update=~/.local/state/dots/wallpaper/path
 ## See Also
 
 - [Smart Colors System](Smart-Colors-System.md)
-- [Rice System](Rice-System-Theme-Management.md)
+- [Appearance Themes](Rice-System-Theme-Management.md)
 - [EWW Widgets](EWW-Widgets.md)
 - [Hyprland Setup](../Hyprland-Setup.md)

--- a/docs/wiki/Quickshell-Shell.md
+++ b/docs/wiki/Quickshell-Shell.md
@@ -75,7 +75,8 @@ Each appearance theme pack configures its M3 scheme via `theme.json`:
 {
   "schemeType": "vibrant",
   "darkMode": true,
-  "gtkTheme": "Orchis-Dark",
+  "gtkTheme": "Orchis-Light-Compact",
+  "gtkPreferDark": false,
   "iconTheme": "Numix-Circle"
 }
 ```

--- a/docs/wiki/Quickshell-Shell.md
+++ b/docs/wiki/Quickshell-Shell.md
@@ -69,14 +69,14 @@ Quickshell uses **Material Design 3** (M3) color palettes generated from your wa
 
 ### Scheme Configuration
 
-Each appearance (rice) configures its M3 scheme via `config.json`:
+Each appearance theme pack configures its M3 scheme via `theme.json`:
 
 ```json
 {
   "schemeType": "vibrant",
   "darkMode": true,
-  "accentColor": "",
-  "barPosition": "top"
+  "gtkTheme": "Orchis-Dark",
+  "iconTheme": "Numix-Circle"
 }
 ```
 
@@ -84,10 +84,10 @@ Each appearance (rice) configures its M3 scheme via `config.json`:
 
 ```bash
 dots appearance list
-dots appearance current
-dots appearance apply machines
-dots appearance set-variant tonalspot
+dots appearance theme apply vapor-dreams
+dots appearance set-variant tonal-spot
 dots appearance set-mode light
+dots appearance doctor
 ```
 
 ---
@@ -165,7 +165,7 @@ Shell behavior is configured via `~/.config/hornero/shell.json`:
 ### Reference Parity Status
 
 - **Matched**: wallpaper-driven M3 theming pipeline, left-rail shell feel, top control center, launcher command modes, right-edge OSD/session controls, rounded frame and edge exclusions.
-- **Intentional deviations**: Hornero-specific `dots-*` integrations, rice selector mode in launcher, AI chat module.
+- **Intentional deviations**: Hornero-specific `dots-*` integrations, appearance/theme selector mode in launcher, AI chat module.
 - **In progress hardening**: deeper panel unification and additional popout parity refinements.
 
 ---

--- a/docs/wiki/Rice-System-Theme-Management.md
+++ b/docs/wiki/Rice-System-Theme-Management.md
@@ -5,11 +5,11 @@ one-shot recipes — they never own a sticky “current theme”.
 
 ## Live sources of truth
 
-| Concern        | Path                                         |
-|----------------|----------------------------------------------|
-| Wallpaper      | `~/.local/state/dots/wallpaper/path`         |
-| Palette        | `~/.cache/dots/smart-colors/scheme.json`     |
-| Mode / flavour | `~/.local/state/dots/scheme/state.json`      |
+| Concern        | Path                                              |
+|----------------|---------------------------------------------------|
+| Wallpaper      | `~/.local/state/dots/wallpaper/path`              |
+| Palette        | `~/.cache/dots/smart-colors/scheme.json`          |
+| Mode / flavour | `~/.local/state/dots/scheme/state.json`           |
 | GTK / icons    | via `dots-gtk-theme` → `settings.ini` + gsettings |
 
 ## Theme packs

--- a/docs/wiki/Rice-System-Theme-Management.md
+++ b/docs/wiki/Rice-System-Theme-Management.md
@@ -10,7 +10,7 @@ one-shot recipes — they never own a sticky “current theme”.
 | Wallpaper      | `~/.local/state/dots/wallpaper/path`         |
 | Palette        | `~/.cache/dots/smart-colors/scheme.json`     |
 | Mode / flavour | `~/.local/state/dots/scheme/state.json`      |
-| GTK / icons    | `~/.config/gtk-3.0/settings.ini` + gsettings |
+| GTK / icons    | via `dots-gtk-theme` → `settings.ini` + gsettings |
 
 ## Theme packs
 
@@ -43,3 +43,4 @@ dots appearance doctor
 
 - Orchestrator: `ThemePipeline` singleton (IPC target `appearance`)
 - Control Center pane configures themes, wallpaper, mode, variant, scheme, GTK, icons
+- GTK/icon apply always goes through `dots-gtk-theme` (never inline `gtk-theme-manager.sh` or raw `gsettings` from QML)

--- a/docs/wiki/Rice-System-Theme-Management.md
+++ b/docs/wiki/Rice-System-Theme-Management.md
@@ -5,12 +5,13 @@ one-shot recipes — they never own a sticky “current theme”.
 
 ## Live sources of truth
 
-| Concern        | Path                                              |
-|----------------|---------------------------------------------------|
-| Wallpaper      | `~/.local/state/dots/wallpaper/path`              |
-| Palette        | `~/.cache/dots/smart-colors/scheme.json`          |
-| Mode / flavour | `~/.local/state/dots/scheme/state.json`           |
-| GTK / icons    | via `dots-gtk-theme` → `settings.ini` + gsettings |
+| Concern        | Path / tool                                              |
+|----------------|----------------------------------------------------------|
+| Wallpaper      | `~/.local/state/dots/wallpaper/path`                     |
+| Palette        | `~/.cache/dots/smart-colors/scheme.json`                 |
+| Mode / flavour | `~/.local/state/dots/scheme/state.json`                  |
+| GTK / icons    | via `dots-gtk-theme` → `settings.ini` + gsettings        |
+| Wal pointer    | `~/.cache/wal/wal` (**text path file**, never a symlink) |
 
 ## Theme packs
 
@@ -39,8 +40,34 @@ dots appearance status
 dots appearance doctor
 ```
 
+GTK entrypoint (canonical for scripts and Quickshell):
+
+```bash
+dots-gtk-theme -q -p list
+dots-gtk-theme -q -p current
+dots-gtk-theme -q -p current-icon
+dots-gtk-theme -q apply Orchis-Dark Numix-Circle true
+dots-gtk-theme -q color-scheme dark
+dots-gtk-theme -q theme vapor-dreams
+```
+
 ## Quickshell
 
 - Orchestrator: `ThemePipeline` singleton (IPC target `appearance`)
 - Control Center pane configures themes, wallpaper, mode, variant, scheme, GTK, icons
 - GTK/icon apply always goes through `dots-gtk-theme` (never inline `gtk-theme-manager.sh` or raw `gsettings` from QML)
+- Launcher actions: `theme` / `appearance`
+
+## Consistency checks
+
+```bash
+./scripts/test-appearance-consistency.sh --source   # CI / repo
+./scripts/test-appearance-consistency.sh             # live doctor + GTK
+dots appearance doctor
+```
+
+## Historical note
+
+Older docs referred to sticky “rices” (`rices/<id>/`, IPC `rice`, `dots-rice`).
+That model was removed; this page is the current contract. The wiki filename
+`Rice-System-Theme-Management` is kept only for stable links.

--- a/docs/wiki/Rice-System-Theme-Management.md
+++ b/docs/wiki/Rice-System-Theme-Management.md
@@ -34,7 +34,7 @@ dots appearance theme apply neon-city --wallpaper ~/Pictures/Wallpapers/neon-cit
 dots appearance set-wallpaper <path>
 dots appearance set-mode dark|light
 dots appearance set-variant expressive
-dots appearance set-gtk Orchis-Dark
+dots appearance set-gtk Orchis-Light-Compact
 dots appearance set-icons Numix-Circle
 dots appearance status
 dots appearance doctor
@@ -46,7 +46,7 @@ GTK entrypoint (canonical for scripts and Quickshell):
 dots-gtk-theme -q -p list
 dots-gtk-theme -q -p current
 dots-gtk-theme -q -p current-icon
-dots-gtk-theme -q apply Orchis-Dark Numix-Circle true
+dots-gtk-theme -q apply Orchis-Light-Compact Numix-Circle true
 dots-gtk-theme -q color-scheme dark
 dots-gtk-theme -q theme vapor-dreams
 ```

--- a/docs/wiki/Smart-Colors-System.md
+++ b/docs/wiki/Smart-Colors-System.md
@@ -12,20 +12,22 @@ Smart Colors generates semantic colors and Material Design 3 palettes from the c
 
 ### Maintained path (Hyprland + Quickshell)
 
-1. `dots-wallpaper-set <image>` (or Control Center Apply / `Rice.setWallpaper`)
-2. When Quickshell is running → IPC `rice setWallpaper`
+1. `dots-wallpaper-set <image>` (or Control Center Apply / `appearance.setWallpaper`)
+2. When Quickshell is running → IPC `appearance setWallpaper`
 3. Otherwise → `apply-appearance.sh` wallpaper-only path:
-   - `wal -i` (honors light/dark from current rice / scheme state)
-   - write `~/.local/state/dots/wallpaper/path`
+   - `wal -i` (honors light/dark from scheme state)
+   - write `~/.local/state/dots/wallpaper/path` (canonical pointer)
+   - rewrite `~/.cache/wal/wal` as a **text path file** (never an image symlink)
    - `generate-m3-colors.py` → `scheme.json`
    - `dots-color-scheme sync-state` → `scheme/state.json`
+   - `dots-gtk-theme color-scheme` to keep GTK/libadwaita in lockstep
 4. `Colours.qml` reloads via file watch or `dots-quickshell ipc colours reload` (real IPC + touch fallback)
 
 ### Wallpaper resolution priority
 
 1. Explicit argument
 2. `~/.local/state/dots/wallpaper/path` (canonical persistent pointer)
-3. `~/.cache/wal/wal` (pywal symlink; last resort)
+3. `~/.cache/wal/wal` (text path file; last resort — not a symlink)
 
 ## Main Commands
 
@@ -56,9 +58,9 @@ Compatibility files may exist for external tooling, but they are not part of the
 ```mermaid
 flowchart LR
   wallpaper[WallpaperChange] --> set[dots-wallpaper-set]
-  set --> rice[RiceIpcOrShellFallback]
-  rice --> wal[pywal]
-  rice --> m3[generate-m3-colors]
+  set --> appearance[AppearanceIpcOrShellFallback]
+  appearance --> wal[pywal]
+  appearance --> m3[generate-m3-colors]
   m3 --> scheme[schemeJson]
   m3 --> state[schemeStateJson]
   scheme --> colours[QuickshellColoursService]
@@ -76,9 +78,9 @@ ls -la ~/.cache/dots/smart-colors/
 
 # Force shell-side reload path
 dots-quickshell ipc colours reload
+
+# Confirm appearance consistency
+dots appearance doctor
 ```
 
-## Notes
-
-- Legacy Waybar/EWW/Rofi integrations are no longer part of the maintained path.
-- The supported default stack is Hyprland + Quickshell.
+See also: [Appearance Themes](Rice-System-Theme-Management.md)

--- a/docs/wiki/Thunar-Side-Panel.md
+++ b/docs/wiki/Thunar-Side-Panel.md
@@ -39,7 +39,7 @@ chezmoi apply --force --include=files
 
 ### Recommended Folder Set
 
-The template includes: Home, Projects, Dev, Downloads, Documents, Pictures, Music, Videos, .config, LocalShare, Rices, Wallpapers, Bin. Remove or reorder directly in the template to reflect your workflow.
+The template includes: Home, Projects, Dev, Downloads, Documents, Pictures, Music, Videos, .config, LocalShare, Themes, Wallpapers, Bin. Remove or reorder directly in the template to reflect your workflow.
 
 ### Adding Extra Bookmarks (Optional Manual Pattern)
 
@@ -50,7 +50,7 @@ If a specific setup needs additional paths (e.g. a theme assets folder), just ap
 If a bookmarked directory no longer exists, Thunar will still show it (but inaccessible). Periodically prune obsolete lines manually. You can safely create missing directories with:
 
 ```bash
-mkdir -p ~/Projects ~/Dev ~/.local/share/dots/rices ~/.local/share/wallpapers
+mkdir -p ~/Projects ~/Dev ~/.local/share/dots/themes ~/.local/share/dots/wallpapers ~/Pictures/Wallpapers
 ```
 
 ### Restoring / Resetting

--- a/home/.chezmoiscripts/run_onchange_after_configure-initialize-services.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_configure-initialize-services.sh.tmpl
@@ -168,7 +168,7 @@ echo "════════════════════════�
 echo ""
 echo "Next steps:"
 echo "  1. Log out and log back in for all changes to take effect"
-echo "  2. Select a rice theme: dots appearance apply neon-city"
+echo "  2. Apply a theme pack: dots appearance theme apply neon-city"
 echo "  3. Configure monitors: dots hypr-monitors"
 echo ""
 echo "For more information, check the documentation:"

--- a/home/dot_config/quickshell/README.md
+++ b/home/dot_config/quickshell/README.md
@@ -16,7 +16,7 @@ A beautiful, functional, and highly customizable desktop shell built with [Quick
 
 ## 🌟 Features
 
-- 🎨 **Theme-Adaptive UI** - Automatically adapts to rice color schemes via Smart Colors
+- 🎨 **Theme-Adaptive UI** - Automatically adapts to appearance / wallpaper palettes via Smart Colors
 - 🎯 **Unified Desktop Shell** - Bar, launcher, dashboard, notifications, and AI chat in one
 - ⚡ **High Performance** - C++ plugin (Hornero) for performance-critical operations
 - 🎵 **Audio Visualization** - Beat detection and spectrum analyzer

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/AppearancePane.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/AppearancePane.qml
@@ -88,8 +88,8 @@ Item {
         if (applyFailed && applyStatusMessage)
             return applyStatusMessage;
         if (hasPendingChanges)
-            return qsTr("Pending appearance changes — press Apply to commit");
-        return qsTr("No pending changes");
+            return qsTr("Pending — will apply when the current job finishes");
+        return qsTr("Click a theme or option to apply");
     }
     property bool previewActive: false
     property string previewSource: ""
@@ -99,6 +99,13 @@ Item {
     property string previewMode: ""
     property string previewWallpaperPath: ""
     property string previewSchemeType: ""
+    property string previewGtkTheme: ""
+    property string previewIconTheme: ""
+    property string previewGtkPrefer: ""
+    property string previewWallpaperLabel: ""
+    property string previewThemeId: ""
+    property var previewTags: []
+    property int previewWallpaperCount: 0
     property string previewGenWallpaper: ""
     property string previewGenMode: "dark"
     property string previewGenSchemeType: "tonal-spot"
@@ -214,6 +221,16 @@ Item {
         previewPaletteDebounce.restart();
     }
 
+    function resetPreviewRecipe(): void {
+        previewGtkTheme = "";
+        previewIconTheme = "";
+        previewGtkPrefer = "";
+        previewWallpaperLabel = "";
+        previewThemeId = "";
+        previewTags = [];
+        previewWallpaperCount = 0;
+    }
+
     function startSchemePreview(modelData: var): void {
         if (!modelData)
             return;
@@ -224,6 +241,11 @@ Item {
         previewSubtitle = qsTr("Color scheme");
         previewVariant = modelData.flavour ?? "";
         previewSchemeType = normalizeSchemeType(modelData.flavour ?? "");
+        resetPreviewRecipe();
+        previewMode = pendingMode;
+        previewGtkTheme = pendingGtkTheme;
+        previewIconTheme = pendingIconTheme;
+        previewWallpaperLabel = pendingWallpaperPath ? pendingWallpaperPath.split("/").pop() : "";
         scheduleGeneratedPreview(previewWallpaperPath || pendingWallpaperPath, pendingMode, previewSchemeType);
     }
 
@@ -239,6 +261,10 @@ Item {
         previewSubtitle = qsTr("Color variant");
         previewVariant = scheme.flavour ?? variant;
         previewSchemeType = normalizeSchemeType(scheme.flavour ?? variant);
+        resetPreviewRecipe();
+        previewMode = pendingMode;
+        previewGtkTheme = pendingGtkTheme;
+        previewIconTheme = pendingIconTheme;
         scheduleGeneratedPreview(previewWallpaperPath || pendingWallpaperPath, pendingMode, previewSchemeType);
     }
 
@@ -253,6 +279,10 @@ Item {
         previewSubtitle = qsTr("Theme mode");
         previewMode = mode;
         previewSchemeType = normalizeSchemeType(previewVariant || current.flavour || pendingVariant);
+        resetPreviewRecipe();
+        previewVariant = previewSchemeType;
+        previewGtkTheme = pendingGtkTheme;
+        previewIconTheme = pendingIconTheme;
         scheduleGeneratedPreview(previewWallpaperPath || pendingWallpaperPath, mode, previewSchemeType);
     }
 
@@ -260,12 +290,24 @@ Item {
         if (!path)
             return;
 
+        const keepThemeRecipe = previewSource === "theme" && !!previewThemeId;
+
         previewActive = true;
-        previewSource = "wallpaper";
-        previewTitle = label || path.split("/").pop();
-        previewSubtitle = qsTr("Wallpaper");
+        if (!keepThemeRecipe) {
+            previewSource = "wallpaper";
+            previewTitle = label || path.split("/").pop();
+            previewSubtitle = qsTr("Wallpaper");
+            resetPreviewRecipe();
+            previewMode = previewMode || pendingMode;
+            previewGtkTheme = pendingGtkTheme;
+            previewIconTheme = pendingIconTheme;
+        }
         previewWallpaperPath = path;
         previewSchemeType = normalizeSchemeType(previewVariant || pendingVariant);
+        previewVariant = previewSchemeType;
+        previewWallpaperLabel = label || path.split("/").pop();
+        if (!previewMode)
+            previewMode = pendingMode;
         scheduleGeneratedPreview(path, previewMode || pendingMode, previewSchemeType);
     }
 
@@ -281,6 +323,23 @@ Item {
         previewMode = modelData.darkMode ? "dark" : "light";
         previewWallpaperPath = modelData.wallpaperPath ?? modelData.wallpaper ?? "";
         previewSchemeType = normalizeSchemeType(modelData.schemeType ?? "");
+        previewGtkTheme = modelData.gtkTheme || "Orchis-Light-Compact";
+        previewIconTheme = modelData.iconTheme || "";
+        if (modelData.gtkPreferDark !== undefined)
+            previewGtkPrefer = modelData.gtkPreferDark ? "prefer-dark" : "prefer-light";
+        else {
+            const gtk = (previewGtkTheme || "").toLowerCase();
+            if (gtk.indexOf("light") >= 0)
+                previewGtkPrefer = "prefer-light";
+            else if (gtk.indexOf("dark") >= 0)
+                previewGtkPrefer = "prefer-dark";
+            else
+                previewGtkPrefer = modelData.darkMode ? "prefer-dark" : "prefer-light";
+        }
+        previewWallpaperLabel = modelData.defaultWallpaper || (previewWallpaperPath ? previewWallpaperPath.split("/").pop() : "");
+        previewThemeId = modelData.id || "";
+        previewTags = modelData.tags ?? [];
+        previewWallpaperCount = Array.isArray(modelData.wallpapers) ? modelData.wallpapers.length : 0;
 
         scheduleGeneratedPreview(previewWallpaperPath || pendingWallpaperPath, previewMode, previewSchemeType);
     }
@@ -299,6 +358,7 @@ Item {
         previewMode = "";
         previewWallpaperPath = "";
         previewSchemeType = "";
+        resetPreviewRecipe();
         previewPalette = {};
         previewRequestKey = "";
         previewRunningKey = "";
@@ -363,6 +423,19 @@ Item {
         iconDirty = false;
         stagedThemeWallpaper = "";
         clearPreview();
+    }
+
+    // Apply staged changes immediately (click-to-apply). If the pipeline is busy,
+    // keep the selection staged and retry from onApplyFinished.
+    function commitPending(): void {
+        if (!hasPendingChanges)
+            return;
+        if (pipelineBusy)
+            return;
+        applyFailed = false;
+        applyStatusMessage = "";
+        commitSelection();
+        saveConfig();
     }
 
     function _flushDeferredMode(): void {
@@ -555,7 +628,7 @@ Item {
 
                 AppearancePreviewPane {
                     Layout.fillWidth: true
-                    Layout.preferredHeight: 320
+                    Layout.preferredHeight: root.previewSource === "theme" ? 460 : 340
                     Layout.bottomMargin: Appearance.spacing.normal
 
                     active: root.previewActive
@@ -565,6 +638,13 @@ Item {
                     variantText: root.previewVariant
                     modeText: root.previewMode
                     wallpaperPath: root.previewWallpaperPath || root.pendingWallpaperPath
+                    gtkThemeText: root.previewGtkTheme
+                    iconThemeText: root.previewIconTheme
+                    gtkPreferText: root.previewGtkPrefer
+                    wallpaperLabel: root.previewWallpaperLabel
+                    themeIdText: root.previewThemeId
+                    tags: root.previewTags
+                    wallpaperCount: root.previewWallpaperCount
                     rootPane: root
                 }
 
@@ -822,12 +902,7 @@ Item {
                             type: IconButton.Filled
                             enabled: root.canApply
                             Accessible.name: qsTr("Apply appearance changes")
-                            onClicked: {
-                                root.applyFailed = false;
-                                root.applyStatusMessage = "";
-                                root.commitSelection();
-                                root.saveConfig();
-                            }
+                            onClicked: root.commitPending()
                         }
                     }
                 }
@@ -895,6 +970,9 @@ Item {
                 liveGtkProc.running = true;
             if (!root.iconDirty)
                 liveIconProc.running = true;
+            // User selected something else while we were busy — apply it now.
+            if (root.hasPendingChanges)
+                root.commitPending();
         }
     }
 

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/AppearancePane.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/AppearancePane.qml
@@ -817,11 +817,11 @@ Item {
 
     Process {
         id: liveIconProc
-        command: ["bash", "-c", `gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'"`]
+        command: ["dots-gtk-theme", "-q", "-p", "current-icon"]
         stdout: StdioCollector {
             onStreamFinished: {
                 const name = text.trim();
-                if (name)
+                if (name && name !== "Unknown")
                     root.pendingIconTheme = name;
             }
         }

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/AppearancePane.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/AppearancePane.qml
@@ -77,7 +77,20 @@ Item {
     property string deferredMode: ""
     property string deferredGtk: ""
     property string deferredIcon: ""
+    property string applyStatusMessage: ""
+    property bool applyFailed: false
     readonly property bool hasPendingChanges: themeDirty || schemeDirty || variantDirty || modeDirty || wallpaperDirty || gtkDirty || iconDirty
+    readonly property bool pipelineBusy: ThemePipeline.busy
+    readonly property bool canApply: hasPendingChanges && !pipelineBusy
+    readonly property string footerStatusText: {
+        if (pipelineBusy)
+            return qsTr("Applying appearance…");
+        if (applyFailed && applyStatusMessage)
+            return applyStatusMessage;
+        if (hasPendingChanges)
+            return qsTr("Pending appearance changes — press Apply to commit");
+        return qsTr("No pending changes");
+    }
     property bool previewActive: false
     property string previewSource: ""
     property string previewTitle: ""
@@ -466,8 +479,11 @@ Item {
         gtkDirty = false;
         iconDirty = false;
         // Seed live GTK/icon so section checkmarks reflect current state.
+        // Do not overwrite a user-staged selection if a previous seed is still in flight.
         liveGtkProc.running = true;
         liveIconProc.running = true;
+        applyFailed = false;
+        applyStatusMessage = "";
         if (!previewActive) {
             previewWallpaperPath = pendingWallpaperPath;
             previewVariant = pendingVariant;
@@ -774,23 +790,41 @@ Item {
 
                         StyledText {
                             Layout.fillWidth: true
-                            text: root.hasPendingChanges ? qsTr("Pending appearance changes") : qsTr("No pending changes")
-                            color: root.hasPendingChanges ? Colours.palette.m3primary : Colours.palette.m3outline
+                            text: root.footerStatusText
+                            color: {
+                                if (root.applyFailed)
+                                    return Colours.palette.m3error;
+                                if (root.pipelineBusy || root.hasPendingChanges)
+                                    return Colours.palette.m3primary;
+                                return Colours.palette.m3outline;
+                            }
                             font.pointSize: Appearance.font.size.small
+                            wrapMode: Text.WordWrap
+                        }
+
+                        CircularIndicator {
+                            visible: root.pipelineBusy
+                            running: root.pipelineBusy
+                            implicitSize: Appearance.font.size.large * 1.4
+                            strokeWidth: Appearance.padding.small * 0.5
                         }
 
                         IconButton {
                             icon: "refresh"
                             type: IconButton.Text
-                            enabled: root.hasPendingChanges
+                            enabled: root.hasPendingChanges && !root.pipelineBusy
+                            Accessible.name: qsTr("Reset pending appearance changes")
                             onClicked: root.resetPendingSelections()
                         }
 
                         IconButton {
-                            icon: "check"
+                            icon: root.pipelineBusy ? "hourglass_top" : "check"
                             type: IconButton.Filled
-                            enabled: root.hasPendingChanges
+                            enabled: root.canApply
+                            Accessible.name: qsTr("Apply appearance changes")
                             onClicked: {
+                                root.applyFailed = false;
+                                root.applyStatusMessage = "";
                                 root.commitSelection();
                                 root.saveConfig();
                             }
@@ -808,6 +842,9 @@ Item {
         command: ["dots-gtk-theme", "-q", "-p", "current"]
         stdout: StdioCollector {
             onStreamFinished: {
+                // Never clobber a staged GTK selection with a late live-seed result.
+                if (root.gtkDirty)
+                    return;
                 const name = text.trim();
                 if (name && name !== "Unknown")
                     root.pendingGtkTheme = name;
@@ -820,6 +857,8 @@ Item {
         command: ["dots-gtk-theme", "-q", "-p", "current-icon"]
         stdout: StdioCollector {
             onStreamFinished: {
+                if (root.iconDirty)
+                    return;
                 const name = text.trim();
                 if (name && name !== "Unknown")
                     root.pendingIconTheme = name;
@@ -844,9 +883,18 @@ Item {
                 root.deferredMode = "";
                 root.deferredGtk = "";
                 root.deferredIcon = "";
+                root.applyFailed = true;
+                root.applyStatusMessage = ThemePipeline.lastError || qsTr("Appearance apply failed");
                 return;
             }
+            root.applyFailed = false;
+            root.applyStatusMessage = "";
             root._flushDeferredPipelineExtras();
+            // Refresh live GTK/icon checkmarks after a successful pipeline apply.
+            if (!root.gtkDirty)
+                liveGtkProc.running = true;
+            if (!root.iconDirty)
+                liveIconProc.running = true;
         }
     }
 

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/AppearancePane.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/AppearancePane.qml
@@ -452,8 +452,6 @@ Item {
         pendingMode = Colours.currentLight ? "light" : "dark";
         pendingWallpaperPath = Wallpapers.actualCurrent;
         stagedThemeWallpaper = "";
-        pendingGtkTheme = "";
-        pendingIconTheme = "";
         wallpaperScopeDir = "";
         wallpaperShowAll = false;
         themeDirty = false;
@@ -467,6 +465,9 @@ Item {
         wallpaperDirty = false;
         gtkDirty = false;
         iconDirty = false;
+        // Seed live GTK/icon so section checkmarks reflect current state.
+        liveGtkProc.running = true;
+        liveIconProc.running = true;
         if (!previewActive) {
             previewWallpaperPath = pendingWallpaperPath;
             previewVariant = pendingVariant;
@@ -800,6 +801,30 @@ Item {
         }
 
         rightContent: appearanceRightContentComponent
+    }
+
+    Process {
+        id: liveGtkProc
+        command: ["dots-gtk-theme", "-q", "-p", "current"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const name = text.trim();
+                if (name && name !== "Unknown")
+                    root.pendingGtkTheme = name;
+            }
+        }
+    }
+
+    Process {
+        id: liveIconProc
+        command: ["bash", "-c", `gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'"`]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const name = text.trim();
+                if (name)
+                    root.pendingIconTheme = name;
+            }
+        }
     }
 
     Connections {

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/AppearancePreviewPane.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/AppearancePreviewPane.qml
@@ -76,7 +76,11 @@ StyledRect {
 
                 StyledText {
                     Layout.fillWidth: true
-                    text: root.subtitleText || qsTr("Preview updates here before applying")
+                    text: {
+                        if (root.rootPane.previewPaletteQueued || !!root.rootPane.previewRunningKey && Object.keys(root.rootPane.previewPalette ?? {}).length === 0)
+                            return qsTr("Generating palette preview…");
+                        return root.subtitleText || qsTr("Preview updates here before applying");
+                    }
                     color: previewColor("m3outline", Colours.palette.m3outline)
                     font.pointSize: Appearance.font.size.small
                     elide: Text.ElideRight

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/AppearancePreviewPane.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/AppearancePreviewPane.qml
@@ -4,6 +4,8 @@ import qs.components
 import qs.components.images
 import qs.services
 import qs.config
+import qs.utils
+import Quickshell
 import QtQuick
 import QtQuick.Layouts
 
@@ -19,11 +21,75 @@ StyledRect {
     required property string wallpaperPath
     required property var rootPane
 
+    property string gtkThemeText: ""
+    property string iconThemeText: ""
+    property string gtkPreferText: ""
+    property string wallpaperLabel: ""
+    property string themeIdText: ""
+    property var tags: []
+    property int wallpaperCount: 0
+
+    readonly property bool isThemePreview: source === "theme"
+    readonly property bool hasRecipe: {
+        return !!modeText || !!variantText || !!gtkThemeText || !!iconThemeText || !!gtkPreferText || !!wallpaperLabel || (tags && tags.length > 0);
+    }
+    readonly property bool showVisualSamples: active && (!!gtkThemeText || !!iconThemeText)
+
     function previewColor(role: string, fallback: color): color {
         const p = root.rootPane.previewPalette;
         if (p && Object.prototype.hasOwnProperty.call(p, role))
             return p[role];
         return fallback;
+    }
+
+    function modeLabel(mode: string): string {
+        return mode === "light" ? qsTr("Light") : qsTr("Dark");
+    }
+
+    function basename(path: string): string {
+        if (!path)
+            return "";
+        const parts = path.split("/");
+        return parts[parts.length - 1] || path;
+    }
+
+    function gtkThumbnailCandidates(theme: string): var {
+        if (!theme || theme === "auto")
+            return [];
+        const home = Paths.home;
+        const data = Quickshell.env("XDG_DATA_HOME") || `${home}/.local/share`;
+        return [
+            `/usr/share/themes/${theme}/gtk-3.0/thumbnail.png`,
+            `/usr/share/themes/${theme}/cinnamon/thumbnail.png`,
+            `/usr/share/themes/${theme}/metacity-1/thumbnail.png`,
+            `${data}/themes/${theme}/gtk-3.0/thumbnail.png`,
+            `${data}/themes/${theme}/cinnamon/thumbnail.png`,
+            `${home}/.themes/${theme}/gtk-3.0/thumbnail.png`
+        ];
+    }
+
+    function iconSampleCandidates(theme: string, name: string): var {
+        if (!theme || !name)
+            return [];
+        const home = Paths.home;
+        const data = Quickshell.env("XDG_DATA_HOME") || `${home}/.local/share`;
+        const roots = [`/usr/share/icons/${theme}`, `${data}/icons/${theme}`, `${home}/.icons/${theme}`];
+        // Prefer common layouts first (Numix/Papirus size/cat, Adwaita scalable, Breeze cat/size).
+        const rels = [
+            `48/apps/${name}.svg`, `48/places/${name}.svg`, `48/categories/${name}.svg`,
+            `48x48/apps/${name}.svg`, `48x48/places/${name}.svg`,
+            `scalable/apps/${name}.svg`, `scalable/places/${name}.svg`, `scalable/categories/${name}.svg`,
+            `32/apps/${name}.svg`, `32/places/${name}.svg`,
+            `apps/64/${name}.svg`, `places/64/${name}.svg`, `categories/64/${name}.svg`,
+            `apps/48/${name}.svg`, `places/48/${name}.svg`,
+            `48/apps/${name}.png`, `48/places/${name}.png`, `scalable/places/${name}.png`
+        ];
+        const out = [];
+        for (let r = 0; r < roots.length; r++) {
+            for (let i = 0; i < rels.length; i++)
+                out.push(`${roots[r]}/${rels[i]}`);
+        }
+        return out;
     }
 
     radius: Appearance.rounding.normal
@@ -37,8 +103,9 @@ StyledRect {
             anchors.fill: parent
             spacing: Appearance.spacing.normal
 
+            // Wallpaper / visual hero
             StyledClippingRect {
-                Layout.preferredWidth: 220
+                Layout.preferredWidth: root.isThemePreview ? 180 : 220
                 Layout.fillHeight: true
                 radius: Appearance.rounding.normal
                 color: previewColor("m3surfaceContainerHigh", Colours.tPalette.m3surfaceContainerHigh)
@@ -49,6 +116,36 @@ StyledRect {
                     fillMode: Image.PreserveAspectCrop
                     asynchronous: true
                     cache: true
+                }
+
+                // Mode badge over wallpaper
+                StyledRect {
+                    anchors.left: parent.left
+                    anchors.top: parent.top
+                    anchors.margins: Appearance.padding.small
+                    visible: root.active && !!root.modeText
+                    radius: Appearance.rounding.full
+                    color: Qt.alpha(previewColor("m3surface", Colours.palette.m3surface), 0.88)
+                    implicitWidth: modeBadge.implicitWidth + Appearance.padding.small * 2
+                    implicitHeight: modeBadge.implicitHeight + Appearance.padding.smaller
+
+                    Row {
+                        id: modeBadge
+                        anchors.centerIn: parent
+                        spacing: 4
+
+                        MaterialIcon {
+                            text: root.modeText === "light" ? "light_mode" : "dark_mode"
+                            font.pointSize: Appearance.font.size.small
+                            color: previewColor("m3primary", Colours.palette.m3primary)
+                        }
+
+                        StyledText {
+                            text: root.modeLabel(root.modeText)
+                            font.pointSize: Appearance.font.size.smaller
+                            color: previewColor("m3onSurface", Colours.palette.m3onSurface)
+                        }
+                    }
                 }
 
                 MaterialIcon {
@@ -77,66 +174,270 @@ StyledRect {
                 StyledText {
                     Layout.fillWidth: true
                     text: {
-                        if (root.rootPane.previewPaletteQueued || !!root.rootPane.previewRunningKey && Object.keys(root.rootPane.previewPalette ?? {}).length === 0)
+                        if (root.rootPane.previewPaletteQueued || (!!root.rootPane.previewRunningKey && Object.keys(root.rootPane.previewPalette ?? {}).length === 0))
                             return qsTr("Generating palette preview…");
-                        return root.subtitleText || qsTr("Preview updates here before applying");
+                        return root.subtitleText || qsTr("Preview updates here — click to apply");
                     }
                     color: previewColor("m3outline", Colours.palette.m3outline)
                     font.pointSize: Appearance.font.size.small
                     elide: Text.ElideRight
+                    maximumLineCount: 2
+                    wrapMode: Text.WordWrap
                 }
 
+                // Palette swatches
                 RowLayout {
                     Layout.fillWidth: true
                     spacing: Appearance.spacing.small
 
-                    StyledRect {
-                        radius: Appearance.rounding.full
-                        color: previewColor("m3primary", Colours.palette.m3primary)
-                        implicitHeight: 24
-                        implicitWidth: 24
-                    }
+                    Repeater {
+                        model: [
+                            {
+                                role: "m3primary",
+                                fallback: Colours.palette.m3primary
+                            },
+                            {
+                                role: "m3secondary",
+                                fallback: Colours.palette.m3secondary
+                            },
+                            {
+                                role: "m3tertiary",
+                                fallback: Colours.palette.m3tertiary
+                            },
+                            {
+                                role: "m3surface",
+                                fallback: Colours.palette.m3surface
+                            },
+                            {
+                                role: "m3error",
+                                fallback: Colours.palette.m3error
+                            }
+                        ]
 
-                    StyledRect {
-                        radius: Appearance.rounding.full
-                        color: previewColor("m3surface", Colours.palette.m3surface)
-                        implicitHeight: 24
-                        implicitWidth: 24
-                    }
-
-                    StyledRect {
-                        radius: Appearance.rounding.full
-                        color: previewColor("m3secondary", Colours.palette.m3secondary)
-                        implicitHeight: 24
-                        implicitWidth: 24
+                        delegate: StyledRect {
+                            required property var modelData
+                            radius: Appearance.rounding.full
+                            color: root.previewColor(modelData.role, modelData.fallback)
+                            implicitHeight: 22
+                            implicitWidth: 22
+                            border.width: 1
+                            border.color: Qt.alpha(previewColor("m3outline", Colours.palette.m3outline), 0.25)
+                        }
                     }
 
                     Item {
                         Layout.fillWidth: true
                     }
+
+                    StyledText {
+                        visible: root.isThemePreview && !!root.themeIdText
+                        text: root.themeIdText
+                        font.family: root.rootPane.fontFamilyMono
+                        font.pointSize: Appearance.font.size.smaller
+                        color: previewColor("m3outline", Colours.palette.m3outline)
+                    }
                 }
 
-                StyledText {
-                    Layout.fillWidth: true
-                    visible: !!root.variantText
-                    text: qsTr("Variant: %1").arg(root.variantText)
-                    font.pointSize: Appearance.font.size.small
-                    color: previewColor("m3onSurfaceVariant", Colours.palette.m3onSurfaceVariant)
-                    elide: Text.ElideRight
-                }
-
-                StyledText {
-                    Layout.fillWidth: true
-                    visible: !!root.modeText
-                    text: qsTr("Mode: %1").arg(root.modeText)
-                    font.pointSize: Appearance.font.size.small
-                    color: previewColor("m3onSurfaceVariant", Colours.palette.m3onSurfaceVariant)
-                    elide: Text.ElideRight
-                }
-
+                // Recipe details (what Apply will set)
                 StyledRect {
                     Layout.fillWidth: true
                     Layout.fillHeight: true
+                    visible: root.active && root.hasRecipe
+                    radius: Appearance.rounding.normal
+                    color: Qt.alpha(previewColor("m3surfaceContainerHigh", Colours.tPalette.m3surfaceContainerHigh), 0.65)
+
+                    ColumnLayout {
+                        anchors.fill: parent
+                        anchors.margins: Appearance.padding.normal
+                        spacing: Appearance.spacing.small / 2
+
+                        StyledText {
+                            text: root.isThemePreview ? qsTr("This theme applies") : qsTr("Preview details")
+                            font.pointSize: Appearance.font.size.small
+                            font.weight: 600
+                            color: previewColor("m3onSurface", Colours.palette.m3onSurface)
+                        }
+
+                        Flow {
+                            Layout.fillWidth: true
+                            visible: !root.isThemePreview
+                            spacing: Appearance.spacing.smaller
+
+                            PreviewChip {
+                                visible: !!root.modeText
+                                icon: root.modeText === "light" ? "light_mode" : "dark_mode"
+                                label: qsTr("Mode")
+                                value: root.modeLabel(root.modeText)
+                            }
+
+                            PreviewChip {
+                                visible: !!root.variantText
+                                icon: "palette"
+                                label: qsTr("Scheme")
+                                value: root.variantText
+                            }
+
+                            PreviewChip {
+                                visible: !!root.gtkThemeText
+                                icon: "desktop_windows"
+                                label: qsTr("GTK")
+                                value: root.gtkThemeText
+                            }
+
+                            PreviewChip {
+                                visible: !!root.iconThemeText
+                                icon: "imagesmode"
+                                label: qsTr("Icons")
+                                value: root.iconThemeText
+                            }
+
+                            PreviewChip {
+                                visible: !!root.wallpaperLabel || !!root.wallpaperPath
+                                icon: "wallpaper"
+                                label: qsTr("Wallpaper")
+                                value: root.wallpaperLabel || root.basename(root.wallpaperPath)
+                            }
+                        }
+
+                        // Exact recipe for theme packs
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            visible: root.isThemePreview
+                            spacing: 2
+
+                            RecipeRow {
+                                icon: root.modeText === "light" ? "light_mode" : "dark_mode"
+                                label: qsTr("Theme mode")
+                                value: root.modeLabel(root.modeText)
+                            }
+
+                            RecipeRow {
+                                icon: "palette"
+                                label: qsTr("M3 scheme type")
+                                value: root.variantText || "—"
+                            }
+
+                            RecipeRow {
+                                icon: "desktop_windows"
+                                label: qsTr("GTK theme")
+                                value: root.gtkThemeText || "—"
+                            }
+
+                            RecipeRow {
+                                icon: root.gtkPreferText === "prefer-light" ? "light_mode" : "dark_mode"
+                                label: qsTr("GTK prefer")
+                                value: root.gtkPreferText || "—"
+                            }
+
+                            RecipeRow {
+                                icon: "imagesmode"
+                                label: qsTr("Icon theme")
+                                value: root.iconThemeText || "—"
+                            }
+
+                            RecipeRow {
+                                icon: "wallpaper"
+                                label: qsTr("Default wallpaper")
+                                value: root.wallpaperLabel || root.basename(root.wallpaperPath) || "—"
+                            }
+
+                            RecipeRow {
+                                visible: root.wallpaperCount > 0
+                                icon: "photo_library"
+                                label: qsTr("Wallpapers in pack")
+                                value: String(root.wallpaperCount)
+                            }
+                        }
+
+                        // Visual samples: GTK thumbnail + icon strip
+                        RowLayout {
+                            Layout.fillWidth: true
+                            Layout.topMargin: Appearance.spacing.small / 2
+                            visible: root.showVisualSamples
+                            spacing: Appearance.spacing.normal
+
+                            ColumnLayout {
+                                spacing: 4
+                                visible: !!root.gtkThemeText
+
+                                StyledText {
+                                    text: qsTr("GTK")
+                                    font.pointSize: Appearance.font.size.smaller
+                                    color: previewColor("m3outline", Colours.palette.m3outline)
+                                }
+
+                                FallbackImage {
+                                    implicitWidth: 88
+                                    implicitHeight: 56
+                                    candidates: root.gtkThumbnailCandidates(root.gtkThemeText)
+                                    placeholderIcon: "desktop_windows"
+                                    placeholderText: root.gtkThemeText === "auto" ? qsTr("auto") : qsTr("No thumb")
+                                }
+                            }
+
+                            ColumnLayout {
+                                Layout.fillWidth: true
+                                spacing: 4
+                                visible: !!root.iconThemeText
+
+                                StyledText {
+                                    text: qsTr("Icons")
+                                    font.pointSize: Appearance.font.size.smaller
+                                    color: previewColor("m3outline", Colours.palette.m3outline)
+                                }
+
+                                Row {
+                                    spacing: Appearance.spacing.small
+
+                                    Repeater {
+                                        model: ["folder", "user-home", "firefox", "terminal", "system-file-manager", "applications-system"]
+
+                                        delegate: FallbackImage {
+                                            required property string modelData
+                                            implicitWidth: 28
+                                            implicitHeight: 28
+                                            candidates: root.iconSampleCandidates(root.iconThemeText, modelData)
+                                            placeholderIcon: ""
+                                            hideWhenMissing: true
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        Flow {
+                            Layout.fillWidth: true
+                            visible: root.tags && root.tags.length > 0
+                            spacing: Appearance.spacing.smaller
+
+                            Repeater {
+                                model: root.tags ?? []
+
+                                delegate: StyledRect {
+                                    required property var modelData
+                                    radius: Appearance.rounding.full
+                                    color: Qt.alpha(previewColor("m3secondaryContainer", Colours.palette.m3secondaryContainer), 0.55)
+                                    implicitWidth: tagLabel.implicitWidth + Appearance.padding.small * 2
+                                    implicitHeight: tagLabel.implicitHeight + Appearance.padding.smaller
+
+                                    StyledText {
+                                        id: tagLabel
+                                        anchors.centerIn: parent
+                                        text: modelData
+                                        font.pointSize: Appearance.font.size.smaller
+                                        color: previewColor("m3onSecondaryContainer", Colours.palette.m3onSecondaryContainer)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Shell chrome preview (non-theme sources keep the typography sandbox)
+                StyledRect {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    visible: root.active && !root.isThemePreview
                     radius: Appearance.rounding.normal * root.rootPane.roundingScale
                     color: root.rootPane.transparencyEnabled ? Qt.alpha(previewColor("m3surfaceContainer", Colours.palette.m3surfaceContainer), root.rootPane.transparencyBase) : previewColor("m3surfaceContainer", Colours.palette.m3surfaceContainer)
 
@@ -161,38 +462,185 @@ StyledRect {
                         }
 
                         StyledText {
-                            text: qsTr("Material font: %1").arg(root.rootPane.fontFamilyMaterial)
-                            font.family: root.rootPane.fontFamilySans
-                            font.pointSize: Appearance.font.size.small * root.rootPane.fontSizeScale
-                            color: previewColor("m3outline", Colours.palette.m3outline)
-                            elide: Text.ElideRight
-                        }
-
-                        StyledText {
-                            text: qsTr("Scale r/s/p/f/a: %1 / %2 / %3 / %4 / %5").arg(root.rootPane.roundingScale.toFixed(2)).arg(root.rootPane.spacingScale.toFixed(2)).arg(root.rootPane.paddingScale.toFixed(2)).arg(root.rootPane.fontSizeScale.toFixed(2)).arg(root.rootPane.animDurationsScale.toFixed(2))
-                            font.family: root.rootPane.fontFamilyMono
-                            font.pointSize: Appearance.font.size.smaller * root.rootPane.fontSizeScale
-                            color: previewColor("m3onSurfaceVariant", Colours.palette.m3onSurfaceVariant)
-                            elide: Text.ElideRight
-                        }
-
-                        StyledText {
-                            text: qsTr("Border: thickness %1 / rounding %2").arg(Math.round(root.rootPane.borderThickness)).arg(Math.round(root.rootPane.borderRounding))
-                            font.family: root.rootPane.fontFamilySans
-                            font.pointSize: Appearance.font.size.smaller * root.rootPane.fontSizeScale
+                            visible: !!root.variantText
+                            text: qsTr("Variant: %1").arg(root.variantText)
+                            font.pointSize: Appearance.font.size.small
                             color: previewColor("m3onSurfaceVariant", Colours.palette.m3onSurfaceVariant)
                         }
 
                         StyledText {
-                            text: qsTr("Clock: %1 (%2) | Visualiser: %3").arg(root.rootPane.desktopClockEnabled ? "on" : "off").arg(root.rootPane.desktopClockPosition).arg(root.rootPane.visualiserEnabled ? "on" : "off")
-                            font.family: root.rootPane.fontFamilySans
-                            font.pointSize: Appearance.font.size.smaller * root.rootPane.fontSizeScale
+                            visible: !!root.modeText
+                            text: qsTr("Mode: %1").arg(root.modeLabel(root.modeText))
+                            font.pointSize: Appearance.font.size.small
                             color: previewColor("m3onSurfaceVariant", Colours.palette.m3onSurfaceVariant)
-                            elide: Text.ElideRight
                         }
                     }
                 }
+
+                // Idle hint
+                Item {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    visible: !root.active
+
+                    StyledText {
+                        anchors.centerIn: parent
+                        text: qsTr("Hover or select a theme, wallpaper, mode, or scheme")
+                        color: previewColor("m3outline", Colours.palette.m3outline)
+                        font.pointSize: Appearance.font.size.small
+                    }
+                }
             }
+        }
+    }
+
+    component PreviewChip: StyledRect {
+        id: chip
+
+        property string icon
+        property string label
+        property string value
+
+        radius: Appearance.rounding.full
+        color: Qt.alpha(previewColor("m3primaryContainer", Colours.palette.m3primaryContainer), 0.7)
+        implicitWidth: chipRow.implicitWidth + Appearance.padding.small * 2
+        implicitHeight: chipRow.implicitHeight + Appearance.padding.smaller
+
+        Row {
+            id: chipRow
+            anchors.centerIn: parent
+            spacing: 4
+
+            MaterialIcon {
+                text: chip.icon
+                font.pointSize: Appearance.font.size.small
+                color: previewColor("m3onPrimaryContainer", Colours.palette.m3onPrimaryContainer)
+            }
+
+            StyledText {
+                text: `${chip.label}: ${chip.value}`
+                font.pointSize: Appearance.font.size.smaller
+                color: previewColor("m3onPrimaryContainer", Colours.palette.m3onPrimaryContainer)
+            }
+        }
+    }
+
+    component RecipeRow: RowLayout {
+        id: row
+
+        property string icon
+        property string label
+        property string value
+
+        Layout.fillWidth: true
+        spacing: Appearance.spacing.small
+
+        MaterialIcon {
+            text: row.icon
+            font.pointSize: Appearance.font.size.small
+            color: previewColor("m3primary", Colours.palette.m3primary)
+        }
+
+        StyledText {
+            text: row.label
+            font.pointSize: Appearance.font.size.small
+            color: previewColor("m3outline", Colours.palette.m3outline)
+            Layout.preferredWidth: 120
+        }
+
+        StyledText {
+            Layout.fillWidth: true
+            text: row.value
+            font.pointSize: Appearance.font.size.small
+            font.weight: 500
+            color: previewColor("m3onSurface", Colours.palette.m3onSurface)
+            elide: Text.ElideMiddle
+        }
+    }
+
+    // Tries candidate file paths until one loads; optional placeholder when none do.
+    component FallbackImage: StyledRect {
+        id: thumb
+
+        property var candidates: []
+        property string placeholderIcon: "image"
+        property string placeholderText: ""
+        property bool hideWhenMissing: false
+
+        property int candidateIndex: 0
+        property bool loaded: false
+        property bool exhausted: false
+
+        radius: Appearance.rounding.small
+        color: Qt.alpha(previewColor("m3surface", Colours.palette.m3surface), 0.55)
+        visible: !(hideWhenMissing && exhausted && !loaded)
+        clip: true
+
+        onCandidatesChanged: {
+            candidateIndex = 0;
+            loaded = false;
+            exhausted = !candidates || candidates.length === 0;
+            img.source = (!exhausted && candidates[0]) ? `file://${candidates[0]}` : "";
+        }
+
+        Image {
+            id: img
+            anchors.fill: parent
+            anchors.margins: loaded ? 0 : Appearance.padding.smaller
+            fillMode: Image.PreserveAspectCrop
+            asynchronous: true
+            cache: true
+            visible: thumb.loaded
+            sourceSize.width: thumb.implicitWidth * 2
+            sourceSize.height: thumb.implicitHeight * 2
+
+            onStatusChanged: {
+                if (status === Image.Ready) {
+                    thumb.loaded = true;
+                    thumb.exhausted = false;
+                    return;
+                }
+                if (status === Image.Error || status === Image.Null) {
+                    const next = thumb.candidateIndex + 1;
+                    if (thumb.candidates && next < thumb.candidates.length) {
+                        thumb.candidateIndex = next;
+                        img.source = `file://${thumb.candidates[next]}`;
+                    } else {
+                        thumb.loaded = false;
+                        thumb.exhausted = true;
+                        img.source = "";
+                    }
+                }
+            }
+        }
+
+        Column {
+            anchors.centerIn: parent
+            spacing: 2
+            visible: !thumb.loaded && !thumb.hideWhenMissing
+
+            MaterialIcon {
+                anchors.horizontalCenter: parent.horizontalCenter
+                visible: !!thumb.placeholderIcon
+                text: thumb.placeholderIcon
+                font.pointSize: Appearance.font.size.normal
+                color: previewColor("m3outline", Colours.palette.m3outline)
+            }
+
+            StyledText {
+                anchors.horizontalCenter: parent.horizontalCenter
+                visible: !!thumb.placeholderText
+                text: thumb.placeholderText
+                font.pointSize: Appearance.font.size.smaller
+                color: previewColor("m3outline", Colours.palette.m3outline)
+            }
+        }
+
+        Component.onCompleted: {
+            if (candidates && candidates.length > 0)
+                img.source = `file://${candidates[0]}`;
+            else
+                exhausted = true;
         }
     }
 }

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/sections/ColorSchemeSection.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/sections/ColorSchemeSection.qml
@@ -45,6 +45,7 @@ CollapsibleSection {
                         const flavour = modelData.flavour;
                         previewController.startSchemePreview(modelData);
                         previewController.stageSchemeApply(name, flavour);
+                        previewController.commitPending();
                     }
                 }
 

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/sections/ColorVariantSection.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/sections/ColorVariantSection.qml
@@ -42,6 +42,7 @@ CollapsibleSection {
 
                         previewController.startVariantPreview(variant);
                         previewController.stageVariantApply(variant);
+                        previewController.commitPending();
                     }
                 }
 

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/sections/GtkThemeSection.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/sections/GtkThemeSection.qml
@@ -18,7 +18,7 @@ CollapsibleSection {
     required property var session
 
     title: qsTr("GTK theme")
-    description: qsTr("Application window theme (staged until Apply)")
+    description: qsTr("Application chrome theme — staged until Apply")
     showBackground: true
 
     property var themeNames: []

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/sections/GtkThemeSection.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/sections/GtkThemeSection.qml
@@ -18,7 +18,7 @@ CollapsibleSection {
     required property var session
 
     title: qsTr("GTK theme")
-    description: qsTr("Application chrome theme — staged until Apply")
+    description: qsTr("Application chrome theme — applies on click")
     showBackground: true
 
     property var themeNames: []
@@ -62,6 +62,7 @@ CollapsibleSection {
                 StateLayer {
                     function onClicked(): void {
                         previewController.stageGtkTheme(modelData);
+                        previewController.commitPending();
                     }
                 }
 

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/sections/GtkThemeSection.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/sections/GtkThemeSection.qml
@@ -32,7 +32,7 @@ CollapsibleSection {
     Process {
         id: listProc
 
-        command: ["bash", "-c", 'source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null; list_installed_gtk_themes 2>/dev/null || true']
+        command: ["dots-gtk-theme", "-q", "-p", "list"]
         stdout: StdioCollector {
             onStreamFinished: {
                 root.themeNames = text.split("\n").map(line => line.trim()).filter(line => line.length > 0);

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/sections/IconThemeSection.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/sections/IconThemeSection.qml
@@ -18,7 +18,7 @@ CollapsibleSection {
     required property var session
 
     title: qsTr("Icon theme")
-    description: qsTr("Desktop icon set (staged until Apply)")
+    description: qsTr("Desktop icon set — staged until Apply")
     showBackground: true
 
     property var iconNames: []

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/sections/IconThemeSection.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/sections/IconThemeSection.qml
@@ -18,7 +18,7 @@ CollapsibleSection {
     required property var session
 
     title: qsTr("Icon theme")
-    description: qsTr("Desktop icon set — staged until Apply")
+    description: qsTr("Desktop icon set — applies on click")
     showBackground: true
 
     property var iconNames: []
@@ -62,6 +62,7 @@ CollapsibleSection {
                 StateLayer {
                     function onClicked(): void {
                         previewController.stageIconTheme(modelData);
+                        previewController.commitPending();
                     }
                 }
 

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/sections/IconThemeSection.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/sections/IconThemeSection.qml
@@ -32,24 +32,7 @@ CollapsibleSection {
     Process {
         id: listProc
 
-        command: ["bash", "-c", `
-data_home="\${XDG_DATA_HOME:-$HOME/.local/share}"
-for d in /usr/share/icons /usr/local/share/icons "$HOME/.icons" "$data_home/icons"; do
-  [ -d "$d" ] || continue
-  find "$d" -maxdepth 1 -mindepth 1 -type d -printf '%f\\n' 2>/dev/null
-done | while read -r name; do
-  [ -z "$name" ] && continue
-  case "$name" in
-    default|hicolor) continue ;;
-  esac
-  for d in /usr/share/icons /usr/local/share/icons "$HOME/.icons" "$data_home/icons"; do
-    if [ -f "$d/$name/index.theme" ]; then
-      printf '%s\\n' "$name"
-      break
-    fi
-  done
-done | sort -u
-`]
+        command: ["dots-gtk-theme", "-q", "-p", "icons"]
         stdout: StdioCollector {
             onStreamFinished: {
                 root.iconNames = text.split("\n").map(line => line.trim()).filter(line => line.length > 0);

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/sections/ThemeModeSection.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/sections/ThemeModeSection.qml
@@ -16,7 +16,7 @@ CollapsibleSection {
     required property var session
 
     title: qsTr("Theme mode")
-    description: qsTr("Light or dark — live preference (theme packs set a default on apply)")
+    description: qsTr("Light or dark — applies on toggle")
     showBackground: true
 
     readonly property bool darkChecked: previewController.pendingMode === "dark"
@@ -38,6 +38,7 @@ CollapsibleSection {
             const mode = checked ? "dark" : "light";
             previewController.startModePreview(mode);
             previewController.stageModeApply(mode);
+            previewController.commitPending();
         }
 
         MouseArea {
@@ -50,7 +51,7 @@ CollapsibleSection {
 
     StyledText {
         visible: root.modeDivergesFromTheme
-        text: qsTr("Differs from staged theme default (%1)").arg(root.themeDefaultMode)
+        text: qsTr("Differs from theme default (%1)").arg(root.themeDefaultMode)
         color: Colours.palette.m3outline
         font.pointSize: Appearance.font.size.small
     }

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/sections/ThemesSection.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/sections/ThemesSection.qml
@@ -31,8 +31,8 @@ CollapsibleSection {
         if (theme.wallpaperPath && theme.defaultWallpaper === filename)
             return theme.wallpaperPath;
         const dir = theme.wallpaperDir || theme.id || "";
-        // Pictures is the canonical post-chezmoi location; list-themes.py
-        // already falls back to the data dir for defaultWallpaperPath.
+        // Prefer Pictures (post-chezmoi link); list-themes wallpaperPath already
+        // falls back to the data dir for the default wallpaper.
         return `${Paths.pictures}/Wallpapers/${dir}/${filename}`;
     }
 

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/sections/ThemesSection.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/sections/ThemesSection.qml
@@ -28,6 +28,9 @@ CollapsibleSection {
     function wallpaperPathFor(theme: var, filename: string): string {
         if (!theme || !filename)
             return "";
+        const mapped = theme.wallpaperPaths?.[filename];
+        if (mapped)
+            return mapped;
         if (theme.wallpaperPath && theme.defaultWallpaper === filename)
             return theme.wallpaperPath;
         const dir = theme.wallpaperDir || theme.id || "";
@@ -53,15 +56,15 @@ CollapsibleSection {
                 Layout.fillWidth: true
                 spacing: 0
 
-                readonly property bool isCurrent: modelData.id === previewController.pendingThemeId
+                readonly property bool isStaged: modelData.id === previewController.pendingThemeId
                 readonly property bool isExpanded: modelData.id === sectionRoot.selectedThemeId
 
                 StyledRect {
                     Layout.fillWidth: true
 
-                    color: Qt.alpha(Colours.tPalette.m3surfaceContainer, themeItem.isCurrent ? Colours.tPalette.m3surfaceContainer.a : 0)
+                    color: Qt.alpha(Colours.tPalette.m3surfaceContainer, themeItem.isStaged ? Colours.tPalette.m3surfaceContainer.a : 0)
                     radius: Appearance.rounding.normal
-                    border.width: themeItem.isCurrent ? 1 : 0
+                    border.width: themeItem.isStaged ? 1 : 0
                     border.color: Colours.palette.m3primary
 
                     StateLayer {
@@ -147,11 +150,20 @@ CollapsibleSection {
                                 }
                             }
 
-                            MaterialIcon {
-                                visible: themeItem.isCurrent
-                                text: "check"
-                                color: Colours.palette.m3primary
-                                font.pointSize: Appearance.font.size.large
+                            StyledRect {
+                                visible: themeItem.isStaged
+                                radius: Appearance.rounding.full
+                                color: Qt.alpha(Colours.palette.m3primaryContainer, 0.85)
+                                implicitWidth: stagedChip.implicitWidth + Appearance.padding.small * 2
+                                implicitHeight: stagedChip.implicitHeight + Appearance.padding.smaller * 2
+
+                                StyledText {
+                                    id: stagedChip
+                                    anchors.centerIn: parent
+                                    text: previewController.themeDirty ? qsTr("Staged") : qsTr("Selected")
+                                    font.pointSize: Appearance.font.size.smaller
+                                    color: Colours.palette.m3onPrimaryContainer
+                                }
                             }
                         }
 

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/sections/ThemesSection.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/sections/ThemesSection.qml
@@ -72,6 +72,7 @@ CollapsibleSection {
                             sectionRoot.selectedThemeId = themeItem.modelData.id;
                             previewController.stageThemeApply(themeItem.modelData.id);
                             previewController.startThemePreview(themeItem.modelData);
+                            previewController.commitPending();
                         }
                     }
 
@@ -133,6 +134,27 @@ CollapsibleSection {
                                     maximumLineCount: 2
                                     wrapMode: Text.WordWrap
                                 }
+
+                                StyledText {
+                                    width: parent.width
+                                    text: {
+                                        const bits = [];
+                                        if (modelData.schemeType)
+                                            bits.push(modelData.schemeType);
+                                        if (modelData.gtkTheme)
+                                            bits.push(modelData.gtkTheme);
+                                        const prefer = modelData.gtkPreferDark === undefined ? "" : (modelData.gtkPreferDark ? "prefer-dark" : "prefer-light");
+                                        if (prefer)
+                                            bits.push(prefer);
+                                        if (modelData.iconTheme)
+                                            bits.push(modelData.iconTheme);
+                                        return bits.join(" · ");
+                                    }
+                                    font.pointSize: Appearance.font.size.smaller
+                                    color: Colours.palette.m3outlineVariant
+                                    elide: Text.ElideRight
+                                    visible: !!(modelData.schemeType || modelData.gtkTheme || modelData.iconTheme)
+                                }
                             }
 
                             StyledRect {
@@ -160,7 +182,7 @@ CollapsibleSection {
                                 StyledText {
                                     id: stagedChip
                                     anchors.centerIn: parent
-                                    text: previewController.themeDirty ? qsTr("Staged") : qsTr("Selected")
+                                    text: previewController.themeDirty ? qsTr("Pending") : qsTr("Selected")
                                     font.pointSize: Appearance.font.size.smaller
                                     color: Colours.palette.m3onPrimaryContainer
                                 }
@@ -243,6 +265,7 @@ CollapsibleSection {
 
                                     function onClicked(): void {
                                         previewController.stageThemeApplyWithWallpaper(sectionRoot.selectedThemeId, wallpaperThumb.fullPath);
+                                        previewController.commitPending();
                                     }
                                 }
 

--- a/home/dot_config/quickshell/modules/controlcenter/components/WallpaperGrid.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/components/WallpaperGrid.qml
@@ -130,9 +130,9 @@ Item {
             radius: itemRadius
 
             function onClicked(): void {
-                // Stage only — Apply in the appearance sidebar commits.
                 root.previewController.startWallpaperPreview(modelData.path, modelData.name);
                 root.previewController.stageWallpaperApply(modelData.path);
+                root.previewController.commitPending();
             }
         }
 

--- a/home/dot_config/quickshell/modules/controlcenter/system/SystemPane.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/system/SystemPane.qml
@@ -388,8 +388,8 @@ Item {
                         ActionTile {
                             icon: "palette"
                             label: qsTr("GTK theme")
-                            description: qsTr("Pick GTK theme, icons and cursors")
-                            action: () => root.run(["nwg-look"])
+                            description: qsTr("Open Appearance to pick GTK theme and icons")
+                            action: () => root.run(["dots-theme-selector"])
                         }
 
                         ActionTile {

--- a/home/dot_config/quickshell/modules/dashboard/Weather.qml
+++ b/home/dot_config/quickshell/modules/dashboard/Weather.qml
@@ -11,9 +11,43 @@ Item {
     implicitHeight: layout.implicitHeight
 
     readonly property var today: Weather.forecast && Weather.forecast.length > 0 ? Weather.forecast[0] : null
-    readonly property bool isLoading: !Weather.city || Weather.forecast.length === 0
+    readonly property bool isLoading: Weather.loading || (!Weather.ready && !Weather.lastError)
+    readonly property bool isError: !Weather.loading && !!Weather.lastError && !Weather.ready
 
     Component.onCompleted: Weather.reload()
+
+    // ── Error state ───────────────────────────────────────────────────────────
+    Loader {
+        active: root.isError
+        visible: active
+        anchors.fill: parent
+
+        sourceComponent: Column {
+            anchors.centerIn: parent
+            spacing: Appearance.spacing.normal
+
+            MaterialIcon {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: "cloud_off"
+                font.pointSize: Appearance.font.size.extraLarge * 2
+                color: Colours.palette.m3error
+            }
+
+            StyledText {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: Weather.lastError || qsTr("Weather unavailable")
+                color: Colours.palette.m3onSurface
+                font.pointSize: Appearance.font.size.normal
+            }
+
+            StyledText {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: qsTr("Check network or set a location in Control Center → Dashboard")
+                color: Colours.palette.m3outline
+                font.pointSize: Appearance.font.size.small
+            }
+        }
+    }
 
     // ── Loading skeleton (shown while weather data is fetching) ───────────────
     Loader {
@@ -102,7 +136,7 @@ Item {
     }
 
     // ── Real content (shown when data is ready) ───────────────────────────────
-    opacity: root.isLoading ? 0 : 1
+    opacity: root.isLoading || root.isError ? 0 : 1
     Behavior on opacity { NumberAnimation { duration: 300; easing.type: Easing.OutCubic } }
 
     ColumnLayout {

--- a/home/dot_config/quickshell/modules/dashboard/dash/Weather.qml
+++ b/home/dot_config/quickshell/modules/dashboard/dash/Weather.qml
@@ -21,7 +21,7 @@ Item {
 
         animate: true
         text: Weather.icon
-        color: Colours.palette.m3secondary
+        color: Weather.lastError && !Weather.ready ? Colours.palette.m3error : Colours.palette.m3secondary
         font.pointSize: Appearance.font.size.extraLarge * 2
     }
 

--- a/home/dot_config/quickshell/modules/launcher/services/Themes.qml
+++ b/home/dot_config/quickshell/modules/launcher/services/Themes.qml
@@ -91,9 +91,18 @@ Searcher {
         readonly property var tags: modelData.tags ?? []
         readonly property bool darkMode: modelData.darkMode !== undefined ? !!modelData.darkMode : true
         readonly property string schemeType: modelData.schemeType || "tonal-spot"
-        readonly property string gtkTheme: modelData.gtkTheme || "auto"
+        readonly property string gtkTheme: modelData.gtkTheme || "Orchis-Light-Compact"
         readonly property string iconTheme: modelData.iconTheme || ""
-
+        readonly property bool gtkPreferDark: {
+            if (modelData.gtkPreferDark !== undefined)
+                return !!modelData.gtkPreferDark;
+            const gtk = gtkTheme.toLowerCase();
+            if (gtk.indexOf("light") >= 0)
+                return false;
+            if (gtk.indexOf("dark") >= 0)
+                return true;
+            return darkMode;
+        }
         function onClicked(list: AppList): void {
             list.visibilities.launcher = false;
             ThemePipeline.applyTheme(id, wallpaperPath || "");

--- a/home/dot_config/quickshell/modules/launcher/services/Themes.qml
+++ b/home/dot_config/quickshell/modules/launcher/services/Themes.qml
@@ -87,6 +87,7 @@ Searcher {
         readonly property string wallpaperDir: modelData.wallpaperDir || id
         readonly property string defaultWallpaper: modelData.defaultWallpaper || ""
         readonly property string wallpaperPath: modelData.wallpaperPath ?? ""
+        readonly property var wallpaperPaths: modelData.wallpaperPaths ?? ({})
         readonly property var tags: modelData.tags ?? []
         readonly property bool darkMode: modelData.darkMode !== undefined ? !!modelData.darkMode : true
         readonly property string schemeType: modelData.schemeType || "tonal-spot"

--- a/home/dot_config/quickshell/services/ThemePipeline.qml
+++ b/home/dot_config/quickshell/services/ThemePipeline.qml
@@ -27,12 +27,34 @@ Singleton {
     property string _pendingIconTheme: ""
     property string _pendingThemeName: ""
     property string _pendingThemeId: ""
+    // "true" | "false" | "" (infer from gtk theme name / shell mode)
+    property string _pendingGtkPreferDark: ""
     property bool _runThemeSideEffects: false
     property string _lastError: ""
     readonly property string lastError: _lastError
     property bool _startupRestored: false
 
     signal applyFinished(bool ok)
+
+    function resolveGtkPreferDark(cfg: var, darkMode: bool): string {
+        if (cfg && cfg.gtkPreferDark !== undefined && cfg.gtkPreferDark !== null && cfg.gtkPreferDark !== "")
+            return cfg.gtkPreferDark ? "true" : "false";
+        const gtk = ((cfg && cfg.gtkTheme) ? cfg.gtkTheme : "").toLowerCase();
+        if (gtk.indexOf("light") >= 0)
+            return "false";
+        if (gtk.indexOf("dark") >= 0)
+            return "true";
+        return darkMode ? "true" : "false";
+    }
+
+    function resolveGtkPreferFromName(gtkTheme: string, darkMode: bool): string {
+        const gtk = (gtkTheme || "").toLowerCase();
+        if (gtk.indexOf("light") >= 0)
+            return "false";
+        if (gtk.indexOf("dark") >= 0)
+            return "true";
+        return darkMode ? "true" : "false";
+    }
 
     function applyTheme(id: string, wallpaperPath: string): void {
         if (!id)
@@ -98,6 +120,7 @@ Singleton {
         _pendingIconTheme = "";
         _pendingThemeName = "";
         _pendingThemeId = "";
+        _pendingGtkPreferDark = "";
 
         if (job.kind === "theme") {
             _runThemeSideEffects = true;
@@ -118,6 +141,7 @@ Singleton {
         } else if (job.kind === "gtk") {
             gtkStandaloneProc.themeName = job.gtkTheme || "";
             gtkStandaloneProc.mode = Colours.currentLight ? "light" : "dark";
+            gtkStandaloneProc.preferDark = root.resolveGtkPreferFromName(job.gtkTheme || "", !Colours.currentLight);
             gtkStandaloneProc.running = true;
         } else if (job.kind === "icons") {
             iconOnlyProc.themeName = job.iconTheme || "";
@@ -197,6 +221,7 @@ Singleton {
             root._pendingGtkTheme = cfg.gtkTheme || "";
             root._pendingIconTheme = cfg.iconTheme || "";
             root._pendingThemeName = cfg.name || themeLoader.themeId;
+            root._pendingGtkPreferDark = root.resolveGtkPreferDark(cfg, root._pendingDarkMode);
 
             const wp = themeLoader.wallpaperOverride;
             if (wp) {
@@ -259,6 +284,7 @@ done
         const cfg = themeLoader.pendingConfig || {};
         _pendingSchemeType = cfg.schemeType || "tonal-spot";
         _pendingDarkMode = cfg.darkMode !== undefined ? !!cfg.darkMode : true;
+        _pendingGtkPreferDark = root.resolveGtkPreferDark(cfg, _pendingDarkMode);
         walPrepProc.running = true;
     }
 
@@ -348,6 +374,7 @@ done
             gtkFinalizeProc.iconTheme = root._runThemeSideEffects ? (root._pendingIconTheme || "") : "";
             gtkFinalizeProc.themeId = root._runThemeSideEffects ? (root._pendingThemeId || "") : "";
             gtkFinalizeProc.mode = root._pendingDarkMode ? "dark" : "light";
+            gtkFinalizeProc.preferDark = root._pendingGtkPreferDark || root.resolveGtkPreferFromName(root._pendingGtkTheme, root._pendingDarkMode);
             gtkFinalizeProc.running = true;
         }
     }
@@ -364,12 +391,20 @@ done
         property string iconTheme: ""
         property string themeId: ""
         property string mode: "dark"
+        property string preferDark: "true"
         command: ["bash", "-c", `
 set -euo pipefail
-prefer=$([[ "\${DOTS_MODE}" == "light" ]] && echo false || echo true)
+prefer="\${DOTS_GTK_PREFER:-}"
+if [[ -z "\$prefer" ]]; then
+  prefer=$([[ "\${DOTS_MODE}" == "light" ]] && echo false || echo true)
+fi
 if [[ -n "\${DOTS_THEME_ID:-}" && ( -z "\${DOTS_GTK_THEME:-}" || "\${DOTS_GTK_THEME}" == "auto" ) ]]; then
   dots-gtk-theme -q theme "\${DOTS_THEME_ID}" || true
-  dots-gtk-theme -q color-scheme "\${DOTS_MODE}" || true
+  if [[ "\$prefer" == "false" ]]; then
+    dots-gtk-theme -q color-scheme light || true
+  else
+    dots-gtk-theme -q color-scheme dark || true
+  fi
 elif [[ -n "\${DOTS_GTK_THEME:-}" && "\${DOTS_GTK_THEME}" != "auto" ]]; then
   if [[ -n "\${DOTS_ICON_THEME:-}" ]]; then
     dots-gtk-theme -q apply "\${DOTS_GTK_THEME}" "\${DOTS_ICON_THEME}" "\$prefer" || true
@@ -379,16 +414,25 @@ elif [[ -n "\${DOTS_GTK_THEME:-}" && "\${DOTS_GTK_THEME}" != "auto" ]]; then
   fi
 elif [[ -n "\${DOTS_ICON_THEME:-}" ]]; then
   dots-gtk-theme -q set-icons "\${DOTS_ICON_THEME}" || true
-  dots-gtk-theme -q color-scheme "\${DOTS_MODE}" || true
+  if [[ "\$prefer" == "false" ]]; then
+    dots-gtk-theme -q color-scheme light || true
+  else
+    dots-gtk-theme -q color-scheme dark || true
+  fi
 else
-  dots-gtk-theme -q color-scheme "\${DOTS_MODE}" || true
+  if [[ "\$prefer" == "false" ]]; then
+    dots-gtk-theme -q color-scheme light || true
+  else
+    dots-gtk-theme -q color-scheme dark || true
+  fi
 fi
 `]
         environment: ({
             "DOTS_GTK_THEME": gtkFinalizeProc.themeName,
             "DOTS_ICON_THEME": gtkFinalizeProc.iconTheme,
             "DOTS_THEME_ID": gtkFinalizeProc.themeId,
-            "DOTS_MODE": gtkFinalizeProc.mode
+            "DOTS_MODE": gtkFinalizeProc.mode,
+            "DOTS_GTK_PREFER": gtkFinalizeProc.preferDark
         })
         onExited: (exitCode, exitStatus) => {
             root._finishJob(true, "");
@@ -400,15 +444,20 @@ fi
         id: gtkStandaloneProc
         property string themeName: ""
         property string mode: "dark"
+        property string preferDark: "true"
         command: ["bash", "-c", `
 set -euo pipefail
-prefer=$([[ "\${DOTS_MODE}" == "light" ]] && echo false || echo true)
+prefer="\${DOTS_GTK_PREFER:-}"
+if [[ -z "\$prefer" ]]; then
+  prefer=$([[ "\${DOTS_MODE}" == "light" ]] && echo false || echo true)
+fi
 # Omit icon: dots-gtk-theme apply resolves the live icon theme.
 dots-gtk-theme -q apply "\${DOTS_GTK_THEME}" "" "\$prefer"
 `]
         environment: ({
             "DOTS_GTK_THEME": gtkStandaloneProc.themeName,
-            "DOTS_MODE": gtkStandaloneProc.mode
+            "DOTS_MODE": gtkStandaloneProc.mode,
+            "DOTS_GTK_PREFER": gtkStandaloneProc.preferDark
         })
         onExited: (exitCode, exitStatus) => {
             root._finishJob(exitCode === 0, exitCode === 0 ? "" : `setGtk failed (exit ${exitCode})`);

--- a/home/dot_config/quickshell/services/ThemePipeline.qml
+++ b/home/dot_config/quickshell/services/ThemePipeline.qml
@@ -26,6 +26,7 @@ Singleton {
     property string _pendingGtkTheme: ""
     property string _pendingIconTheme: ""
     property string _pendingThemeName: ""
+    property string _pendingThemeId: ""
     property bool _runThemeSideEffects: false
     property string _lastError: ""
     property bool _startupRestored: false
@@ -95,9 +96,11 @@ Singleton {
         _pendingGtkTheme = "";
         _pendingIconTheme = "";
         _pendingThemeName = "";
+        _pendingThemeId = "";
 
         if (job.kind === "theme") {
             _runThemeSideEffects = true;
+            _pendingThemeId = job.themeId || "";
             themeLoader.themeId = job.themeId;
             themeLoader.wallpaperOverride = job.wallpaper || "";
             themeLoader.running = true;
@@ -339,9 +342,10 @@ done
             }
             touchSchemeProc.running = true;
             root._runSideEffects();
-            // Finalize GTK (theme name + prefer-dark/color-scheme) before completing.
+            // Finalize GTK via the canonical dots-gtk-theme CLI before completing.
             gtkFinalizeProc.themeName = root._runThemeSideEffects ? (root._pendingGtkTheme || "") : "";
             gtkFinalizeProc.iconTheme = root._runThemeSideEffects ? (root._pendingIconTheme || "") : "";
+            gtkFinalizeProc.themeId = root._runThemeSideEffects ? (root._pendingThemeId || "") : "";
             gtkFinalizeProc.mode = root._pendingDarkMode ? "dark" : "light";
             gtkFinalizeProc.running = true;
         }
@@ -352,32 +356,38 @@ done
         command: ["touch", root.schemeJson]
     }
 
-    // Apply GTK theme/icons (optional) then force color-scheme to match live mode.
-    // Used only at the end of theme/wallpaper/reload jobs (calls _finishJob).
+    // Apply GTK via dots-gtk-theme (canonical CLI) then complete the job.
     Process {
         id: gtkFinalizeProc
         property string themeName: ""
         property string iconTheme: ""
+        property string themeId: ""
         property string mode: "dark"
         command: ["bash", "-c", `
 set -euo pipefail
-source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || exit 0
-icon_theme="\${DOTS_ICON_THEME:-}"
-if [[ -z "\$icon_theme" ]]; then
-  icon_theme="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'" || true)"
-fi
-[[ -n "\$icon_theme" ]] || icon_theme="Numix-Circle"
-if [[ -n "\${DOTS_GTK_THEME:-}" && "\${DOTS_GTK_THEME}" != "auto" ]]; then
-  prefer=$([[ "\${DOTS_MODE}" == "light" ]] && echo false || echo true)
-  apply_gtk_theme "\${DOTS_GTK_THEME}" "\$icon_theme" "\$prefer" || true
+prefer=$([[ "\${DOTS_MODE}" == "light" ]] && echo false || echo true)
+if [[ -n "\${DOTS_THEME_ID:-}" && ( -z "\${DOTS_GTK_THEME:-}" || "\${DOTS_GTK_THEME}" == "auto" ) ]]; then
+  dots-gtk-theme -q theme "\${DOTS_THEME_ID}" || true
+  dots-gtk-theme -q color-scheme "\${DOTS_MODE}" || true
+elif [[ -n "\${DOTS_GTK_THEME:-}" && "\${DOTS_GTK_THEME}" != "auto" ]]; then
+  if [[ -n "\${DOTS_ICON_THEME:-}" ]]; then
+    dots-gtk-theme -q apply "\${DOTS_GTK_THEME}" "\${DOTS_ICON_THEME}" "\$prefer" || true
+  else
+    icon="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'" || true)"
+    [[ -n "\$icon" ]] || icon="Numix-Circle"
+    dots-gtk-theme -q apply "\${DOTS_GTK_THEME}" "\$icon" "\$prefer" || true
+  fi
 elif [[ -n "\${DOTS_ICON_THEME:-}" ]]; then
-  gsettings set org.gnome.desktop.interface icon-theme "\${DOTS_ICON_THEME}" >/dev/null 2>&1 || true
+  dots-gtk-theme -q set-icons "\${DOTS_ICON_THEME}" || true
+  dots-gtk-theme -q color-scheme "\${DOTS_MODE}" || true
+else
+  dots-gtk-theme -q color-scheme "\${DOTS_MODE}" || true
 fi
-apply_gtk_color_scheme "\${DOTS_MODE}" || true
 `]
         environment: ({
             "DOTS_GTK_THEME": gtkFinalizeProc.themeName,
             "DOTS_ICON_THEME": gtkFinalizeProc.iconTheme,
+            "DOTS_THEME_ID": gtkFinalizeProc.themeId,
             "DOTS_MODE": gtkFinalizeProc.mode
         })
         onExited: (exitCode, exitStatus) => {
@@ -385,34 +395,35 @@ apply_gtk_color_scheme "\${DOTS_MODE}" || true
         }
     }
 
-    // Queued GTK override — must call _finishJob (unlike the old fire-and-forget path).
+    // Queued GTK override through dots-gtk-theme.
     Process {
         id: gtkStandaloneProc
         property string themeName: ""
         property string mode: "dark"
         command: ["bash", "-c", `
 set -euo pipefail
-source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || exit 0
-icon_theme="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'" || true)"
-[[ -n "\$icon_theme" ]] || icon_theme="Numix-Circle"
-if [[ -n "\${DOTS_GTK_THEME:-}" && "\${DOTS_GTK_THEME}" != "auto" ]]; then
-  prefer=$([[ "\${DOTS_MODE}" == "light" ]] && echo false || echo true)
-  apply_gtk_theme "\${DOTS_GTK_THEME}" "\$icon_theme" "\$prefer" || true
-fi
-apply_gtk_color_scheme "\${DOTS_MODE}" || true
+prefer=$([[ "\${DOTS_MODE}" == "light" ]] && echo false || echo true)
+icon="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'" || true)"
+[[ -n "\$icon" ]] || icon="Numix-Circle"
+dots-gtk-theme -q apply "\${DOTS_GTK_THEME}" "\$icon" "\$prefer"
 `]
         environment: ({
             "DOTS_GTK_THEME": gtkStandaloneProc.themeName,
             "DOTS_MODE": gtkStandaloneProc.mode
         })
         onExited: (exitCode, exitStatus) => {
-            root._finishJob(true, "");
+            root._finishJob(exitCode === 0, exitCode === 0 ? "" : `setGtk failed (exit ${exitCode})`);
         }
     }
 
     function _runSideEffects(): void {
         hyprlockProc.running = true;
         hyprReloadProc.running = true;
+
+        if (root._runThemeSideEffects && root._pendingThemeId) {
+            snappyProc.themeId = root._pendingThemeId;
+            snappyProc.running = true;
+        }
 
         if (root._runThemeSideEffects && root._pendingThemeName) {
             notifyProc.themeName = root._pendingThemeName;
@@ -426,9 +437,15 @@ apply_gtk_color_scheme "\${DOTS_MODE}" || true
     }
 
     Process {
+        id: snappyProc
+        property string themeId: ""
+        command: ["dots-snappy-switcher", "apply-theme-pack", snappyProc.themeId]
+    }
+
+    Process {
         id: iconOnlyProc
         property string themeName: ""
-        command: ["gsettings", "set", "org.gnome.desktop.interface", "icon-theme", iconOnlyProc.themeName]
+        command: ["dots-gtk-theme", "-q", "set-icons", iconOnlyProc.themeName]
         onExited: (exitCode, exitStatus) => {
             root._finishJob(exitCode === 0, exitCode === 0 ? "" : `setIcons failed (exit ${exitCode})`);
         }

--- a/home/dot_config/quickshell/services/ThemePipeline.qml
+++ b/home/dot_config/quickshell/services/ThemePipeline.qml
@@ -373,9 +373,8 @@ elif [[ -n "\${DOTS_GTK_THEME:-}" && "\${DOTS_GTK_THEME}" != "auto" ]]; then
   if [[ -n "\${DOTS_ICON_THEME:-}" ]]; then
     dots-gtk-theme -q apply "\${DOTS_GTK_THEME}" "\${DOTS_ICON_THEME}" "\$prefer" || true
   else
-    icon="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'" || true)"
-    [[ -n "\$icon" ]] || icon="Numix-Circle"
-    dots-gtk-theme -q apply "\${DOTS_GTK_THEME}" "\$icon" "\$prefer" || true
+    # Omit icon: dots-gtk-theme apply resolves the live icon theme.
+    dots-gtk-theme -q apply "\${DOTS_GTK_THEME}" "" "\$prefer" || true
   fi
 elif [[ -n "\${DOTS_ICON_THEME:-}" ]]; then
   dots-gtk-theme -q set-icons "\${DOTS_ICON_THEME}" || true
@@ -403,9 +402,8 @@ fi
         command: ["bash", "-c", `
 set -euo pipefail
 prefer=$([[ "\${DOTS_MODE}" == "light" ]] && echo false || echo true)
-icon="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'" || true)"
-[[ -n "\$icon" ]] || icon="Numix-Circle"
-dots-gtk-theme -q apply "\${DOTS_GTK_THEME}" "\$icon" "\$prefer"
+# Omit icon: dots-gtk-theme apply resolves the live icon theme.
+dots-gtk-theme -q apply "\${DOTS_GTK_THEME}" "" "\$prefer"
 `]
         environment: ({
             "DOTS_GTK_THEME": gtkStandaloneProc.themeName,

--- a/home/dot_config/quickshell/services/ThemePipeline.qml
+++ b/home/dot_config/quickshell/services/ThemePipeline.qml
@@ -29,6 +29,7 @@ Singleton {
     property string _pendingThemeId: ""
     property bool _runThemeSideEffects: false
     property string _lastError: ""
+    readonly property string lastError: _lastError
     property bool _startupRestored: false
 
     signal applyFinished(bool ok)

--- a/home/dot_config/quickshell/services/Weather.qml
+++ b/home/dot_config/quickshell/services/Weather.qml
@@ -14,11 +14,30 @@ Singleton {
     property var cc
     property list<var> forecast
     property list<var> hourlyForecast
+    property string lastError: ""
+    property bool loading: false
 
-    readonly property string icon: cc ? Icons.getWeatherIcon(cc.weatherCode) : "cloud_alert"
-    readonly property string description: cc?.weatherDesc ?? qsTr("No weather")
-    readonly property string temp: Config.services.useFahrenheit ? `${cc?.tempF ?? 0}°F` : `${cc?.tempC ?? 0}°C`
-    readonly property string feelsLike: Config.services.useFahrenheit ? `${cc?.feelsLikeF ?? 0}°F` : `${cc?.feelsLikeC ?? 0}°C`
+    readonly property bool ready: !!cc && forecast.length > 0
+    readonly property string icon: cc ? Icons.getWeatherIcon(String(cc.weatherCode)) : "cloud_alert"
+    readonly property string description: {
+        if (cc?.weatherDesc)
+            return cc.weatherDesc;
+        if (loading)
+            return qsTr("Loading…");
+        if (lastError)
+            return qsTr("Weather unavailable");
+        return qsTr("No weather");
+    }
+    readonly property string temp: {
+        if (!cc)
+            return loading ? "…" : "--";
+        return Config.services.useFahrenheit ? `${cc.tempF}°F` : `${cc.tempC}°C`;
+    }
+    readonly property string feelsLike: {
+        if (!cc)
+            return "--";
+        return Config.services.useFahrenheit ? `${cc.feelsLikeF}°F` : `${cc.feelsLikeC}°C`;
+    }
     readonly property int humidity: cc?.humidity ?? 0
     readonly property real windSpeed: cc?.windSpeed ?? 0
     readonly property string sunrise: cc ? Qt.formatDateTime(new Date(cc.sunrise), Config.services.useTwelveHourClock ? "h:mm A" : "h:mm") : "--:--"
@@ -26,26 +45,112 @@ Singleton {
 
     readonly property var cachedCities: new Map()
 
+    // Prefer providers that work on restrictive networks (ipinfo.io often times out).
+    readonly property var geoProviderUrls: [
+        "http://ip-api.com/json/",
+        "https://ipapi.co/json/",
+        "https://get.geojs.io/v1/ip/geo.json",
+        "https://ipinfo.io/json"
+    ]
+
     function reload(): void {
-        const configLocation = Config.services.weatherLocation;
+        const configLocation = (Config.services.weatherLocation || "").trim();
+        lastError = "";
+        loading = true;
 
         if (configLocation) {
             if (configLocation.indexOf(",") !== -1 && !isNaN(parseFloat(configLocation.split(",")[0]))) {
-                loc = configLocation;
+                _setLocation(configLocation, "");
                 fetchCityFromCoords(configLocation);
             } else {
                 fetchCoordsFromCity(configLocation);
             }
-        } else if (!loc || timer.elapsed() > 900) {
-            Requests.get("https://ipinfo.io/json", text => {
-                const response = JSON.parse(text);
-                if (response.loc) {
-                    loc = response.loc;
-                    city = response.city ?? "";
-                    timer.restart();
-                }
-            });
+            return;
         }
+
+        if (loc && timer.elapsed() <= 900) {
+            fetchWeatherData();
+            return;
+        }
+
+        detectLocation(0);
+    }
+
+    function parseGeoResponse(url: string, text: string): var {
+        const r = JSON.parse(text);
+        if (url.indexOf("ip-api.com") !== -1) {
+            if (r.status && r.status !== "success")
+                return null;
+            if (r.lat === undefined || r.lon === undefined)
+                return null;
+            return {
+                loc: `${r.lat},${r.lon}`,
+                city: r.city || r.regionName || ""
+            };
+        }
+        if (url.indexOf("ipapi.co") !== -1) {
+            if (r.error || r.latitude === undefined || r.longitude === undefined)
+                return null;
+            return {
+                loc: `${r.latitude},${r.longitude}`,
+                city: r.city || r.region || ""
+            };
+        }
+        if (url.indexOf("geojs.io") !== -1) {
+            if (r.latitude === undefined || r.longitude === undefined)
+                return null;
+            return {
+                loc: `${r.latitude},${r.longitude}`,
+                city: r.city || r.region || ""
+            };
+        }
+        // ipinfo.io
+        if (!r.loc)
+            return null;
+        return {
+            loc: r.loc,
+            city: r.city || ""
+        };
+    }
+
+    function detectLocation(providerIndex: int): void {
+        if (providerIndex >= geoProviderUrls.length) {
+            loading = false;
+            lastError = qsTr("Could not detect location");
+            console.warn("Weather: all geo providers failed");
+            return;
+        }
+
+        const url = geoProviderUrls[providerIndex];
+        Requests.get(url, text => {
+            try {
+                const parsed = parseGeoResponse(url, text);
+                if (!parsed || !parsed.loc) {
+                    detectLocation(providerIndex + 1);
+                    return;
+                }
+                city = parsed.city || city;
+                _setLocation(parsed.loc, parsed.city || "");
+                timer.restart();
+            } catch (e) {
+                console.warn("Weather: geo parse failed for", url, e);
+                detectLocation(providerIndex + 1);
+            }
+        }, err => {
+            console.warn("Weather: geo request failed for", url, err);
+            detectLocation(providerIndex + 1);
+        });
+    }
+
+    function _setLocation(coords: string, cityName: string): void {
+        if (cityName)
+            city = cityName;
+        if (loc === coords) {
+            // Same coords: onLocChanged will not fire — refresh explicitly.
+            fetchWeatherData();
+            return;
+        }
+        loc = coords;
     }
 
     function fetchCityFromCoords(coords: string): void {
@@ -55,16 +160,24 @@ Singleton {
         }
 
         const [lat, lon] = coords.split(",");
+        // Nominatim requires a UA in theory; Qt may send one. Falls back to Unknown City.
         const url = `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lon}&format=geocodejson`;
         Requests.get(url, text => {
-            const geo = JSON.parse(text).features?.[0]?.properties.geocoding;
-            if (geo) {
-                const geoCity = geo.type === "city" ? geo.name : geo.city;
-                city = geoCity;
-                cachedCities.set(coords, geoCity);
-            } else {
+            try {
+                const geo = JSON.parse(text).features?.[0]?.properties?.geocoding;
+                if (geo) {
+                    const geoCity = geo.type === "city" ? geo.name : (geo.city || geo.name || geo.state);
+                    city = geoCity || "Unknown City";
+                    cachedCities.set(coords, city);
+                } else {
+                    city = "Unknown City";
+                }
+            } catch (e) {
                 city = "Unknown City";
             }
+        }, err => {
+            console.warn("Weather: reverse geocode failed", err);
+            city = city || "Unknown City";
         });
     }
 
@@ -72,72 +185,100 @@ Singleton {
         const url = `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(cityName)}&count=1&language=en&format=json`;
 
         Requests.get(url, text => {
-            const json = JSON.parse(text);
-            if (json.results && json.results.length > 0) {
-                const result = json.results[0];
-                loc = result.latitude + "," + result.longitude;
-                city = result.name;
-            } else {
-                loc = "";
-                reload();
+            try {
+                const json = JSON.parse(text);
+                if (json.results && json.results.length > 0) {
+                    const result = json.results[0];
+                    city = result.name;
+                    _setLocation(`${result.latitude},${result.longitude}`, result.name);
+                } else {
+                    loading = false;
+                    lastError = qsTr("Location not found");
+                    console.warn("Weather: no geocoding results for", cityName);
+                }
+            } catch (e) {
+                loading = false;
+                lastError = qsTr("Location lookup failed");
             }
+        }, err => {
+            loading = false;
+            lastError = qsTr("Location lookup failed");
+            console.warn("Weather: city geocode failed", err);
         });
     }
 
     function fetchWeatherData(): void {
         const url = getWeatherUrl();
-        if (url === "")
+        if (url === "") {
+            loading = false;
             return;
+        }
 
+        loading = true;
         Requests.get(url, text => {
-            const json = JSON.parse(text);
-            if (!json.current || !json.daily)
-                return;
+            try {
+                const json = JSON.parse(text);
+                if (!json.current || !json.daily) {
+                    loading = false;
+                    lastError = qsTr("Invalid weather response");
+                    return;
+                }
 
-            cc = {
-                weatherCode: json.current.weather_code,
-                weatherDesc: getWeatherCondition(json.current.weather_code),
-                tempC: Math.round(json.current.temperature_2m),
-                tempF: Math.round(toFahrenheit(json.current.temperature_2m)),
-                feelsLikeC: Math.round(json.current.apparent_temperature),
-                feelsLikeF: Math.round(toFahrenheit(json.current.apparent_temperature)),
-                humidity: json.current.relative_humidity_2m,
-                windSpeed: json.current.wind_speed_10m,
-                isDay: json.current.is_day,
-                sunrise: json.daily.sunrise[0],
-                sunset: json.daily.sunset[0]
-            };
+                cc = {
+                    weatherCode: json.current.weather_code,
+                    weatherDesc: getWeatherCondition(json.current.weather_code),
+                    tempC: Math.round(json.current.temperature_2m),
+                    tempF: Math.round(toFahrenheit(json.current.temperature_2m)),
+                    feelsLikeC: Math.round(json.current.apparent_temperature),
+                    feelsLikeF: Math.round(toFahrenheit(json.current.apparent_temperature)),
+                    humidity: json.current.relative_humidity_2m,
+                    windSpeed: json.current.wind_speed_10m,
+                    isDay: json.current.is_day,
+                    sunrise: json.daily.sunrise[0],
+                    sunset: json.daily.sunset[0]
+                };
 
-            const forecastList = [];
-            for (let i = 0; i < json.daily.time.length; i++)
-                forecastList.push({
-                    date: json.daily.time[i],
-                    maxTempC: Math.round(json.daily.temperature_2m_max[i]),
-                    maxTempF: Math.round(toFahrenheit(json.daily.temperature_2m_max[i])),
-                    minTempC: Math.round(json.daily.temperature_2m_min[i]),
-                    minTempF: Math.round(toFahrenheit(json.daily.temperature_2m_min[i])),
-                    weatherCode: json.daily.weather_code[i],
-                    icon: Icons.getWeatherIcon(json.daily.weather_code[i])
-                });
-            forecast = forecastList;
+                const forecastList = [];
+                for (let i = 0; i < json.daily.time.length; i++)
+                    forecastList.push({
+                        date: json.daily.time[i],
+                        maxTempC: Math.round(json.daily.temperature_2m_max[i]),
+                        maxTempF: Math.round(toFahrenheit(json.daily.temperature_2m_max[i])),
+                        minTempC: Math.round(json.daily.temperature_2m_min[i]),
+                        minTempF: Math.round(toFahrenheit(json.daily.temperature_2m_min[i])),
+                        weatherCode: json.daily.weather_code[i],
+                        icon: Icons.getWeatherIcon(String(json.daily.weather_code[i]))
+                    });
+                forecast = forecastList;
 
-            const hourlyList = [];
-            const now = new Date();
-            for (let i = 0; i < json.hourly.time.length; i++) {
-                const time = new Date(json.hourly.time[i]);
-                if (time < now)
-                    continue;
+                const hourlyList = [];
+                const now = new Date();
+                for (let i = 0; i < json.hourly.time.length; i++) {
+                    const time = new Date(json.hourly.time[i]);
+                    if (time < now)
+                        continue;
 
-                hourlyList.push({
-                    timestamp: json.hourly.time[i],
-                    hour: time.getHours(),
-                    tempC: Math.round(json.hourly.temperature_2m[i]),
-                    tempF: Math.round(toFahrenheit(json.hourly.temperature_2m[i])),
-                    weatherCode: json.hourly.weather_code[i],
-                    icon: Icons.getWeatherIcon(json.hourly.weather_code[i])
-                });
+                    hourlyList.push({
+                        timestamp: json.hourly.time[i],
+                        hour: time.getHours(),
+                        tempC: Math.round(json.hourly.temperature_2m[i]),
+                        tempF: Math.round(toFahrenheit(json.hourly.temperature_2m[i])),
+                        weatherCode: json.hourly.weather_code[i],
+                        icon: Icons.getWeatherIcon(String(json.hourly.weather_code[i]))
+                    });
+                }
+                hourlyForecast = hourlyList;
+                lastError = "";
+                loading = false;
+            } catch (e) {
+                loading = false;
+                lastError = qsTr("Weather parse failed");
+                console.warn("Weather: parse failed", e);
             }
-            hourlyForecast = hourlyList;
+        }, err => {
+            loading = false;
+            lastError = qsTr("Weather request failed");
+            console.warn("Weather: forecast request failed", err);
         });
     }
 
@@ -156,7 +297,8 @@ Singleton {
         return baseUrl + "?" + params.join("&");
     }
 
-    function getWeatherCondition(code: string): string {
+    function getWeatherCondition(code: var): string {
+        const key = String(code);
         const conditions = {
             "0": "Clear",
             "1": "Clear",
@@ -187,20 +329,29 @@ Singleton {
             "96": "Thunderstorm with hail",
             "99": "Thunderstorm with hail"
         };
-        return conditions[code] || "Unknown";
+        return conditions[key] || "Unknown";
     }
 
     onLocChanged: fetchWeatherData()
 
-    // Refresh current location hourly
+    // Refresh forecast hourly; re-detect location every 6 hours.
     Timer {
-        interval: 3600000 // 1 hour
+        interval: 3600000
         running: true
         repeat: true
-        onTriggered: fetchWeatherData()
+        onTriggered: {
+            if (Config.services.weatherLocation)
+                fetchWeatherData();
+            else if (timer.elapsed() > 21600)
+                root.reload();
+            else
+                fetchWeatherData();
+        }
     }
 
     ElapsedTimer {
         id: timer
     }
+
+    Component.onCompleted: reload()
 }

--- a/home/dot_local/bin/executable_dots-appearance
+++ b/home/dot_local/bin/executable_dots-appearance
@@ -14,397 +14,397 @@ cmd="${1:-}"
 shift 2>/dev/null || true
 
 json_escape() {
-  python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1"
+	python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1"
 }
 
 _wait_appearance_ipc() {
-  local _i busy="" last_error
-  for _i in $(seq 1 120); do
-    if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
-      echo "Error: failed to poll appearance isBusy via Quickshell IPC" >&2
-      return 1
-    fi
-    busy="${busy//$'\r'/}"
-    busy="${busy//$'\n'/}"
-    [[ $busy == "1" ]] || break
-    sleep 0.5
-  done
-  if [[ $busy == "1" ]]; then
-    echo "Error: appearance apply timed out waiting for Quickshell" >&2
-    return 1
-  fi
-  last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
-  last_error="${last_error//$'\r'/}"
-  last_error="${last_error//$'\n'/}"
-  if [[ -n $last_error ]]; then
-    echo "Error: appearance apply failed: $last_error" >&2
-    return 1
-  fi
-  return 0
+	local _i busy="" last_error
+	for _i in $(seq 1 120); do
+		if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
+			echo "Error: failed to poll appearance isBusy via Quickshell IPC" >&2
+			return 1
+		fi
+		busy="${busy//$'\r'/}"
+		busy="${busy//$'\n'/}"
+		[[ $busy == "1" ]] || break
+		sleep 0.5
+	done
+	if [[ $busy == "1" ]]; then
+		echo "Error: appearance apply timed out waiting for Quickshell" >&2
+		return 1
+	fi
+	last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
+	last_error="${last_error//$'\r'/}"
+	last_error="${last_error//$'\n'/}"
+	if [[ -n $last_error ]]; then
+		echo "Error: appearance apply failed: $last_error" >&2
+		return 1
+	fi
+	return 0
 }
 
 cmd_theme_list() {
-  local script="${HOME}/.local/lib/dots/list-themes.py"
-  if [[ -f $script ]]; then
-    python3 "$script" "$THEMES_DIR"
-  else
-    echo "[]"
-  fi
+	local script="${HOME}/.local/lib/dots/list-themes.py"
+	if [[ -f $script ]]; then
+		python3 "$script" "$THEMES_DIR"
+	else
+		echo "[]"
+	fi
 }
 
 cmd_theme_show() {
-  local id="${1:-}"
-  [[ -n $id ]] || {
-    echo "Usage: dots-appearance theme show <id>" >&2
-    exit 1
-  }
-  local path="${THEMES_DIR}/${id}/theme.json"
-  [[ -f $path ]] || {
-    echo "Theme not found: $id" >&2
-    exit 1
-  }
-  cat "$path"
+	local id="${1:-}"
+	[[ -n $id ]] || {
+		echo "Usage: dots-appearance theme show <id>" >&2
+		exit 1
+	}
+	local path="${THEMES_DIR}/${id}/theme.json"
+	[[ -f $path ]] || {
+		echo "Theme not found: $id" >&2
+		exit 1
+	}
+	cat "$path"
 }
 
 _shell_theme_apply() {
-  local id="$1"
-  local wallpaper="${2:-}"
-  # shellcheck source=/dev/null
-  source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
-  # shellcheck source=/dev/null
-  source "$HOME/.local/lib/dots/apply-appearance.sh"
-  dots_apply_theme "$id" "$wallpaper"
+	local id="$1"
+	local wallpaper="${2:-}"
+	# shellcheck source=/dev/null
+	source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
+	# shellcheck source=/dev/null
+	source "$HOME/.local/lib/dots/apply-appearance.sh"
+	dots_apply_theme "$id" "$wallpaper"
 }
 
 cmd_theme_apply() {
-  local id="${1:-}"
-  local wallpaper=""
-  shift 2>/dev/null || true
-  while [[ $# -gt 0 ]]; do
-    case "${1:-}" in
-      --wallpaper)
-        [[ -n ${2:-} ]] || {
-          echo "dots-appearance theme apply: --wallpaper requires a path" >&2
-          exit 1
-        }
-        wallpaper="$2"
-        shift 2
-        ;;
-      *)
-        echo "dots-appearance theme apply: unknown argument: $1" >&2
-        exit 1
-        ;;
-    esac
-  done
+	local id="${1:-}"
+	local wallpaper=""
+	shift 2>/dev/null || true
+	while [[ $# -gt 0 ]]; do
+		case "${1:-}" in
+		--wallpaper)
+			[[ -n ${2:-} ]] || {
+				echo "dots-appearance theme apply: --wallpaper requires a path" >&2
+				exit 1
+			}
+			wallpaper="$2"
+			shift 2
+			;;
+		*)
+			echo "dots-appearance theme apply: unknown argument: $1" >&2
+			exit 1
+			;;
+		esac
+	done
 
-  [[ -n $id ]] || {
-    echo "Usage: dots-appearance theme apply <id> [--wallpaper <path>]" >&2
-    exit 1
-  }
+	[[ -n $id ]] || {
+		echo "Usage: dots-appearance theme apply <id> [--wallpaper <path>]" >&2
+		exit 1
+	}
 
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    local ipc_out=""
-    if ipc_out="$(quickshell ipc call appearance applyTheme "$id" "${wallpaper:-}" 2>&1)"; then
-      case "$ipc_out" in
-        "Target not found."* | *"Target not found"*)
-          echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
-          ;;
-        *)
-          _wait_appearance_ipc || exit 1
-          exit 0
-          ;;
-      esac
-    else
-      echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
-    fi
-  fi
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		local ipc_out=""
+		if ipc_out="$(quickshell ipc call appearance applyTheme "$id" "${wallpaper:-}" 2>&1)"; then
+			case "$ipc_out" in
+			"Target not found."* | *"Target not found"*)
+				echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
+				;;
+			*)
+				_wait_appearance_ipc || exit 1
+				exit 0
+				;;
+			esac
+		else
+			echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
+		fi
+	fi
 
-  _shell_theme_apply "$id" "$wallpaper"
+	_shell_theme_apply "$id" "$wallpaper"
 }
 
 cmd_theme() {
-  local sub="${1:-}"
-  shift 2>/dev/null || true
-  case "$sub" in
-    list) cmd_theme_list ;;
-    show) cmd_theme_show "${1:-}" ;;
-    apply) cmd_theme_apply "$@" ;;
-    *)
-      cat <<'EOF' >&2
+	local sub="${1:-}"
+	shift 2>/dev/null || true
+	case "$sub" in
+	list) cmd_theme_list ;;
+	show) cmd_theme_show "${1:-}" ;;
+	apply) cmd_theme_apply "$@" ;;
+	*)
+		cat <<'EOF' >&2
 Usage: dots-appearance theme <list|show|apply> …
 
   theme list
   theme show <id>
   theme apply <id> [--wallpaper <path>]
 EOF
-      exit 1
-      ;;
-  esac
+		exit 1
+		;;
+	esac
 }
 
 cmd_status() {
-  local wallpaper="" mode="" flavour="" gtk_theme="" icon_theme=""
-  if command -v dots-wallpaper-current >/dev/null 2>&1; then
-    wallpaper="$(dots-wallpaper-current 2>/dev/null || true)"
-  fi
-  local state_file="${HOME}/.local/state/dots/scheme/state.json"
-  if [[ -f $state_file ]]; then
-    flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
-    mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
-  fi
-  if [[ -f ${HOME}/.config/gtk-3.0/settings.ini ]]; then
-    gtk_theme="$(grep -E '^gtk-theme-name=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-  fi
-  if command -v gsettings >/dev/null 2>&1; then
-    icon_theme="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'\"" || true)"
-  fi
+	local wallpaper="" mode="" flavour="" gtk_theme="" icon_theme=""
+	if command -v dots-wallpaper-current >/dev/null 2>&1; then
+		wallpaper="$(dots-wallpaper-current 2>/dev/null || true)"
+	fi
+	local state_file="${HOME}/.local/state/dots/scheme/state.json"
+	if [[ -f $state_file ]]; then
+		flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
+		mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
+	fi
+	if [[ -f ${HOME}/.config/gtk-3.0/settings.ini ]]; then
+		gtk_theme="$(grep -E '^gtk-theme-name=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+	fi
+	if command -v gsettings >/dev/null 2>&1; then
+		icon_theme="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'\"" || true)"
+	fi
 
-  if [[ ${1:-} == "--json" ]]; then
-    printf '{"wallpaper":%s,"mode":%s,"flavour":%s,"gtkTheme":%s,"iconTheme":%s}\n' \
-      "$(json_escape "${wallpaper:-}")" \
-      "$(json_escape "${mode:-}")" \
-      "$(json_escape "${flavour:-}")" \
-      "$(json_escape "${gtk_theme:-}")" \
-      "$(json_escape "${icon_theme:-}")"
-  else
-    echo "wallpaper : ${wallpaper:-}"
-    echo "mode      : ${mode:-}"
-    echo "flavour   : ${flavour:-}"
-    echo "gtkTheme  : ${gtk_theme:-}"
-    echo "iconTheme : ${icon_theme:-}"
-  fi
+	if [[ ${1:-} == "--json" ]]; then
+		printf '{"wallpaper":%s,"mode":%s,"flavour":%s,"gtkTheme":%s,"iconTheme":%s}\n' \
+			"$(json_escape "${wallpaper:-}")" \
+			"$(json_escape "${mode:-}")" \
+			"$(json_escape "${flavour:-}")" \
+			"$(json_escape "${gtk_theme:-}")" \
+			"$(json_escape "${icon_theme:-}")"
+	else
+		echo "wallpaper : ${wallpaper:-}"
+		echo "mode      : ${mode:-}"
+		echo "flavour   : ${flavour:-}"
+		echo "gtkTheme  : ${gtk_theme:-}"
+		echo "iconTheme : ${icon_theme:-}"
+	fi
 }
 
 cmd_set_wallpaper() {
-  local wallpaper="${1:-}"
-  [[ -n $wallpaper ]] || {
-    echo "Usage: dots-appearance set-wallpaper <path>" >&2
-    exit 1
-  }
-  dots-wallpaper-set "$wallpaper"
+	local wallpaper="${1:-}"
+	[[ -n $wallpaper ]] || {
+		echo "Usage: dots-appearance set-wallpaper <path>" >&2
+		exit 1
+	}
+	dots-wallpaper-set "$wallpaper"
 }
 
 cmd_set_variant() {
-  dots-color-scheme variant "${1:-}"
+	dots-color-scheme variant "${1:-}"
 }
 
 cmd_set_mode() {
-  dots-color-scheme mode "${1:-}"
+	dots-color-scheme mode "${1:-}"
 }
 
 cmd_set_gtk() {
-  local theme="${1:-}"
-  [[ -n $theme ]] || {
-    echo "Usage: dots-appearance set-gtk <theme>" >&2
-    exit 1
-  }
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    if quickshell ipc call appearance setGtk "$theme" >/dev/null 2>&1; then
-      _wait_appearance_ipc || exit 1
-      exit 0
-    fi
-  fi
-  local prefer="true" mode="dark"
-  local state_json="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
-  if [[ -f $state_json ]]; then
-    mode="$(python3 -c "import json;print(json.load(open('$state_json')).get('mode','dark'))" 2>/dev/null || echo dark)"
-  fi
-  prefer=$([[ $mode == "light" ]] && echo false || echo true)
-  local icon
-  icon="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'" || true)"
-  [[ -n $icon ]] || icon="Numix-Circle"
-  dots-gtk-theme -q apply "$theme" "$icon" "$prefer"
+	local theme="${1:-}"
+	[[ -n $theme ]] || {
+		echo "Usage: dots-appearance set-gtk <theme>" >&2
+		exit 1
+	}
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		if quickshell ipc call appearance setGtk "$theme" >/dev/null 2>&1; then
+			_wait_appearance_ipc || exit 1
+			exit 0
+		fi
+	fi
+	local prefer="true" mode="dark"
+	local state_json="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
+	if [[ -f $state_json ]]; then
+		mode="$(python3 -c "import json;print(json.load(open('$state_json')).get('mode','dark'))" 2>/dev/null || echo dark)"
+	fi
+	prefer=$([[ $mode == "light" ]] && echo false || echo true)
+	local icon
+	icon="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'" || true)"
+	[[ -n $icon ]] || icon="Numix-Circle"
+	dots-gtk-theme -q apply "$theme" "$icon" "$prefer"
 }
 
 cmd_set_icons() {
-  local theme="${1:-}"
-  [[ -n $theme ]] || {
-    echo "Usage: dots-appearance set-icons <theme>" >&2
-    exit 1
-  }
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    if quickshell ipc call appearance setIcons "$theme" >/dev/null 2>&1; then
-      _wait_appearance_ipc || exit 1
-      exit 0
-    fi
-  fi
-  dots-gtk-theme -q set-icons "$theme"
+	local theme="${1:-}"
+	[[ -n $theme ]] || {
+		echo "Usage: dots-appearance set-icons <theme>" >&2
+		exit 1
+	}
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		if quickshell ipc call appearance setIcons "$theme" >/dev/null 2>&1; then
+			_wait_appearance_ipc || exit 1
+			exit 0
+		fi
+	fi
+	dots-gtk-theme -q set-icons "$theme"
 }
 
 cmd_sync() {
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    if quickshell ipc call appearance reload >/dev/null 2>&1; then
-      _wait_appearance_ipc || exit 1
-    fi
-  fi
-  dots-color-scheme sync-state >/dev/null 2>&1 || true
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		if quickshell ipc call appearance reload >/dev/null 2>&1; then
+			_wait_appearance_ipc || exit 1
+		fi
+	fi
+	dots-color-scheme sync-state >/dev/null 2>&1 || true
 }
 
 cmd_doctor() {
-  local ok=0
-  local scheme_flavour="" state_flavour="" scheme_mode="" state_mode=""
-  local pointer="" resolved="" wal_target=""
+	local ok=0
+	local scheme_flavour="" state_flavour="" scheme_mode="" state_mode=""
+	local pointer="" resolved="" wal_target=""
 
-  # One-time purge of removed rice state / legacy pointers.
-  rm -f "$HOME/.local/share/dots/rices/.current_rice" \
-    "$HOME/.cache/dots/current_rice" \
-    "$HOME/.local/state/dots/rice/current" 2>/dev/null || true
-  rmdir "$HOME/.local/state/dots/rice" 2>/dev/null || true
+	# One-time purge of removed rice state / legacy pointers.
+	rm -f "$HOME/.local/share/dots/rices/.current_rice" \
+		"$HOME/.cache/dots/current_rice" \
+		"$HOME/.local/state/dots/rice/current" 2>/dev/null || true
+	rmdir "$HOME/.local/state/dots/rice" 2>/dev/null || true
 
-  local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
-  local state_file="${HOME}/.local/state/dots/scheme/state.json"
-  if [[ -f $scheme_file ]]; then
-    scheme_flavour="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('flavour',''))" 2>/dev/null || true)"
-    scheme_mode="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('mode',''))" 2>/dev/null || true)"
-  fi
-  if [[ -f $state_file ]]; then
-    state_flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
-    state_mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
-  fi
+	local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
+	local state_file="${HOME}/.local/state/dots/scheme/state.json"
+	if [[ -f $scheme_file ]]; then
+		scheme_flavour="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('flavour',''))" 2>/dev/null || true)"
+		scheme_mode="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('mode',''))" 2>/dev/null || true)"
+	fi
+	if [[ -f $state_file ]]; then
+		state_flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
+		state_mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
+	fi
 
-  pointer="${DOTS_WALLPAPER_POINTER_FILE:-$HOME/.local/state/dots/wallpaper/path}"
-  local pointer_val=""
-  [[ -f $pointer ]] && pointer_val="$(head -n 1 "$pointer" | tr -d '\r')"
-  if command -v dots-wallpaper-current >/dev/null 2>&1; then
-    resolved="$(dots-wallpaper-current 2>/dev/null || true)"
-  fi
-  if [[ -L $HOME/.cache/wal/wal ]]; then
-    wal_target="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
-  elif [[ -f $HOME/.cache/wal/wal ]]; then
-    wal_target="$(head -n 1 "$HOME/.cache/wal/wal" | tr -d '\r')"
-    wal_target="$(readlink -f "$wal_target" 2>/dev/null || true)"
-  fi
+	pointer="${DOTS_WALLPAPER_POINTER_FILE:-$HOME/.local/state/dots/wallpaper/path}"
+	local pointer_val=""
+	[[ -f $pointer ]] && pointer_val="$(head -n 1 "$pointer" | tr -d '\r')"
+	if command -v dots-wallpaper-current >/dev/null 2>&1; then
+		resolved="$(dots-wallpaper-current 2>/dev/null || true)"
+	fi
+	if [[ -L $HOME/.cache/wal/wal ]]; then
+		wal_target="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
+	elif [[ -f $HOME/.cache/wal/wal ]]; then
+		wal_target="$(head -n 1 "$HOME/.cache/wal/wal" | tr -d '\r')"
+		wal_target="$(readlink -f "$wal_target" 2>/dev/null || true)"
+	fi
 
-  echo "=== dots-appearance doctor ==="
-  echo "scheme.flavour : ${scheme_flavour:-"(missing)"}"
-  echo "state.flavour  : ${state_flavour:-"(missing)"}"
-  echo "scheme.mode    : ${scheme_mode:-"(missing)"}"
-  echo "state.mode     : ${state_mode:-"(missing)"}"
-  local hyprlock_conf="${HOME}/.cache/dots/smart-colors/colors-hyprlock.conf"
-  local hyprlock_bytes=0
-  [[ -f $hyprlock_conf ]] && hyprlock_bytes="$(wc -c <"$hyprlock_conf" | tr -d ' ')"
-  local gtk_theme_ini="" gtk_prefer_dark="" gtk_color_scheme=""
-  if [[ -f ${HOME}/.config/gtk-3.0/settings.ini ]]; then
-    gtk_theme_ini="$(grep -E '^gtk-theme-name=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-    gtk_prefer_dark="$(grep -E '^gtk-application-prefer-dark-theme=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-  fi
-  if command -v gsettings >/dev/null 2>&1; then
-    gtk_color_scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'\"" || true)"
-  fi
+	echo "=== dots-appearance doctor ==="
+	echo "scheme.flavour : ${scheme_flavour:-"(missing)"}"
+	echo "state.flavour  : ${state_flavour:-"(missing)"}"
+	echo "scheme.mode    : ${scheme_mode:-"(missing)"}"
+	echo "state.mode     : ${state_mode:-"(missing)"}"
+	local hyprlock_conf="${HOME}/.cache/dots/smart-colors/colors-hyprlock.conf"
+	local hyprlock_bytes=0
+	[[ -f $hyprlock_conf ]] && hyprlock_bytes="$(wc -c <"$hyprlock_conf" | tr -d ' ')"
+	local gtk_theme_ini="" gtk_prefer_dark="" gtk_color_scheme=""
+	if [[ -f ${HOME}/.config/gtk-3.0/settings.ini ]]; then
+		gtk_theme_ini="$(grep -E '^gtk-theme-name=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+		gtk_prefer_dark="$(grep -E '^gtk-application-prefer-dark-theme=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+	fi
+	if command -v gsettings >/dev/null 2>&1; then
+		gtk_color_scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'\"" || true)"
+	fi
 
-  echo "wallpaper.ptr  : ${pointer_val:-"(missing)"}"
-  echo "wallpaper.res  : ${resolved:-"(missing)"}"
-  echo "wal.target     : ${wal_target:-"(missing)"}"
-  echo "hyprlock.conf  : ${hyprlock_bytes} bytes"
-  echo "gtk.theme.ini  : ${gtk_theme_ini:-"(missing)"}"
-  echo "gtk.preferDark : ${gtk_prefer_dark:-"(missing)"}"
-  echo "gtk.colorScheme: ${gtk_color_scheme:-"(missing)"}"
+	echo "wallpaper.ptr  : ${pointer_val:-"(missing)"}"
+	echo "wallpaper.res  : ${resolved:-"(missing)"}"
+	echo "wal.target     : ${wal_target:-"(missing)"}"
+	echo "hyprlock.conf  : ${hyprlock_bytes} bytes"
+	echo "gtk.theme.ini  : ${gtk_theme_ini:-"(missing)"}"
+	echo "gtk.preferDark : ${gtk_prefer_dark:-"(missing)"}"
+	echo "gtk.colorScheme: ${gtk_color_scheme:-"(missing)"}"
 
-  if [[ -e $HOME/.local/share/dots/rices/.current_rice || -e $HOME/.cache/dots/current_rice || -e $HOME/.local/state/dots/rice/current ]]; then
-    echo "FAIL: legacy rice pointer still present" >&2
-    ok=1
-  fi
-  if [[ -n $scheme_flavour && -n $state_flavour && $scheme_flavour != "$state_flavour" ]]; then
-    echo "FAIL: scheme flavour != state flavour ($scheme_flavour vs $state_flavour)" >&2
-    ok=1
-  fi
-  if [[ -n $scheme_mode && -n $state_mode && $scheme_mode != "$state_mode" ]]; then
-    echo "FAIL: scheme mode != state mode ($scheme_mode vs $state_mode)" >&2
-    ok=1
-  fi
-  if [[ -z $pointer_val ]]; then
-    echo "FAIL: wallpaper pointer missing" >&2
-    ok=1
-  elif [[ ! -f $pointer_val ]]; then
-    echo "FAIL: wallpaper pointer does not exist: $pointer_val" >&2
-    ok=1
-  fi
-  if [[ -n $pointer_val && -n $resolved && $pointer_val != "$resolved" ]]; then
-    local ptr_real res_real
-    ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
-    res_real="$(readlink -f "$resolved" 2>/dev/null || true)"
-    if [[ -n $ptr_real && -n $res_real && $ptr_real != "$res_real" ]]; then
-      echo "FAIL: pointer != dots-wallpaper-current ($pointer_val vs $resolved)" >&2
-      ok=1
-    fi
-  fi
-  if [[ -n $pointer_val && -f $pointer_val ]]; then
-    local ptr_real wal_real
-    ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
-    if [[ -L $HOME/.cache/wal/wal ]]; then
-      wal_real="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
-    elif [[ -f $HOME/.cache/wal/wal ]]; then
-      wal_real="$(head -n 1 "$HOME/.cache/wal/wal" | tr -d '\r')"
-      wal_real="$(readlink -f "$wal_real" 2>/dev/null || true)"
-    fi
-    if [[ -z ${wal_real:-} ]]; then
-      echo "FAIL: ~/.cache/wal/wal missing or broken" >&2
-      ok=1
-    elif [[ -n $ptr_real && $ptr_real != "$wal_real" ]]; then
-      echo "FAIL: wal target != wallpaper pointer ($wal_real vs $ptr_real)" >&2
-      ok=1
-    fi
-  fi
-  if [[ ! -f $hyprlock_conf || ${hyprlock_bytes:-0} -eq 0 ]]; then
-    echo "FAIL: colors-hyprlock.conf missing or empty" >&2
-    ok=1
-  fi
-  if [[ -f ${HOME}/.local/state/dots/wallpaper/path.txt ]]; then
-    echo "FAIL: orphan wallpaper/path.txt present (use wallpaper/path)" >&2
-    ok=1
-  fi
-  if [[ -f ${HOME}/.cache/dots/smart-colors/wallpaper ]]; then
-    echo "FAIL: orphan smart-colors/wallpaper cache present" >&2
-    ok=1
-  fi
-  if [[ -n $state_mode && -n $gtk_prefer_dark ]]; then
-    if [[ $state_mode == "dark" && $gtk_prefer_dark == "false" ]]; then
-      echo "FAIL: GTK prefer-dark=false while live mode is dark" >&2
-      ok=1
-    elif [[ $state_mode == "light" && $gtk_prefer_dark == "true" ]]; then
-      echo "FAIL: GTK prefer-dark=true while live mode is light" >&2
-      ok=1
-    fi
-  fi
-  if [[ -n $state_mode && -n $gtk_color_scheme ]]; then
-    if [[ $state_mode == "dark" && $gtk_color_scheme != "prefer-dark" ]]; then
-      echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is dark" >&2
-      ok=1
-    elif [[ $state_mode == "light" && $gtk_color_scheme != "prefer-light" ]]; then
-      echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is light" >&2
-      ok=1
-    fi
-  fi
-  if [[ -n $wal_target && -f $wal_target ]]; then
-    if ! file -b --mime-type "$wal_target" 2>/dev/null | grep -q '^image/'; then
-      echo "WARN: wal target is not an image: $wal_target" >&2
-    fi
-  fi
+	if [[ -e $HOME/.local/share/dots/rices/.current_rice || -e $HOME/.cache/dots/current_rice || -e $HOME/.local/state/dots/rice/current ]]; then
+		echo "FAIL: legacy rice pointer still present" >&2
+		ok=1
+	fi
+	if [[ -n $scheme_flavour && -n $state_flavour && $scheme_flavour != "$state_flavour" ]]; then
+		echo "FAIL: scheme flavour != state flavour ($scheme_flavour vs $state_flavour)" >&2
+		ok=1
+	fi
+	if [[ -n $scheme_mode && -n $state_mode && $scheme_mode != "$state_mode" ]]; then
+		echo "FAIL: scheme mode != state mode ($scheme_mode vs $state_mode)" >&2
+		ok=1
+	fi
+	if [[ -z $pointer_val ]]; then
+		echo "FAIL: wallpaper pointer missing" >&2
+		ok=1
+	elif [[ ! -f $pointer_val ]]; then
+		echo "FAIL: wallpaper pointer does not exist: $pointer_val" >&2
+		ok=1
+	fi
+	if [[ -n $pointer_val && -n $resolved && $pointer_val != "$resolved" ]]; then
+		local ptr_real res_real
+		ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
+		res_real="$(readlink -f "$resolved" 2>/dev/null || true)"
+		if [[ -n $ptr_real && -n $res_real && $ptr_real != "$res_real" ]]; then
+			echo "FAIL: pointer != dots-wallpaper-current ($pointer_val vs $resolved)" >&2
+			ok=1
+		fi
+	fi
+	if [[ -n $pointer_val && -f $pointer_val ]]; then
+		local ptr_real wal_real
+		ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
+		if [[ -L $HOME/.cache/wal/wal ]]; then
+			wal_real="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
+		elif [[ -f $HOME/.cache/wal/wal ]]; then
+			wal_real="$(head -n 1 "$HOME/.cache/wal/wal" | tr -d '\r')"
+			wal_real="$(readlink -f "$wal_real" 2>/dev/null || true)"
+		fi
+		if [[ -z ${wal_real:-} ]]; then
+			echo "FAIL: ~/.cache/wal/wal missing or broken" >&2
+			ok=1
+		elif [[ -n $ptr_real && $ptr_real != "$wal_real" ]]; then
+			echo "FAIL: wal target != wallpaper pointer ($wal_real vs $ptr_real)" >&2
+			ok=1
+		fi
+	fi
+	if [[ ! -f $hyprlock_conf || ${hyprlock_bytes:-0} -eq 0 ]]; then
+		echo "FAIL: colors-hyprlock.conf missing or empty" >&2
+		ok=1
+	fi
+	if [[ -f ${HOME}/.local/state/dots/wallpaper/path.txt ]]; then
+		echo "FAIL: orphan wallpaper/path.txt present (use wallpaper/path)" >&2
+		ok=1
+	fi
+	if [[ -f ${HOME}/.cache/dots/smart-colors/wallpaper ]]; then
+		echo "FAIL: orphan smart-colors/wallpaper cache present" >&2
+		ok=1
+	fi
+	if [[ -n $state_mode && -n $gtk_prefer_dark ]]; then
+		if [[ $state_mode == "dark" && $gtk_prefer_dark == "false" ]]; then
+			echo "FAIL: GTK prefer-dark=false while live mode is dark" >&2
+			ok=1
+		elif [[ $state_mode == "light" && $gtk_prefer_dark == "true" ]]; then
+			echo "FAIL: GTK prefer-dark=true while live mode is light" >&2
+			ok=1
+		fi
+	fi
+	if [[ -n $state_mode && -n $gtk_color_scheme ]]; then
+		if [[ $state_mode == "dark" && $gtk_color_scheme != "prefer-dark" ]]; then
+			echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is dark" >&2
+			ok=1
+		elif [[ $state_mode == "light" && $gtk_color_scheme != "prefer-light" ]]; then
+			echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is light" >&2
+			ok=1
+		fi
+	fi
+	if [[ -n $wal_target && -f $wal_target ]]; then
+		if ! file -b --mime-type "$wal_target" 2>/dev/null | grep -q '^image/'; then
+			echo "WARN: wal target is not an image: $wal_target" >&2
+		fi
+	fi
 
-  if [[ $ok -eq 0 ]]; then
-    echo "OK: appearance state is consistent"
-  else
-    echo "DONE: inconsistencies detected (exit $ok)"
-  fi
-  return "$ok"
+	if [[ $ok -eq 0 ]]; then
+		echo "OK: appearance state is consistent"
+	else
+		echo "DONE: inconsistencies detected (exit $ok)"
+	fi
+	return "$ok"
 }
 
 case "${cmd:-}" in
-  theme) cmd_theme "$@" ;;
-  status) cmd_status "${1:-}" ;;
-  set-variant) cmd_set_variant "${1:-}" ;;
-  set-mode) cmd_set_mode "${1:-}" ;;
-  set-wallpaper) cmd_set_wallpaper "${1:-}" ;;
-  set-gtk) cmd_set_gtk "${1:-}" ;;
-  set-icons) cmd_set_icons "${1:-}" ;;
-  sync) cmd_sync ;;
-  doctor) cmd_doctor ;;
-  # Back-compat shims during transition
-  list) cmd_theme_list ;;
-  apply) cmd_theme_apply "$@" ;;
-  preview) cmd_theme_show "${1:-}" ;;
-  *)
-    cat <<'EOF' >&2
+theme) cmd_theme "$@" ;;
+status) cmd_status "${1:-}" ;;
+set-variant) cmd_set_variant "${1:-}" ;;
+set-mode) cmd_set_mode "${1:-}" ;;
+set-wallpaper) cmd_set_wallpaper "${1:-}" ;;
+set-gtk) cmd_set_gtk "${1:-}" ;;
+set-icons) cmd_set_icons "${1:-}" ;;
+sync) cmd_sync ;;
+doctor) cmd_doctor ;;
+# Back-compat shims during transition
+list) cmd_theme_list ;;
+apply) cmd_theme_apply "$@" ;;
+preview) cmd_theme_show "${1:-}" ;;
+*)
+	cat <<'EOF' >&2
 Usage: dots-appearance <command> [args]
 
 Commands:
@@ -418,6 +418,6 @@ Commands:
   sync
   doctor
 EOF
-    exit 1
-    ;;
+	exit 1
+	;;
 esac

--- a/home/dot_local/bin/executable_dots-appearance
+++ b/home/dot_local/bin/executable_dots-appearance
@@ -14,388 +14,397 @@ cmd="${1:-}"
 shift 2>/dev/null || true
 
 json_escape() {
-	python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1"
+  python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1"
 }
 
 _wait_appearance_ipc() {
-	local _i busy="" last_error
-	for _i in $(seq 1 120); do
-		if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
-			echo "Error: failed to poll appearance isBusy via Quickshell IPC" >&2
-			return 1
-		fi
-		busy="${busy//$'\r'/}"
-		busy="${busy//$'\n'/}"
-		[[ $busy == "1" ]] || break
-		sleep 0.5
-	done
-	if [[ $busy == "1" ]]; then
-		echo "Error: appearance apply timed out waiting for Quickshell" >&2
-		return 1
-	fi
-	last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
-	last_error="${last_error//$'\r'/}"
-	last_error="${last_error//$'\n'/}"
-	if [[ -n $last_error ]]; then
-		echo "Error: appearance apply failed: $last_error" >&2
-		return 1
-	fi
-	return 0
+  local _i busy="" last_error
+  for _i in $(seq 1 120); do
+    if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
+      echo "Error: failed to poll appearance isBusy via Quickshell IPC" >&2
+      return 1
+    fi
+    busy="${busy//$'\r'/}"
+    busy="${busy//$'\n'/}"
+    [[ $busy == "1" ]] || break
+    sleep 0.5
+  done
+  if [[ $busy == "1" ]]; then
+    echo "Error: appearance apply timed out waiting for Quickshell" >&2
+    return 1
+  fi
+  last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
+  last_error="${last_error//$'\r'/}"
+  last_error="${last_error//$'\n'/}"
+  if [[ -n $last_error ]]; then
+    echo "Error: appearance apply failed: $last_error" >&2
+    return 1
+  fi
+  return 0
 }
 
 cmd_theme_list() {
-	local script="${HOME}/.local/lib/dots/list-themes.py"
-	if [[ -f $script ]]; then
-		python3 "$script" "$THEMES_DIR"
-	else
-		echo "[]"
-	fi
+  local script="${HOME}/.local/lib/dots/list-themes.py"
+  if [[ -f $script ]]; then
+    python3 "$script" "$THEMES_DIR"
+  else
+    echo "[]"
+  fi
 }
 
 cmd_theme_show() {
-	local id="${1:-}"
-	[[ -n $id ]] || {
-		echo "Usage: dots-appearance theme show <id>" >&2
-		exit 1
-	}
-	local path="${THEMES_DIR}/${id}/theme.json"
-	[[ -f $path ]] || {
-		echo "Theme not found: $id" >&2
-		exit 1
-	}
-	cat "$path"
+  local id="${1:-}"
+  [[ -n $id ]] || {
+    echo "Usage: dots-appearance theme show <id>" >&2
+    exit 1
+  }
+  local path="${THEMES_DIR}/${id}/theme.json"
+  [[ -f $path ]] || {
+    echo "Theme not found: $id" >&2
+    exit 1
+  }
+  cat "$path"
 }
 
 _shell_theme_apply() {
-	local id="$1"
-	local wallpaper="${2:-}"
-	# shellcheck source=/dev/null
-	source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
-	# shellcheck source=/dev/null
-	source "$HOME/.local/lib/dots/apply-appearance.sh"
-	dots_apply_theme "$id" "$wallpaper"
+  local id="$1"
+  local wallpaper="${2:-}"
+  # shellcheck source=/dev/null
+  source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
+  # shellcheck source=/dev/null
+  source "$HOME/.local/lib/dots/apply-appearance.sh"
+  dots_apply_theme "$id" "$wallpaper"
 }
 
 cmd_theme_apply() {
-	local id="${1:-}"
-	local wallpaper=""
-	shift 2>/dev/null || true
-	while [[ $# -gt 0 ]]; do
-		case "${1:-}" in
-		--wallpaper)
-			[[ -n ${2:-} ]] || {
-				echo "dots-appearance theme apply: --wallpaper requires a path" >&2
-				exit 1
-			}
-			wallpaper="$2"
-			shift 2
-			;;
-		*)
-			echo "dots-appearance theme apply: unknown argument: $1" >&2
-			exit 1
-			;;
-		esac
-	done
+  local id="${1:-}"
+  local wallpaper=""
+  shift 2>/dev/null || true
+  while [[ $# -gt 0 ]]; do
+    case "${1:-}" in
+      --wallpaper)
+        [[ -n ${2:-} ]] || {
+          echo "dots-appearance theme apply: --wallpaper requires a path" >&2
+          exit 1
+        }
+        wallpaper="$2"
+        shift 2
+        ;;
+      *)
+        echo "dots-appearance theme apply: unknown argument: $1" >&2
+        exit 1
+        ;;
+    esac
+  done
 
-	[[ -n $id ]] || {
-		echo "Usage: dots-appearance theme apply <id> [--wallpaper <path>]" >&2
-		exit 1
-	}
+  [[ -n $id ]] || {
+    echo "Usage: dots-appearance theme apply <id> [--wallpaper <path>]" >&2
+    exit 1
+  }
 
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		local ipc_out=""
-		if ipc_out="$(quickshell ipc call appearance applyTheme "$id" "${wallpaper:-}" 2>&1)"; then
-			case "$ipc_out" in
-			"Target not found."* | *"Target not found"*)
-				echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
-				;;
-			*)
-				_wait_appearance_ipc || exit 1
-				exit 0
-				;;
-			esac
-		else
-			echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
-		fi
-	fi
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    local ipc_out=""
+    if ipc_out="$(quickshell ipc call appearance applyTheme "$id" "${wallpaper:-}" 2>&1)"; then
+      case "$ipc_out" in
+        "Target not found."* | *"Target not found"*)
+          echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
+          ;;
+        *)
+          _wait_appearance_ipc || exit 1
+          exit 0
+          ;;
+      esac
+    else
+      echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
+    fi
+  fi
 
-	_shell_theme_apply "$id" "$wallpaper"
+  _shell_theme_apply "$id" "$wallpaper"
 }
 
 cmd_theme() {
-	local sub="${1:-}"
-	shift 2>/dev/null || true
-	case "$sub" in
-	list) cmd_theme_list ;;
-	show) cmd_theme_show "${1:-}" ;;
-	apply) cmd_theme_apply "$@" ;;
-	*)
-		cat <<'EOF' >&2
+  local sub="${1:-}"
+  shift 2>/dev/null || true
+  case "$sub" in
+    list) cmd_theme_list ;;
+    show) cmd_theme_show "${1:-}" ;;
+    apply) cmd_theme_apply "$@" ;;
+    *)
+      cat <<'EOF' >&2
 Usage: dots-appearance theme <list|show|apply> …
 
   theme list
   theme show <id>
   theme apply <id> [--wallpaper <path>]
 EOF
-		exit 1
-		;;
-	esac
+      exit 1
+      ;;
+  esac
 }
 
 cmd_status() {
-	local wallpaper="" mode="" flavour="" gtk_theme="" icon_theme=""
-	if command -v dots-wallpaper-current >/dev/null 2>&1; then
-		wallpaper="$(dots-wallpaper-current 2>/dev/null || true)"
-	fi
-	local state_file="${HOME}/.local/state/dots/scheme/state.json"
-	if [[ -f $state_file ]]; then
-		flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
-		mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
-	fi
-	if [[ -f ${HOME}/.config/gtk-3.0/settings.ini ]]; then
-		gtk_theme="$(grep -E '^gtk-theme-name=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-	fi
-	if command -v gsettings >/dev/null 2>&1; then
-		icon_theme="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'\"" || true)"
-	fi
+  local wallpaper="" mode="" flavour="" gtk_theme="" icon_theme=""
+  if command -v dots-wallpaper-current >/dev/null 2>&1; then
+    wallpaper="$(dots-wallpaper-current 2>/dev/null || true)"
+  fi
+  local state_file="${HOME}/.local/state/dots/scheme/state.json"
+  if [[ -f $state_file ]]; then
+    flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
+    mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
+  fi
+  if [[ -f ${HOME}/.config/gtk-3.0/settings.ini ]]; then
+    gtk_theme="$(grep -E '^gtk-theme-name=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+  fi
+  if command -v gsettings >/dev/null 2>&1; then
+    icon_theme="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'\"" || true)"
+  fi
 
-	if [[ ${1:-} == "--json" ]]; then
-		printf '{"wallpaper":%s,"mode":%s,"flavour":%s,"gtkTheme":%s,"iconTheme":%s}\n' \
-			"$(json_escape "${wallpaper:-}")" \
-			"$(json_escape "${mode:-}")" \
-			"$(json_escape "${flavour:-}")" \
-			"$(json_escape "${gtk_theme:-}")" \
-			"$(json_escape "${icon_theme:-}")"
-	else
-		echo "wallpaper : ${wallpaper:-}"
-		echo "mode      : ${mode:-}"
-		echo "flavour   : ${flavour:-}"
-		echo "gtkTheme  : ${gtk_theme:-}"
-		echo "iconTheme : ${icon_theme:-}"
-	fi
+  if [[ ${1:-} == "--json" ]]; then
+    printf '{"wallpaper":%s,"mode":%s,"flavour":%s,"gtkTheme":%s,"iconTheme":%s}\n' \
+      "$(json_escape "${wallpaper:-}")" \
+      "$(json_escape "${mode:-}")" \
+      "$(json_escape "${flavour:-}")" \
+      "$(json_escape "${gtk_theme:-}")" \
+      "$(json_escape "${icon_theme:-}")"
+  else
+    echo "wallpaper : ${wallpaper:-}"
+    echo "mode      : ${mode:-}"
+    echo "flavour   : ${flavour:-}"
+    echo "gtkTheme  : ${gtk_theme:-}"
+    echo "iconTheme : ${icon_theme:-}"
+  fi
 }
 
 cmd_set_wallpaper() {
-	local wallpaper="${1:-}"
-	[[ -n $wallpaper ]] || {
-		echo "Usage: dots-appearance set-wallpaper <path>" >&2
-		exit 1
-	}
-	dots-wallpaper-set "$wallpaper"
+  local wallpaper="${1:-}"
+  [[ -n $wallpaper ]] || {
+    echo "Usage: dots-appearance set-wallpaper <path>" >&2
+    exit 1
+  }
+  dots-wallpaper-set "$wallpaper"
 }
 
 cmd_set_variant() {
-	dots-color-scheme variant "${1:-}"
+  dots-color-scheme variant "${1:-}"
 }
 
 cmd_set_mode() {
-	dots-color-scheme mode "${1:-}"
+  dots-color-scheme mode "${1:-}"
 }
 
 cmd_set_gtk() {
-	local theme="${1:-}"
-	[[ -n $theme ]] || {
-		echo "Usage: dots-appearance set-gtk <theme>" >&2
-		exit 1
-	}
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		if quickshell ipc call appearance setGtk "$theme" >/dev/null 2>&1; then
-			_wait_appearance_ipc || exit 1
-			exit 0
-		fi
-	fi
-	dots-gtk-theme apply "$theme"
+  local theme="${1:-}"
+  [[ -n $theme ]] || {
+    echo "Usage: dots-appearance set-gtk <theme>" >&2
+    exit 1
+  }
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    if quickshell ipc call appearance setGtk "$theme" >/dev/null 2>&1; then
+      _wait_appearance_ipc || exit 1
+      exit 0
+    fi
+  fi
+  local prefer="true" mode="dark"
+  local state_json="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
+  if [[ -f $state_json ]]; then
+    mode="$(python3 -c "import json;print(json.load(open('$state_json')).get('mode','dark'))" 2>/dev/null || echo dark)"
+  fi
+  prefer=$([[ $mode == "light" ]] && echo false || echo true)
+  local icon
+  icon="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'" || true)"
+  [[ -n $icon ]] || icon="Numix-Circle"
+  dots-gtk-theme -q apply "$theme" "$icon" "$prefer"
 }
 
 cmd_set_icons() {
-	local theme="${1:-}"
-	[[ -n $theme ]] || {
-		echo "Usage: dots-appearance set-icons <theme>" >&2
-		exit 1
-	}
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		if quickshell ipc call appearance setIcons "$theme" >/dev/null 2>&1; then
-			_wait_appearance_ipc || exit 1
-			exit 0
-		fi
-	fi
-	gsettings set org.gnome.desktop.interface icon-theme "$theme"
+  local theme="${1:-}"
+  [[ -n $theme ]] || {
+    echo "Usage: dots-appearance set-icons <theme>" >&2
+    exit 1
+  }
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    if quickshell ipc call appearance setIcons "$theme" >/dev/null 2>&1; then
+      _wait_appearance_ipc || exit 1
+      exit 0
+    fi
+  fi
+  dots-gtk-theme -q set-icons "$theme"
 }
 
 cmd_sync() {
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		if quickshell ipc call appearance reload >/dev/null 2>&1; then
-			_wait_appearance_ipc || exit 1
-		fi
-	fi
-	dots-color-scheme sync-state >/dev/null 2>&1 || true
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    if quickshell ipc call appearance reload >/dev/null 2>&1; then
+      _wait_appearance_ipc || exit 1
+    fi
+  fi
+  dots-color-scheme sync-state >/dev/null 2>&1 || true
 }
 
 cmd_doctor() {
-	local ok=0
-	local scheme_flavour="" state_flavour="" scheme_mode="" state_mode=""
-	local pointer="" resolved="" wal_target=""
+  local ok=0
+  local scheme_flavour="" state_flavour="" scheme_mode="" state_mode=""
+  local pointer="" resolved="" wal_target=""
 
-	# One-time purge of removed rice state / legacy pointers.
-	rm -f "$HOME/.local/share/dots/rices/.current_rice" \
-		"$HOME/.cache/dots/current_rice" \
-		"$HOME/.local/state/dots/rice/current" 2>/dev/null || true
-	rmdir "$HOME/.local/state/dots/rice" 2>/dev/null || true
+  # One-time purge of removed rice state / legacy pointers.
+  rm -f "$HOME/.local/share/dots/rices/.current_rice" \
+    "$HOME/.cache/dots/current_rice" \
+    "$HOME/.local/state/dots/rice/current" 2>/dev/null || true
+  rmdir "$HOME/.local/state/dots/rice" 2>/dev/null || true
 
-	local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
-	local state_file="${HOME}/.local/state/dots/scheme/state.json"
-	if [[ -f $scheme_file ]]; then
-		scheme_flavour="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('flavour',''))" 2>/dev/null || true)"
-		scheme_mode="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('mode',''))" 2>/dev/null || true)"
-	fi
-	if [[ -f $state_file ]]; then
-		state_flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
-		state_mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
-	fi
+  local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
+  local state_file="${HOME}/.local/state/dots/scheme/state.json"
+  if [[ -f $scheme_file ]]; then
+    scheme_flavour="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('flavour',''))" 2>/dev/null || true)"
+    scheme_mode="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('mode',''))" 2>/dev/null || true)"
+  fi
+  if [[ -f $state_file ]]; then
+    state_flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
+    state_mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
+  fi
 
-	pointer="${DOTS_WALLPAPER_POINTER_FILE:-$HOME/.local/state/dots/wallpaper/path}"
-	local pointer_val=""
-	[[ -f $pointer ]] && pointer_val="$(head -n 1 "$pointer" | tr -d '\r')"
-	if command -v dots-wallpaper-current >/dev/null 2>&1; then
-		resolved="$(dots-wallpaper-current 2>/dev/null || true)"
-	fi
-	if [[ -L $HOME/.cache/wal/wal ]]; then
-		wal_target="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
-	elif [[ -f $HOME/.cache/wal/wal ]]; then
-		wal_target="$(head -n 1 "$HOME/.cache/wal/wal" | tr -d '\r')"
-		wal_target="$(readlink -f "$wal_target" 2>/dev/null || true)"
-	fi
+  pointer="${DOTS_WALLPAPER_POINTER_FILE:-$HOME/.local/state/dots/wallpaper/path}"
+  local pointer_val=""
+  [[ -f $pointer ]] && pointer_val="$(head -n 1 "$pointer" | tr -d '\r')"
+  if command -v dots-wallpaper-current >/dev/null 2>&1; then
+    resolved="$(dots-wallpaper-current 2>/dev/null || true)"
+  fi
+  if [[ -L $HOME/.cache/wal/wal ]]; then
+    wal_target="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
+  elif [[ -f $HOME/.cache/wal/wal ]]; then
+    wal_target="$(head -n 1 "$HOME/.cache/wal/wal" | tr -d '\r')"
+    wal_target="$(readlink -f "$wal_target" 2>/dev/null || true)"
+  fi
 
-	echo "=== dots-appearance doctor ==="
-	echo "scheme.flavour : ${scheme_flavour:-"(missing)"}"
-	echo "state.flavour  : ${state_flavour:-"(missing)"}"
-	echo "scheme.mode    : ${scheme_mode:-"(missing)"}"
-	echo "state.mode     : ${state_mode:-"(missing)"}"
-	local hyprlock_conf="${HOME}/.cache/dots/smart-colors/colors-hyprlock.conf"
-	local hyprlock_bytes=0
-	[[ -f $hyprlock_conf ]] && hyprlock_bytes="$(wc -c <"$hyprlock_conf" | tr -d ' ')"
-	local gtk_theme_ini="" gtk_prefer_dark="" gtk_color_scheme=""
-	if [[ -f ${HOME}/.config/gtk-3.0/settings.ini ]]; then
-		gtk_theme_ini="$(grep -E '^gtk-theme-name=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-		gtk_prefer_dark="$(grep -E '^gtk-application-prefer-dark-theme=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-	fi
-	if command -v gsettings >/dev/null 2>&1; then
-		gtk_color_scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'\"" || true)"
-	fi
+  echo "=== dots-appearance doctor ==="
+  echo "scheme.flavour : ${scheme_flavour:-"(missing)"}"
+  echo "state.flavour  : ${state_flavour:-"(missing)"}"
+  echo "scheme.mode    : ${scheme_mode:-"(missing)"}"
+  echo "state.mode     : ${state_mode:-"(missing)"}"
+  local hyprlock_conf="${HOME}/.cache/dots/smart-colors/colors-hyprlock.conf"
+  local hyprlock_bytes=0
+  [[ -f $hyprlock_conf ]] && hyprlock_bytes="$(wc -c <"$hyprlock_conf" | tr -d ' ')"
+  local gtk_theme_ini="" gtk_prefer_dark="" gtk_color_scheme=""
+  if [[ -f ${HOME}/.config/gtk-3.0/settings.ini ]]; then
+    gtk_theme_ini="$(grep -E '^gtk-theme-name=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+    gtk_prefer_dark="$(grep -E '^gtk-application-prefer-dark-theme=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+  fi
+  if command -v gsettings >/dev/null 2>&1; then
+    gtk_color_scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'\"" || true)"
+  fi
 
-	echo "wallpaper.ptr  : ${pointer_val:-"(missing)"}"
-	echo "wallpaper.res  : ${resolved:-"(missing)"}"
-	echo "wal.target     : ${wal_target:-"(missing)"}"
-	echo "hyprlock.conf  : ${hyprlock_bytes} bytes"
-	echo "gtk.theme.ini  : ${gtk_theme_ini:-"(missing)"}"
-	echo "gtk.preferDark : ${gtk_prefer_dark:-"(missing)"}"
-	echo "gtk.colorScheme: ${gtk_color_scheme:-"(missing)"}"
+  echo "wallpaper.ptr  : ${pointer_val:-"(missing)"}"
+  echo "wallpaper.res  : ${resolved:-"(missing)"}"
+  echo "wal.target     : ${wal_target:-"(missing)"}"
+  echo "hyprlock.conf  : ${hyprlock_bytes} bytes"
+  echo "gtk.theme.ini  : ${gtk_theme_ini:-"(missing)"}"
+  echo "gtk.preferDark : ${gtk_prefer_dark:-"(missing)"}"
+  echo "gtk.colorScheme: ${gtk_color_scheme:-"(missing)"}"
 
-	if [[ -e $HOME/.local/share/dots/rices/.current_rice || -e $HOME/.cache/dots/current_rice || -e $HOME/.local/state/dots/rice/current ]]; then
-		echo "FAIL: legacy rice pointer still present" >&2
-		ok=1
-	fi
-	if [[ -n $scheme_flavour && -n $state_flavour && $scheme_flavour != "$state_flavour" ]]; then
-		echo "FAIL: scheme flavour != state flavour ($scheme_flavour vs $state_flavour)" >&2
-		ok=1
-	fi
-	if [[ -n $scheme_mode && -n $state_mode && $scheme_mode != "$state_mode" ]]; then
-		echo "FAIL: scheme mode != state mode ($scheme_mode vs $state_mode)" >&2
-		ok=1
-	fi
-	if [[ -z $pointer_val ]]; then
-		echo "FAIL: wallpaper pointer missing" >&2
-		ok=1
-	elif [[ ! -f $pointer_val ]]; then
-		echo "FAIL: wallpaper pointer does not exist: $pointer_val" >&2
-		ok=1
-	fi
-	if [[ -n $pointer_val && -n $resolved && $pointer_val != "$resolved" ]]; then
-		local ptr_real res_real
-		ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
-		res_real="$(readlink -f "$resolved" 2>/dev/null || true)"
-		if [[ -n $ptr_real && -n $res_real && $ptr_real != "$res_real" ]]; then
-			echo "FAIL: pointer != dots-wallpaper-current ($pointer_val vs $resolved)" >&2
-			ok=1
-		fi
-	fi
-	if [[ -n $pointer_val && -f $pointer_val ]]; then
-		local ptr_real wal_real
-		ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
-		if [[ -L $HOME/.cache/wal/wal ]]; then
-			wal_real="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
-		elif [[ -f $HOME/.cache/wal/wal ]]; then
-			wal_real="$(head -n 1 "$HOME/.cache/wal/wal" | tr -d '\r')"
-			wal_real="$(readlink -f "$wal_real" 2>/dev/null || true)"
-		fi
-		if [[ -z ${wal_real:-} ]]; then
-			echo "FAIL: ~/.cache/wal/wal missing or broken" >&2
-			ok=1
-		elif [[ -n $ptr_real && $ptr_real != "$wal_real" ]]; then
-			echo "FAIL: wal target != wallpaper pointer ($wal_real vs $ptr_real)" >&2
-			ok=1
-		fi
-	fi
-	if [[ ! -f $hyprlock_conf || ${hyprlock_bytes:-0} -eq 0 ]]; then
-		echo "FAIL: colors-hyprlock.conf missing or empty" >&2
-		ok=1
-	fi
-	if [[ -f ${HOME}/.local/state/dots/wallpaper/path.txt ]]; then
-		echo "FAIL: orphan wallpaper/path.txt present (use wallpaper/path)" >&2
-		ok=1
-	fi
-	if [[ -f ${HOME}/.cache/dots/smart-colors/wallpaper ]]; then
-		echo "FAIL: orphan smart-colors/wallpaper cache present" >&2
-		ok=1
-	fi
-	if [[ -n $state_mode && -n $gtk_prefer_dark ]]; then
-		if [[ $state_mode == "dark" && $gtk_prefer_dark == "false" ]]; then
-			echo "FAIL: GTK prefer-dark=false while live mode is dark" >&2
-			ok=1
-		elif [[ $state_mode == "light" && $gtk_prefer_dark == "true" ]]; then
-			echo "FAIL: GTK prefer-dark=true while live mode is light" >&2
-			ok=1
-		fi
-	fi
-	if [[ -n $state_mode && -n $gtk_color_scheme ]]; then
-		if [[ $state_mode == "dark" && $gtk_color_scheme != "prefer-dark" ]]; then
-			echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is dark" >&2
-			ok=1
-		elif [[ $state_mode == "light" && $gtk_color_scheme != "prefer-light" ]]; then
-			echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is light" >&2
-			ok=1
-		fi
-	fi
-	if [[ -n $wal_target && -f $wal_target ]]; then
-		if ! file -b --mime-type "$wal_target" 2>/dev/null | grep -q '^image/'; then
-			echo "WARN: wal target is not an image: $wal_target" >&2
-		fi
-	fi
+  if [[ -e $HOME/.local/share/dots/rices/.current_rice || -e $HOME/.cache/dots/current_rice || -e $HOME/.local/state/dots/rice/current ]]; then
+    echo "FAIL: legacy rice pointer still present" >&2
+    ok=1
+  fi
+  if [[ -n $scheme_flavour && -n $state_flavour && $scheme_flavour != "$state_flavour" ]]; then
+    echo "FAIL: scheme flavour != state flavour ($scheme_flavour vs $state_flavour)" >&2
+    ok=1
+  fi
+  if [[ -n $scheme_mode && -n $state_mode && $scheme_mode != "$state_mode" ]]; then
+    echo "FAIL: scheme mode != state mode ($scheme_mode vs $state_mode)" >&2
+    ok=1
+  fi
+  if [[ -z $pointer_val ]]; then
+    echo "FAIL: wallpaper pointer missing" >&2
+    ok=1
+  elif [[ ! -f $pointer_val ]]; then
+    echo "FAIL: wallpaper pointer does not exist: $pointer_val" >&2
+    ok=1
+  fi
+  if [[ -n $pointer_val && -n $resolved && $pointer_val != "$resolved" ]]; then
+    local ptr_real res_real
+    ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
+    res_real="$(readlink -f "$resolved" 2>/dev/null || true)"
+    if [[ -n $ptr_real && -n $res_real && $ptr_real != "$res_real" ]]; then
+      echo "FAIL: pointer != dots-wallpaper-current ($pointer_val vs $resolved)" >&2
+      ok=1
+    fi
+  fi
+  if [[ -n $pointer_val && -f $pointer_val ]]; then
+    local ptr_real wal_real
+    ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
+    if [[ -L $HOME/.cache/wal/wal ]]; then
+      wal_real="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
+    elif [[ -f $HOME/.cache/wal/wal ]]; then
+      wal_real="$(head -n 1 "$HOME/.cache/wal/wal" | tr -d '\r')"
+      wal_real="$(readlink -f "$wal_real" 2>/dev/null || true)"
+    fi
+    if [[ -z ${wal_real:-} ]]; then
+      echo "FAIL: ~/.cache/wal/wal missing or broken" >&2
+      ok=1
+    elif [[ -n $ptr_real && $ptr_real != "$wal_real" ]]; then
+      echo "FAIL: wal target != wallpaper pointer ($wal_real vs $ptr_real)" >&2
+      ok=1
+    fi
+  fi
+  if [[ ! -f $hyprlock_conf || ${hyprlock_bytes:-0} -eq 0 ]]; then
+    echo "FAIL: colors-hyprlock.conf missing or empty" >&2
+    ok=1
+  fi
+  if [[ -f ${HOME}/.local/state/dots/wallpaper/path.txt ]]; then
+    echo "FAIL: orphan wallpaper/path.txt present (use wallpaper/path)" >&2
+    ok=1
+  fi
+  if [[ -f ${HOME}/.cache/dots/smart-colors/wallpaper ]]; then
+    echo "FAIL: orphan smart-colors/wallpaper cache present" >&2
+    ok=1
+  fi
+  if [[ -n $state_mode && -n $gtk_prefer_dark ]]; then
+    if [[ $state_mode == "dark" && $gtk_prefer_dark == "false" ]]; then
+      echo "FAIL: GTK prefer-dark=false while live mode is dark" >&2
+      ok=1
+    elif [[ $state_mode == "light" && $gtk_prefer_dark == "true" ]]; then
+      echo "FAIL: GTK prefer-dark=true while live mode is light" >&2
+      ok=1
+    fi
+  fi
+  if [[ -n $state_mode && -n $gtk_color_scheme ]]; then
+    if [[ $state_mode == "dark" && $gtk_color_scheme != "prefer-dark" ]]; then
+      echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is dark" >&2
+      ok=1
+    elif [[ $state_mode == "light" && $gtk_color_scheme != "prefer-light" ]]; then
+      echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is light" >&2
+      ok=1
+    fi
+  fi
+  if [[ -n $wal_target && -f $wal_target ]]; then
+    if ! file -b --mime-type "$wal_target" 2>/dev/null | grep -q '^image/'; then
+      echo "WARN: wal target is not an image: $wal_target" >&2
+    fi
+  fi
 
-	if [[ $ok -eq 0 ]]; then
-		echo "OK: appearance state is consistent"
-	else
-		echo "DONE: inconsistencies detected (exit $ok)"
-	fi
-	return "$ok"
+  if [[ $ok -eq 0 ]]; then
+    echo "OK: appearance state is consistent"
+  else
+    echo "DONE: inconsistencies detected (exit $ok)"
+  fi
+  return "$ok"
 }
 
 case "${cmd:-}" in
-theme) cmd_theme "$@" ;;
-status) cmd_status "${1:-}" ;;
-set-variant) cmd_set_variant "${1:-}" ;;
-set-mode) cmd_set_mode "${1:-}" ;;
-set-wallpaper) cmd_set_wallpaper "${1:-}" ;;
-set-gtk) cmd_set_gtk "${1:-}" ;;
-set-icons) cmd_set_icons "${1:-}" ;;
-sync) cmd_sync ;;
-doctor) cmd_doctor ;;
-# Back-compat shims during transition
-list) cmd_theme_list ;;
-apply) cmd_theme_apply "$@" ;;
-preview) cmd_theme_show "${1:-}" ;;
-*)
-	cat <<'EOF' >&2
+  theme) cmd_theme "$@" ;;
+  status) cmd_status "${1:-}" ;;
+  set-variant) cmd_set_variant "${1:-}" ;;
+  set-mode) cmd_set_mode "${1:-}" ;;
+  set-wallpaper) cmd_set_wallpaper "${1:-}" ;;
+  set-gtk) cmd_set_gtk "${1:-}" ;;
+  set-icons) cmd_set_icons "${1:-}" ;;
+  sync) cmd_sync ;;
+  doctor) cmd_doctor ;;
+  # Back-compat shims during transition
+  list) cmd_theme_list ;;
+  apply) cmd_theme_apply "$@" ;;
+  preview) cmd_theme_show "${1:-}" ;;
+  *)
+    cat <<'EOF' >&2
 Usage: dots-appearance <command> [args]
 
 Commands:
@@ -409,6 +418,6 @@ Commands:
   sync
   doctor
 EOF
-	exit 1
-	;;
+    exit 1
+    ;;
 esac

--- a/home/dot_local/bin/executable_dots-color-scheme
+++ b/home/dot_local/bin/executable_dots-color-scheme
@@ -7,9 +7,9 @@
 
 set -euo pipefail
 
-if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+if [[ -r "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
 	# shellcheck source=/dev/null
-	source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+	source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
 fi
 
 SCHEME_FILE="${HOME}/.cache/dots/smart-colors/scheme.json"
@@ -74,9 +74,13 @@ resolve_wallpaper() {
 
 	local wall=""
 	if [[ -f $CURRENT_WALL_CACHE ]]; then
-		wall=$(<"$CURRENT_WALL_CACHE")
-	elif [[ -e $WAL_WALL_LINK ]]; then
-		wall=$(readlink -f "$WAL_WALL_LINK" 2>/dev/null || true)
+		wall="$(head -n 1 "$CURRENT_WALL_CACHE" 2>/dev/null | tr -d '\r' || true)"
+	elif [[ -L $WAL_WALL_LINK ]]; then
+		# Legacy pywal image symlink
+		wall="$(readlink -f "$WAL_WALL_LINK" 2>/dev/null || true)"
+	elif [[ -f $WAL_WALL_LINK ]]; then
+		# Canonical: text path file (never treat the wal file itself as the image)
+		wall="$(head -n 1 "$WAL_WALL_LINK" 2>/dev/null | tr -d '\r' || true)"
 	fi
 
 	if [[ -n ${wall:-} && -f $wall ]]; then

--- a/home/dot_local/bin/executable_dots-color-scheme
+++ b/home/dot_local/bin/executable_dots-color-scheme
@@ -8,8 +8,8 @@
 set -euo pipefail
 
 if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-  # shellcheck source=/dev/null
-  source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+	# shellcheck source=/dev/null
+	source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
 fi
 
 SCHEME_FILE="${HOME}/.cache/dots/smart-colors/scheme.json"
@@ -25,75 +25,75 @@ cmd="${1:-}"
 shift 2>/dev/null || true
 
 normalize_scheme_type() {
-  local raw="${1:-tonal-spot}"
-  local normalized
-  normalized=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
-  case "$normalized" in
-    vibrant) echo "vibrant" ;;
-    tonalspot | tonal-spot) echo "tonal-spot" ;;
-    expressive) echo "expressive" ;;
-    fidelity) echo "fidelity" ;;
-    content) echo "content" ;;
-    neutral) echo "neutral" ;;
-    monochrome) echo "monochrome" ;;
-    fruitsalad | rainbow) echo "expressive" ;;
-    auto | *) echo "tonal-spot" ;;
-  esac
+	local raw="${1:-tonal-spot}"
+	local normalized
+	normalized=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
+	case "$normalized" in
+	vibrant) echo "vibrant" ;;
+	tonalspot | tonal-spot) echo "tonal-spot" ;;
+	expressive) echo "expressive" ;;
+	fidelity) echo "fidelity" ;;
+	content) echo "content" ;;
+	neutral) echo "neutral" ;;
+	monochrome) echo "monochrome" ;;
+	fruitsalad | rainbow) echo "expressive" ;;
+	auto | *) echo "tonal-spot" ;;
+	esac
 }
 
 normalize_variant() {
-  local raw="${1:-tonalspot}"
-  local normalized
-  normalized=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
-  case "$normalized" in
-    tonal-spot | tonalspot) echo "tonalspot" ;;
-    vibrant | expressive | fidelity | content | neutral | monochrome | fruitsalad | rainbow) echo "$normalized" ;;
-    *) echo "tonalspot" ;;
-  esac
+	local raw="${1:-tonalspot}"
+	local normalized
+	normalized=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
+	case "$normalized" in
+	tonal-spot | tonalspot) echo "tonalspot" ;;
+	vibrant | expressive | fidelity | content | neutral | monochrome | fruitsalad | rainbow) echo "$normalized" ;;
+	*) echo "tonalspot" ;;
+	esac
 }
 
 variant_to_scheme_type() {
-  local variant
-  variant=$(normalize_variant "${1:-}")
-  case "$variant" in
-    tonalspot) echo "tonal-spot" ;;
-    fruitsalad | rainbow) echo "expressive" ;;
-    *) echo "$variant" ;;
-  esac
+	local variant
+	variant=$(normalize_variant "${1:-}")
+	case "$variant" in
+	tonalspot) echo "tonal-spot" ;;
+	fruitsalad | rainbow) echo "expressive" ;;
+	*) echo "$variant" ;;
+	esac
 }
 
 resolve_wallpaper() {
-  if declare -f dots_current_wallpaper >/dev/null 2>&1; then
-    local unified=""
-    unified="$(dots_current_wallpaper 2>/dev/null || true)"
-    if [[ -n ${unified:-} && -f $unified ]]; then
-      printf '%s\n' "$unified"
-      return 0
-    fi
-  fi
+	if declare -f dots_current_wallpaper >/dev/null 2>&1; then
+		local unified=""
+		unified="$(dots_current_wallpaper 2>/dev/null || true)"
+		if [[ -n ${unified:-} && -f $unified ]]; then
+			printf '%s\n' "$unified"
+			return 0
+		fi
+	fi
 
-  local wall=""
-  if [[ -f $CURRENT_WALL_CACHE ]]; then
-    wall=$(<"$CURRENT_WALL_CACHE")
-  elif [[ -e $WAL_WALL_LINK ]]; then
-    wall=$(readlink -f "$WAL_WALL_LINK" 2>/dev/null || true)
-  fi
+	local wall=""
+	if [[ -f $CURRENT_WALL_CACHE ]]; then
+		wall=$(<"$CURRENT_WALL_CACHE")
+	elif [[ -e $WAL_WALL_LINK ]]; then
+		wall=$(readlink -f "$WAL_WALL_LINK" 2>/dev/null || true)
+	fi
 
-  if [[ -n ${wall:-} && -f $wall ]]; then
-    printf '%s\n' "$wall"
-    return 0
-  fi
-  return 1
+	if [[ -n ${wall:-} && -f $wall ]]; then
+		printf '%s\n' "$wall"
+		return 0
+	fi
+	return 1
 }
 
 ensure_state_dir() {
-  mkdir -p "$STATE_DIR"
+	mkdir -p "$STATE_DIR"
 }
 
 read_scheme_meta() {
-  local field="${1:-}"
-  [[ -f $SCHEME_FILE ]] || return 1
-  python3 - "$SCHEME_FILE" "$field" <<'PY'
+	local field="${1:-}"
+	[[ -f $SCHEME_FILE ]] || return 1
+	python3 - "$SCHEME_FILE" "$field" <<'PY'
 import json
 import sys
 path, field = sys.argv[1], sys.argv[2]
@@ -104,12 +104,12 @@ PY
 }
 
 write_state() {
-  local name="$1"
-  local flavour="$2"
-  local mode="$3"
-  local variant="$4"
-  ensure_state_dir
-  python3 - "$STATE_FILE" "$name" "$flavour" "$mode" "$variant" <<'PY'
+	local name="$1"
+	local flavour="$2"
+	local mode="$3"
+	local variant="$4"
+	ensure_state_dir
+	python3 - "$STATE_FILE" "$name" "$flavour" "$mode" "$variant" <<'PY'
 import json
 import pathlib
 import sys
@@ -126,31 +126,31 @@ PY
 }
 
 ensure_state() {
-  ensure_state_dir
-  if [[ -f $STATE_FILE ]]; then
-    return 0
-  fi
+	ensure_state_dir
+	if [[ -f $STATE_FILE ]]; then
+		return 0
+	fi
 
-  local flavour="tonal-spot"
-  local mode="dark"
-  local variant="tonalspot"
+	local flavour="tonal-spot"
+	local mode="dark"
+	local variant="tonalspot"
 
-  if [[ -f $SCHEME_FILE ]]; then
-    local f m
-    f="$(read_scheme_meta flavour || true)"
-    m="$(read_scheme_meta mode || true)"
-    [[ -n ${f:-} ]] && flavour="$(normalize_scheme_type "$f")"
-    [[ $m == "light" || $m == "dark" ]] && mode="$m"
-    variant="$(normalize_variant "$flavour")"
-  fi
+	if [[ -f $SCHEME_FILE ]]; then
+		local f m
+		f="$(read_scheme_meta flavour || true)"
+		m="$(read_scheme_meta mode || true)"
+		[[ -n ${f:-} ]] && flavour="$(normalize_scheme_type "$f")"
+		[[ $m == "light" || $m == "dark" ]] && mode="$m"
+		variant="$(normalize_variant "$flavour")"
+	fi
 
-  write_state "dynamic" "$flavour" "$mode" "$variant"
+	write_state "dynamic" "$flavour" "$mode" "$variant"
 }
 
 read_state_field() {
-  local field="$1"
-  ensure_state
-  python3 - "$STATE_FILE" "$field" <<'PY'
+	local field="$1"
+	ensure_state
+	python3 - "$STATE_FILE" "$field" <<'PY'
 import json
 import sys
 path, field = sys.argv[1], sys.argv[2]
@@ -161,56 +161,56 @@ PY
 }
 
 ensure_scheme_file() {
-  if [[ -f $SCHEME_FILE ]]; then
-    return 0
-  fi
-  regenerate_scheme >/dev/null 2>&1 || true
+	if [[ -f $SCHEME_FILE ]]; then
+		return 0
+	fi
+	regenerate_scheme >/dev/null 2>&1 || true
 }
 
 regenerate_scheme() {
-  ensure_state
-  command -v python3 >/dev/null 2>&1 || return 1
-  [[ -f $M3_SCRIPT ]] || return 1
+	ensure_state
+	command -v python3 >/dev/null 2>&1 || return 1
+	[[ -f $M3_SCRIPT ]] || return 1
 
-  local wallpaper
-  wallpaper="$(resolve_wallpaper)" || return 1
+	local wallpaper
+	wallpaper="$(resolve_wallpaper)" || return 1
 
-  local flavour mode
-  flavour="$(read_state_field flavour)"
-  mode="$(read_state_field mode)"
-  flavour="$(normalize_scheme_type "$flavour")"
-  [[ $mode == "light" || $mode == "dark" ]] || mode="dark"
+	local flavour mode
+	flavour="$(read_state_field flavour)"
+	mode="$(read_state_field mode)"
+	flavour="$(normalize_scheme_type "$flavour")"
+	[[ $mode == "light" || $mode == "dark" ]] || mode="dark"
 
-  mkdir -p "$(dirname "$SCHEME_FILE")"
-  local accent_args=()
-  local accent_override="${XDG_CACHE_HOME:-${HOME}/.cache}/dots/smart-colors/accent-override"
-  if [[ -f $accent_override ]]; then
-    local accent_hex
-    accent_hex="$(cat "$accent_override")"
-    [[ -n $accent_hex ]] && accent_args=(--source-color "$accent_hex")
-  fi
-  python3 "$M3_SCRIPT" \
-    --image "$wallpaper" \
-    --output "$SCHEME_FILE" \
-    --mode "$mode" \
-    --scheme-type "$flavour" \
-    "${accent_args[@]}" >/dev/null 2>&1 || return 1
+	mkdir -p "$(dirname "$SCHEME_FILE")"
+	local accent_args=()
+	local accent_override="${XDG_CACHE_HOME:-${HOME}/.cache}/dots/smart-colors/accent-override"
+	if [[ -f $accent_override ]]; then
+		local accent_hex
+		accent_hex="$(cat "$accent_override")"
+		[[ -n $accent_hex ]] && accent_args=(--source-color "$accent_hex")
+	fi
+	python3 "$M3_SCRIPT" \
+		--image "$wallpaper" \
+		--output "$SCHEME_FILE" \
+		--mode "$mode" \
+		--scheme-type "$flavour" \
+		"${accent_args[@]}" >/dev/null 2>&1 || return 1
 
-  # Regenerate hyprlock theme colors from the new scheme
-  if command -v dots-hyprlock-theme >/dev/null 2>&1; then
-    dots-hyprlock-theme >/dev/null 2>&1 || true
-  fi
+	# Regenerate hyprlock theme colors from the new scheme
+	if command -v dots-hyprlock-theme >/dev/null 2>&1; then
+		dots-hyprlock-theme >/dev/null 2>&1 || true
+	fi
 
-  if pgrep -x quickshell >/dev/null 2>&1 && command -v dots-quickshell >/dev/null 2>&1; then
-    dots-quickshell ipc colours reload >/dev/null 2>&1 || true
-  fi
+	if pgrep -x quickshell >/dev/null 2>&1 && command -v dots-quickshell >/dev/null 2>&1; then
+		dots-quickshell ipc colours reload >/dev/null 2>&1 || true
+	fi
 }
 
 cmd_list() {
-  ensure_state
-  ensure_scheme_file
+	ensure_state
+	ensure_scheme_file
 
-  python3 - "$SCHEME_FILE" "${SCHEME_TYPES[@]}" <<'PY'
+	python3 - "$SCHEME_FILE" "${SCHEME_TYPES[@]}" <<'PY'
 import json
 import pathlib
 import sys
@@ -232,117 +232,117 @@ PY
 }
 
 cmd_current() {
-  ensure_state
-  local name flavour variant
-  name="$(read_state_field name)"
-  flavour="$(read_state_field flavour)"
-  variant="$(read_state_field variant)"
-  [[ -n $name ]] || name="dynamic"
-  [[ -n $flavour ]] || flavour="tonal-spot"
-  [[ -n $variant ]] || variant="tonalspot"
-  printf '%s\n' "$name"
-  printf '%s\n' "$flavour"
-  printf '%s\n' "$variant"
+	ensure_state
+	local name flavour variant
+	name="$(read_state_field name)"
+	flavour="$(read_state_field flavour)"
+	variant="$(read_state_field variant)"
+	[[ -n $name ]] || name="dynamic"
+	[[ -n $flavour ]] || flavour="tonal-spot"
+	[[ -n $variant ]] || variant="tonalspot"
+	printf '%s\n' "$name"
+	printf '%s\n' "$flavour"
+	printf '%s\n' "$variant"
 }
 
 cmd_set() {
-  ensure_state
-  local name flavour mode variant
-  name="$(read_state_field name)"
-  flavour="$(read_state_field flavour)"
-  mode="$(read_state_field mode)"
-  variant="$(read_state_field variant)"
+	ensure_state
+	local name flavour mode variant
+	name="$(read_state_field name)"
+	flavour="$(read_state_field flavour)"
+	mode="$(read_state_field mode)"
+	variant="$(read_state_field variant)"
 
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      -n | --name)
-        name="${2:-$name}"
-        shift 2
-        ;;
-      -f | --flavour | --flavor)
-        flavour="$(normalize_scheme_type "${2:-$flavour}")"
-        variant="$(normalize_variant "$flavour")"
-        shift 2
-        ;;
-      *)
-        shift
-        ;;
-    esac
-  done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		-n | --name)
+			name="${2:-$name}"
+			shift 2
+			;;
+		-f | --flavour | --flavor)
+			flavour="$(normalize_scheme_type "${2:-$flavour}")"
+			variant="$(normalize_variant "$flavour")"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
 
-  write_state "$name" "$flavour" "$mode" "$variant"
-  regenerate_scheme || true
+	write_state "$name" "$flavour" "$mode" "$variant"
+	regenerate_scheme || true
 }
 
 cmd_variant() {
-  ensure_state
-  local variant_in="${1:-tonalspot}"
-  local variant flavour name mode
-  variant="$(normalize_variant "$variant_in")"
-  flavour="$(variant_to_scheme_type "$variant")"
-  name="$(read_state_field name)"
-  mode="$(read_state_field mode)"
-  write_state "${name:-dynamic}" "$flavour" "${mode:-dark}" "$variant"
-  regenerate_scheme || true
+	ensure_state
+	local variant_in="${1:-tonalspot}"
+	local variant flavour name mode
+	variant="$(normalize_variant "$variant_in")"
+	flavour="$(variant_to_scheme_type "$variant")"
+	name="$(read_state_field name)"
+	mode="$(read_state_field mode)"
+	write_state "${name:-dynamic}" "$flavour" "${mode:-dark}" "$variant"
+	regenerate_scheme || true
 }
 
 cmd_mode() {
-  ensure_state
-  local mode="${1:-}"
-  if [[ $mode != "light" && $mode != "dark" ]]; then
-    echo "Usage: dots-color-scheme mode {light|dark}" >&2
-    exit 1
-  fi
-  local name flavour variant
-  name="$(read_state_field name)"
-  flavour="$(normalize_scheme_type "$(read_state_field flavour)")"
-  variant="$(read_state_field variant)"
-  write_state "${name:-dynamic}" "$flavour" "$mode" "${variant:-tonalspot}"
-  regenerate_scheme || true
-  # Keep GTK/libadwaita color-scheme aligned with live appearance mode.
-  if command -v dots-gtk-theme >/dev/null 2>&1; then
-    dots-gtk-theme -q color-scheme "$mode" >/dev/null 2>&1 || true
-  elif [[ -f ${HOME}/.local/lib/dots/gtk-theme-manager.sh ]]; then
-    # shellcheck source=/dev/null
-    source "${HOME}/.local/lib/dots/gtk-theme-manager.sh"
-    if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
-      apply_gtk_color_scheme "$mode" || true
-    fi
-  fi
+	ensure_state
+	local mode="${1:-}"
+	if [[ $mode != "light" && $mode != "dark" ]]; then
+		echo "Usage: dots-color-scheme mode {light|dark}" >&2
+		exit 1
+	fi
+	local name flavour variant
+	name="$(read_state_field name)"
+	flavour="$(normalize_scheme_type "$(read_state_field flavour)")"
+	variant="$(read_state_field variant)"
+	write_state "${name:-dynamic}" "$flavour" "$mode" "${variant:-tonalspot}"
+	regenerate_scheme || true
+	# Keep GTK/libadwaita color-scheme aligned with live appearance mode.
+	if command -v dots-gtk-theme >/dev/null 2>&1; then
+		dots-gtk-theme -q color-scheme "$mode" >/dev/null 2>&1 || true
+	elif [[ -f ${HOME}/.local/lib/dots/gtk-theme-manager.sh ]]; then
+		# shellcheck source=/dev/null
+		source "${HOME}/.local/lib/dots/gtk-theme-manager.sh"
+		if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
+			apply_gtk_color_scheme "$mode" || true
+		fi
+	fi
 }
 
 cmd_regenerate() {
-  ensure_scheme_file
+	ensure_scheme_file
 }
 
 # Sync state.json from the meta already present in scheme.json (no regenerate).
 # Used by ThemePipeline.qml / apply-appearance.sh after a successful M3 write so boot
 # regenerate cannot fight the live schemeType/mode.
 cmd_sync_state() {
-  [[ -f $SCHEME_FILE ]] || {
-    echo "dots-color-scheme sync-state: scheme.json missing" >&2
-    return 1
-  }
-  local flavour mode name variant
-  flavour="$(normalize_scheme_type "$(read_scheme_meta flavour || true)")"
-  mode="$(read_scheme_meta mode || true)"
-  [[ $mode == "light" || $mode == "dark" ]] || mode="dark"
-  name="$(read_scheme_meta name || true)"
-  [[ -n $name ]] || name="dynamic"
-  variant="$(normalize_variant "$flavour")"
-  write_state "$name" "$flavour" "$mode" "$variant"
+	[[ -f $SCHEME_FILE ]] || {
+		echo "dots-color-scheme sync-state: scheme.json missing" >&2
+		return 1
+	}
+	local flavour mode name variant
+	flavour="$(normalize_scheme_type "$(read_scheme_meta flavour || true)")"
+	mode="$(read_scheme_meta mode || true)"
+	[[ $mode == "light" || $mode == "dark" ]] || mode="dark"
+	name="$(read_scheme_meta name || true)"
+	[[ -n $name ]] || name="dynamic"
+	variant="$(normalize_variant "$flavour")"
+	write_state "$name" "$flavour" "$mode" "$variant"
 }
 
 case "$cmd" in
-  list) cmd_list ;;
-  current) cmd_current ;;
-  set) cmd_set "$@" ;;
-  variant) cmd_variant "${1:-}" ;;
-  mode) cmd_mode "${1:-}" ;;
-  regenerate) cmd_regenerate ;;
-  sync-state) cmd_sync_state ;;
-  *)
-    echo "Usage: dots-color-scheme {list|current|set|variant|mode|regenerate|sync-state}" >&2
-    exit 1
-    ;;
+list) cmd_list ;;
+current) cmd_current ;;
+set) cmd_set "$@" ;;
+variant) cmd_variant "${1:-}" ;;
+mode) cmd_mode "${1:-}" ;;
+regenerate) cmd_regenerate ;;
+sync-state) cmd_sync_state ;;
+*)
+	echo "Usage: dots-color-scheme {list|current|set|variant|mode|regenerate|sync-state}" >&2
+	exit 1
+	;;
 esac

--- a/home/dot_local/bin/executable_dots-color-scheme
+++ b/home/dot_local/bin/executable_dots-color-scheme
@@ -8,8 +8,8 @@
 set -euo pipefail
 
 if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-	# shellcheck source=/dev/null
-	source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+  # shellcheck source=/dev/null
+  source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
 fi
 
 SCHEME_FILE="${HOME}/.cache/dots/smart-colors/scheme.json"
@@ -25,75 +25,75 @@ cmd="${1:-}"
 shift 2>/dev/null || true
 
 normalize_scheme_type() {
-	local raw="${1:-tonal-spot}"
-	local normalized
-	normalized=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
-	case "$normalized" in
-	vibrant) echo "vibrant" ;;
-	tonalspot | tonal-spot) echo "tonal-spot" ;;
-	expressive) echo "expressive" ;;
-	fidelity) echo "fidelity" ;;
-	content) echo "content" ;;
-	neutral) echo "neutral" ;;
-	monochrome) echo "monochrome" ;;
-	fruitsalad | rainbow) echo "expressive" ;;
-	auto | *) echo "tonal-spot" ;;
-	esac
+  local raw="${1:-tonal-spot}"
+  local normalized
+  normalized=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
+  case "$normalized" in
+    vibrant) echo "vibrant" ;;
+    tonalspot | tonal-spot) echo "tonal-spot" ;;
+    expressive) echo "expressive" ;;
+    fidelity) echo "fidelity" ;;
+    content) echo "content" ;;
+    neutral) echo "neutral" ;;
+    monochrome) echo "monochrome" ;;
+    fruitsalad | rainbow) echo "expressive" ;;
+    auto | *) echo "tonal-spot" ;;
+  esac
 }
 
 normalize_variant() {
-	local raw="${1:-tonalspot}"
-	local normalized
-	normalized=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
-	case "$normalized" in
-	tonal-spot | tonalspot) echo "tonalspot" ;;
-	vibrant | expressive | fidelity | content | neutral | monochrome | fruitsalad | rainbow) echo "$normalized" ;;
-	*) echo "tonalspot" ;;
-	esac
+  local raw="${1:-tonalspot}"
+  local normalized
+  normalized=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
+  case "$normalized" in
+    tonal-spot | tonalspot) echo "tonalspot" ;;
+    vibrant | expressive | fidelity | content | neutral | monochrome | fruitsalad | rainbow) echo "$normalized" ;;
+    *) echo "tonalspot" ;;
+  esac
 }
 
 variant_to_scheme_type() {
-	local variant
-	variant=$(normalize_variant "${1:-}")
-	case "$variant" in
-	tonalspot) echo "tonal-spot" ;;
-	fruitsalad | rainbow) echo "expressive" ;;
-	*) echo "$variant" ;;
-	esac
+  local variant
+  variant=$(normalize_variant "${1:-}")
+  case "$variant" in
+    tonalspot) echo "tonal-spot" ;;
+    fruitsalad | rainbow) echo "expressive" ;;
+    *) echo "$variant" ;;
+  esac
 }
 
 resolve_wallpaper() {
-	if declare -f dots_current_wallpaper >/dev/null 2>&1; then
-		local unified=""
-		unified="$(dots_current_wallpaper 2>/dev/null || true)"
-		if [[ -n ${unified:-} && -f $unified ]]; then
-			printf '%s\n' "$unified"
-			return 0
-		fi
-	fi
+  if declare -f dots_current_wallpaper >/dev/null 2>&1; then
+    local unified=""
+    unified="$(dots_current_wallpaper 2>/dev/null || true)"
+    if [[ -n ${unified:-} && -f $unified ]]; then
+      printf '%s\n' "$unified"
+      return 0
+    fi
+  fi
 
-	local wall=""
-	if [[ -f $CURRENT_WALL_CACHE ]]; then
-		wall=$(<"$CURRENT_WALL_CACHE")
-	elif [[ -e $WAL_WALL_LINK ]]; then
-		wall=$(readlink -f "$WAL_WALL_LINK" 2>/dev/null || true)
-	fi
+  local wall=""
+  if [[ -f $CURRENT_WALL_CACHE ]]; then
+    wall=$(<"$CURRENT_WALL_CACHE")
+  elif [[ -e $WAL_WALL_LINK ]]; then
+    wall=$(readlink -f "$WAL_WALL_LINK" 2>/dev/null || true)
+  fi
 
-	if [[ -n ${wall:-} && -f $wall ]]; then
-		printf '%s\n' "$wall"
-		return 0
-	fi
-	return 1
+  if [[ -n ${wall:-} && -f $wall ]]; then
+    printf '%s\n' "$wall"
+    return 0
+  fi
+  return 1
 }
 
 ensure_state_dir() {
-	mkdir -p "$STATE_DIR"
+  mkdir -p "$STATE_DIR"
 }
 
 read_scheme_meta() {
-	local field="${1:-}"
-	[[ -f $SCHEME_FILE ]] || return 1
-	python3 - "$SCHEME_FILE" "$field" <<'PY'
+  local field="${1:-}"
+  [[ -f $SCHEME_FILE ]] || return 1
+  python3 - "$SCHEME_FILE" "$field" <<'PY'
 import json
 import sys
 path, field = sys.argv[1], sys.argv[2]
@@ -104,12 +104,12 @@ PY
 }
 
 write_state() {
-	local name="$1"
-	local flavour="$2"
-	local mode="$3"
-	local variant="$4"
-	ensure_state_dir
-	python3 - "$STATE_FILE" "$name" "$flavour" "$mode" "$variant" <<'PY'
+  local name="$1"
+  local flavour="$2"
+  local mode="$3"
+  local variant="$4"
+  ensure_state_dir
+  python3 - "$STATE_FILE" "$name" "$flavour" "$mode" "$variant" <<'PY'
 import json
 import pathlib
 import sys
@@ -126,31 +126,31 @@ PY
 }
 
 ensure_state() {
-	ensure_state_dir
-	if [[ -f $STATE_FILE ]]; then
-		return 0
-	fi
+  ensure_state_dir
+  if [[ -f $STATE_FILE ]]; then
+    return 0
+  fi
 
-	local flavour="tonal-spot"
-	local mode="dark"
-	local variant="tonalspot"
+  local flavour="tonal-spot"
+  local mode="dark"
+  local variant="tonalspot"
 
-	if [[ -f $SCHEME_FILE ]]; then
-		local f m
-		f="$(read_scheme_meta flavour || true)"
-		m="$(read_scheme_meta mode || true)"
-		[[ -n ${f:-} ]] && flavour="$(normalize_scheme_type "$f")"
-		[[ $m == "light" || $m == "dark" ]] && mode="$m"
-		variant="$(normalize_variant "$flavour")"
-	fi
+  if [[ -f $SCHEME_FILE ]]; then
+    local f m
+    f="$(read_scheme_meta flavour || true)"
+    m="$(read_scheme_meta mode || true)"
+    [[ -n ${f:-} ]] && flavour="$(normalize_scheme_type "$f")"
+    [[ $m == "light" || $m == "dark" ]] && mode="$m"
+    variant="$(normalize_variant "$flavour")"
+  fi
 
-	write_state "dynamic" "$flavour" "$mode" "$variant"
+  write_state "dynamic" "$flavour" "$mode" "$variant"
 }
 
 read_state_field() {
-	local field="$1"
-	ensure_state
-	python3 - "$STATE_FILE" "$field" <<'PY'
+  local field="$1"
+  ensure_state
+  python3 - "$STATE_FILE" "$field" <<'PY'
 import json
 import sys
 path, field = sys.argv[1], sys.argv[2]
@@ -161,56 +161,56 @@ PY
 }
 
 ensure_scheme_file() {
-	if [[ -f $SCHEME_FILE ]]; then
-		return 0
-	fi
-	regenerate_scheme >/dev/null 2>&1 || true
+  if [[ -f $SCHEME_FILE ]]; then
+    return 0
+  fi
+  regenerate_scheme >/dev/null 2>&1 || true
 }
 
 regenerate_scheme() {
-	ensure_state
-	command -v python3 >/dev/null 2>&1 || return 1
-	[[ -f $M3_SCRIPT ]] || return 1
+  ensure_state
+  command -v python3 >/dev/null 2>&1 || return 1
+  [[ -f $M3_SCRIPT ]] || return 1
 
-	local wallpaper
-	wallpaper="$(resolve_wallpaper)" || return 1
+  local wallpaper
+  wallpaper="$(resolve_wallpaper)" || return 1
 
-	local flavour mode
-	flavour="$(read_state_field flavour)"
-	mode="$(read_state_field mode)"
-	flavour="$(normalize_scheme_type "$flavour")"
-	[[ $mode == "light" || $mode == "dark" ]] || mode="dark"
+  local flavour mode
+  flavour="$(read_state_field flavour)"
+  mode="$(read_state_field mode)"
+  flavour="$(normalize_scheme_type "$flavour")"
+  [[ $mode == "light" || $mode == "dark" ]] || mode="dark"
 
-	mkdir -p "$(dirname "$SCHEME_FILE")"
-	local accent_args=()
-	local accent_override="${XDG_CACHE_HOME:-${HOME}/.cache}/dots/smart-colors/accent-override"
-	if [[ -f $accent_override ]]; then
-		local accent_hex
-		accent_hex="$(cat "$accent_override")"
-		[[ -n $accent_hex ]] && accent_args=(--source-color "$accent_hex")
-	fi
-	python3 "$M3_SCRIPT" \
-		--image "$wallpaper" \
-		--output "$SCHEME_FILE" \
-		--mode "$mode" \
-		--scheme-type "$flavour" \
-		"${accent_args[@]}" >/dev/null 2>&1 || return 1
+  mkdir -p "$(dirname "$SCHEME_FILE")"
+  local accent_args=()
+  local accent_override="${XDG_CACHE_HOME:-${HOME}/.cache}/dots/smart-colors/accent-override"
+  if [[ -f $accent_override ]]; then
+    local accent_hex
+    accent_hex="$(cat "$accent_override")"
+    [[ -n $accent_hex ]] && accent_args=(--source-color "$accent_hex")
+  fi
+  python3 "$M3_SCRIPT" \
+    --image "$wallpaper" \
+    --output "$SCHEME_FILE" \
+    --mode "$mode" \
+    --scheme-type "$flavour" \
+    "${accent_args[@]}" >/dev/null 2>&1 || return 1
 
-	# Regenerate hyprlock theme colors from the new scheme
-	if command -v dots-hyprlock-theme >/dev/null 2>&1; then
-		dots-hyprlock-theme >/dev/null 2>&1 || true
-	fi
+  # Regenerate hyprlock theme colors from the new scheme
+  if command -v dots-hyprlock-theme >/dev/null 2>&1; then
+    dots-hyprlock-theme >/dev/null 2>&1 || true
+  fi
 
-	if pgrep -x quickshell >/dev/null 2>&1 && command -v dots-quickshell >/dev/null 2>&1; then
-		dots-quickshell ipc colours reload >/dev/null 2>&1 || true
-	fi
+  if pgrep -x quickshell >/dev/null 2>&1 && command -v dots-quickshell >/dev/null 2>&1; then
+    dots-quickshell ipc colours reload >/dev/null 2>&1 || true
+  fi
 }
 
 cmd_list() {
-	ensure_state
-	ensure_scheme_file
+  ensure_state
+  ensure_scheme_file
 
-	python3 - "$SCHEME_FILE" "${SCHEME_TYPES[@]}" <<'PY'
+  python3 - "$SCHEME_FILE" "${SCHEME_TYPES[@]}" <<'PY'
 import json
 import pathlib
 import sys
@@ -232,115 +232,117 @@ PY
 }
 
 cmd_current() {
-	ensure_state
-	local name flavour variant
-	name="$(read_state_field name)"
-	flavour="$(read_state_field flavour)"
-	variant="$(read_state_field variant)"
-	[[ -n $name ]] || name="dynamic"
-	[[ -n $flavour ]] || flavour="tonal-spot"
-	[[ -n $variant ]] || variant="tonalspot"
-	printf '%s\n' "$name"
-	printf '%s\n' "$flavour"
-	printf '%s\n' "$variant"
+  ensure_state
+  local name flavour variant
+  name="$(read_state_field name)"
+  flavour="$(read_state_field flavour)"
+  variant="$(read_state_field variant)"
+  [[ -n $name ]] || name="dynamic"
+  [[ -n $flavour ]] || flavour="tonal-spot"
+  [[ -n $variant ]] || variant="tonalspot"
+  printf '%s\n' "$name"
+  printf '%s\n' "$flavour"
+  printf '%s\n' "$variant"
 }
 
 cmd_set() {
-	ensure_state
-	local name flavour mode variant
-	name="$(read_state_field name)"
-	flavour="$(read_state_field flavour)"
-	mode="$(read_state_field mode)"
-	variant="$(read_state_field variant)"
+  ensure_state
+  local name flavour mode variant
+  name="$(read_state_field name)"
+  flavour="$(read_state_field flavour)"
+  mode="$(read_state_field mode)"
+  variant="$(read_state_field variant)"
 
-	while [[ $# -gt 0 ]]; do
-		case "$1" in
-		-n | --name)
-			name="${2:-$name}"
-			shift 2
-			;;
-		-f | --flavour | --flavor)
-			flavour="$(normalize_scheme_type "${2:-$flavour}")"
-			variant="$(normalize_variant "$flavour")"
-			shift 2
-			;;
-		*)
-			shift
-			;;
-		esac
-	done
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -n | --name)
+        name="${2:-$name}"
+        shift 2
+        ;;
+      -f | --flavour | --flavor)
+        flavour="$(normalize_scheme_type "${2:-$flavour}")"
+        variant="$(normalize_variant "$flavour")"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
 
-	write_state "$name" "$flavour" "$mode" "$variant"
-	regenerate_scheme || true
+  write_state "$name" "$flavour" "$mode" "$variant"
+  regenerate_scheme || true
 }
 
 cmd_variant() {
-	ensure_state
-	local variant_in="${1:-tonalspot}"
-	local variant flavour name mode
-	variant="$(normalize_variant "$variant_in")"
-	flavour="$(variant_to_scheme_type "$variant")"
-	name="$(read_state_field name)"
-	mode="$(read_state_field mode)"
-	write_state "${name:-dynamic}" "$flavour" "${mode:-dark}" "$variant"
-	regenerate_scheme || true
+  ensure_state
+  local variant_in="${1:-tonalspot}"
+  local variant flavour name mode
+  variant="$(normalize_variant "$variant_in")"
+  flavour="$(variant_to_scheme_type "$variant")"
+  name="$(read_state_field name)"
+  mode="$(read_state_field mode)"
+  write_state "${name:-dynamic}" "$flavour" "${mode:-dark}" "$variant"
+  regenerate_scheme || true
 }
 
 cmd_mode() {
-	ensure_state
-	local mode="${1:-}"
-	if [[ $mode != "light" && $mode != "dark" ]]; then
-		echo "Usage: dots-color-scheme mode {light|dark}" >&2
-		exit 1
-	fi
-	local name flavour variant
-	name="$(read_state_field name)"
-	flavour="$(normalize_scheme_type "$(read_state_field flavour)")"
-	variant="$(read_state_field variant)"
-	write_state "${name:-dynamic}" "$flavour" "$mode" "${variant:-tonalspot}"
-	regenerate_scheme || true
-	# Keep GTK/libadwaita color-scheme aligned with live appearance mode.
-	if [[ -f ${HOME}/.local/lib/dots/gtk-theme-manager.sh ]]; then
-		# shellcheck source=/dev/null
-		source "${HOME}/.local/lib/dots/gtk-theme-manager.sh"
-		if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
-			apply_gtk_color_scheme "$mode" || true
-		fi
-	fi
+  ensure_state
+  local mode="${1:-}"
+  if [[ $mode != "light" && $mode != "dark" ]]; then
+    echo "Usage: dots-color-scheme mode {light|dark}" >&2
+    exit 1
+  fi
+  local name flavour variant
+  name="$(read_state_field name)"
+  flavour="$(normalize_scheme_type "$(read_state_field flavour)")"
+  variant="$(read_state_field variant)"
+  write_state "${name:-dynamic}" "$flavour" "$mode" "${variant:-tonalspot}"
+  regenerate_scheme || true
+  # Keep GTK/libadwaita color-scheme aligned with live appearance mode.
+  if command -v dots-gtk-theme >/dev/null 2>&1; then
+    dots-gtk-theme -q color-scheme "$mode" >/dev/null 2>&1 || true
+  elif [[ -f ${HOME}/.local/lib/dots/gtk-theme-manager.sh ]]; then
+    # shellcheck source=/dev/null
+    source "${HOME}/.local/lib/dots/gtk-theme-manager.sh"
+    if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
+      apply_gtk_color_scheme "$mode" || true
+    fi
+  fi
 }
 
 cmd_regenerate() {
-	ensure_scheme_file
+  ensure_scheme_file
 }
 
 # Sync state.json from the meta already present in scheme.json (no regenerate).
 # Used by ThemePipeline.qml / apply-appearance.sh after a successful M3 write so boot
 # regenerate cannot fight the live schemeType/mode.
 cmd_sync_state() {
-	[[ -f $SCHEME_FILE ]] || {
-		echo "dots-color-scheme sync-state: scheme.json missing" >&2
-		return 1
-	}
-	local flavour mode name variant
-	flavour="$(normalize_scheme_type "$(read_scheme_meta flavour || true)")"
-	mode="$(read_scheme_meta mode || true)"
-	[[ $mode == "light" || $mode == "dark" ]] || mode="dark"
-	name="$(read_scheme_meta name || true)"
-	[[ -n $name ]] || name="dynamic"
-	variant="$(normalize_variant "$flavour")"
-	write_state "$name" "$flavour" "$mode" "$variant"
+  [[ -f $SCHEME_FILE ]] || {
+    echo "dots-color-scheme sync-state: scheme.json missing" >&2
+    return 1
+  }
+  local flavour mode name variant
+  flavour="$(normalize_scheme_type "$(read_scheme_meta flavour || true)")"
+  mode="$(read_scheme_meta mode || true)"
+  [[ $mode == "light" || $mode == "dark" ]] || mode="dark"
+  name="$(read_scheme_meta name || true)"
+  [[ -n $name ]] || name="dynamic"
+  variant="$(normalize_variant "$flavour")"
+  write_state "$name" "$flavour" "$mode" "$variant"
 }
 
 case "$cmd" in
-list) cmd_list ;;
-current) cmd_current ;;
-set) cmd_set "$@" ;;
-variant) cmd_variant "${1:-}" ;;
-mode) cmd_mode "${1:-}" ;;
-regenerate) cmd_regenerate ;;
-sync-state) cmd_sync_state ;;
-*)
-	echo "Usage: dots-color-scheme {list|current|set|variant|mode|regenerate|sync-state}" >&2
-	exit 1
-	;;
+  list) cmd_list ;;
+  current) cmd_current ;;
+  set) cmd_set "$@" ;;
+  variant) cmd_variant "${1:-}" ;;
+  mode) cmd_mode "${1:-}" ;;
+  regenerate) cmd_regenerate ;;
+  sync-state) cmd_sync_state ;;
+  *)
+    echo "Usage: dots-color-scheme {list|current|set|variant|mode|regenerate|sync-state}" >&2
+    exit 1
+    ;;
 esac

--- a/home/dot_local/bin/executable_dots-gtk-theme
+++ b/home/dot_local/bin/executable_dots-gtk-theme
@@ -49,23 +49,23 @@ source ~/.local/lib/dots/easy-options/easyoptions.sh || exit
 
 # Source the GTK theme manager - try multiple locations
 gtk_theme_manager_paths=(
-  "$HOME/.local/lib/dots/gtk-theme-manager.sh"
-  "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../lib/dots/gtk-theme-manager.sh"
+	"$HOME/.local/lib/dots/gtk-theme-manager.sh"
+	"$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../lib/dots/gtk-theme-manager.sh"
 )
 
 gtk_theme_manager_found=false
 for path in "${gtk_theme_manager_paths[@]}"; do
-  if [[ -f $path ]]; then
-    source "$path"
-    gtk_theme_manager_found=true
-    break
-  fi
+	if [[ -f $path ]]; then
+		source "$path"
+		gtk_theme_manager_found=true
+		break
+	fi
 done
 
 if [[ $gtk_theme_manager_found != "true" ]]; then
-  echo "Error: GTK theme manager not found in any of these locations:" >&2
-  printf '  %s\n' "${gtk_theme_manager_paths[@]}" >&2
-  exit 1
+	echo "Error: GTK theme manager not found in any of these locations:" >&2
+	printf '  %s\n' "${gtk_theme_manager_paths[@]}" >&2
+	exit 1
 fi
 
 # Color definitions for output
@@ -79,420 +79,420 @@ readonly NC='\033[0m' # No Color
 
 # Function to log messages with verbosity control
 log() {
-  local level="$1"
-  shift
-  local message="$*"
+	local level="$1"
+	shift
+	local message="$*"
 
-  if [[ ${quiet:-} == "yes" ]] && [[ $level != "ERROR" ]]; then
-    return 0
-  fi
+	if [[ ${quiet:-} == "yes" ]] && [[ $level != "ERROR" ]]; then
+		return 0
+	fi
 
-  local timestamp
-  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+	local timestamp
+	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-  case "$level" in
-    "ERROR")
-      echo -e "${RED}❌ [ERROR] $message${NC}" >&2
-      ;;
-    "WARN")
-      echo -e "${YELLOW}⚠️  [WARN] $message${NC}" >&2
-      ;;
-    "INFO")
-      if [[ ${verbose:-} == "yes" ]]; then
-        echo -e "${BLUE}ℹ️  [INFO] $message${NC}"
-      fi
-      ;;
-    "DEBUG")
-      if [[ ${debug:-} == "yes" ]]; then
-        echo -e "${PURPLE}🐛 [DEBUG] [$timestamp] $message${NC}" >&2
-      fi
-      ;;
-    *)
-      echo -e "$message"
-      ;;
-  esac
+	case "$level" in
+	"ERROR")
+		echo -e "${RED}❌ [ERROR] $message${NC}" >&2
+		;;
+	"WARN")
+		echo -e "${YELLOW}⚠️  [WARN] $message${NC}" >&2
+		;;
+	"INFO")
+		if [[ ${verbose:-} == "yes" ]]; then
+			echo -e "${BLUE}ℹ️  [INFO] $message${NC}"
+		fi
+		;;
+	"DEBUG")
+		if [[ ${debug:-} == "yes" ]]; then
+			echo -e "${PURPLE}🐛 [DEBUG] [$timestamp] $message${NC}" >&2
+		fi
+		;;
+	*)
+		echo -e "$message"
+		;;
+	esac
 }
 
 # Function to list installed GTK themes
 cmd_list() {
-  local use_plain=false
-  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+	local use_plain=false
+	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-  local themes
-  themes=$(list_installed_gtk_themes)
+	local themes
+	themes=$(list_installed_gtk_themes)
 
-  if [[ -z $themes ]]; then
-    [[ $use_plain == true ]] || log "WARN" "No GTK themes found"
-    return 1
-  fi
+	if [[ -z $themes ]]; then
+		[[ $use_plain == true ]] || log "WARN" "No GTK themes found"
+		return 1
+	fi
 
-  if [[ $use_plain == true ]]; then
-    printf '%s\n' "$themes"
-    return 0
-  fi
+	if [[ $use_plain == true ]]; then
+		printf '%s\n' "$themes"
+		return 0
+	fi
 
-  log "" "${BLUE}📋 Installed GTK themes:${NC}"
-  log "" ""
+	log "" "${BLUE}📋 Installed GTK themes:${NC}"
+	log "" ""
 
-  local current_theme
-  current_theme=$(get_current_gtk_theme)
-  log "DEBUG" "Current theme: $current_theme"
+	local current_theme
+	current_theme=$(get_current_gtk_theme)
+	log "DEBUG" "Current theme: $current_theme"
 
-  while IFS= read -r theme; do
-    if [[ $theme == "$current_theme" ]]; then
-      log "" "  ${GREEN}✓${NC} $theme ${CYAN}(current)${NC}"
-    else
-      log "" "    $theme"
-    fi
-  done <<<"$themes"
+	while IFS= read -r theme; do
+		if [[ $theme == "$current_theme" ]]; then
+			log "" "  ${GREEN}✓${NC} $theme ${CYAN}(current)${NC}"
+		else
+			log "" "    $theme"
+		fi
+	done <<<"$themes"
 
-  log "" ""
-  log "" "${CYAN}💡 Tip:${NC} Use 'dots gtk-theme apply <theme>' to apply a theme"
+	log "" ""
+	log "" "${CYAN}💡 Tip:${NC} Use 'dots gtk-theme apply <theme>' to apply a theme"
 }
 
 # Function to show current theme
 cmd_current() {
-  local use_plain=false
-  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+	local use_plain=false
+	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-  local current_theme
-  current_theme=$(get_current_gtk_theme)
+	local current_theme
+	current_theme=$(get_current_gtk_theme)
 
-  if [[ $use_plain == true ]]; then
-    printf '%s\n' "$current_theme"
-    return 0
-  fi
+	if [[ $use_plain == true ]]; then
+		printf '%s\n' "$current_theme"
+		return 0
+	fi
 
-  log "" "${BLUE}🎨 Current GTK Theme:${NC} $current_theme"
+	log "" "${BLUE}🎨 Current GTK Theme:${NC} $current_theme"
 
-  # Show additional info
-  if [[ -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
-    local icon_theme
-    icon_theme=$(grep "^gtk-icon-theme-name=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
-    log "" "${BLUE}🎯 Icon Theme:${NC} $icon_theme"
+	# Show additional info
+	if [[ -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
+		local icon_theme
+		icon_theme=$(grep "^gtk-icon-theme-name=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
+		log "" "${BLUE}🎯 Icon Theme:${NC} $icon_theme"
 
-    local dark_pref
-    dark_pref=$(grep "^gtk-application-prefer-dark-theme=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
-    log "" "${BLUE}🌙 Dark Theme Preference:${NC} $dark_pref"
-  fi
+		local dark_pref
+		dark_pref=$(grep "^gtk-application-prefer-dark-theme=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
+		log "" "${BLUE}🌙 Dark Theme Preference:${NC} $dark_pref"
+	fi
 }
 
 # Function to apply specific theme
 cmd_apply() {
-  local theme_name="$1"
-  local icon_theme="${2:-}"
-  local prefer_dark="${3:-}"
+	local theme_name="$1"
+	local icon_theme="${2:-}"
+	local prefer_dark="${3:-}"
 
-  if [[ -z $icon_theme ]]; then
-    icon_theme="$(get_current_icon_theme 2>/dev/null || true)"
-    [[ -n $icon_theme ]] || icon_theme="Numix-Circle"
-  fi
-  if [[ -z $prefer_dark ]]; then
-    # Derive from live scheme state when callers omit prefer-dark.
-    local mode="dark"
-    local state_json="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
-    if [[ -f $state_json ]]; then
-      mode="$(python3 -c "import json;print(json.load(open('$state_json')).get('mode','dark'))" 2>/dev/null || echo dark)"
-    fi
-    prefer_dark=$([[ $mode == "light" ]] && echo false || echo true)
-  fi
+	if [[ -z $icon_theme ]]; then
+		icon_theme="$(get_current_icon_theme 2>/dev/null || true)"
+		[[ -n $icon_theme ]] || icon_theme="Numix-Circle"
+	fi
+	if [[ -z $prefer_dark ]]; then
+		# Derive from live scheme state when callers omit prefer-dark.
+		local mode="dark"
+		local state_json="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
+		if [[ -f $state_json ]]; then
+			mode="$(python3 -c "import json;print(json.load(open('$state_json')).get('mode','dark'))" 2>/dev/null || echo dark)"
+		fi
+		prefer_dark=$([[ $mode == "light" ]] && echo false || echo true)
+	fi
 
-  log "" "${BLUE}🎨 Applying GTK Theme:${NC} $theme_name"
-  log "DEBUG" "Icon theme: $icon_theme, prefer dark: $prefer_dark"
+	log "" "${BLUE}🎨 Applying GTK Theme:${NC} $theme_name"
+	log "DEBUG" "Icon theme: $icon_theme, prefer dark: $prefer_dark"
 
-  if apply_gtk_theme "$theme_name" "$icon_theme" "$prefer_dark"; then
-    log "" "${GREEN}✅ Theme applied successfully${NC}"
-  else
-    log "ERROR" "Failed to apply theme"
-    return 1
-  fi
+	if apply_gtk_theme "$theme_name" "$icon_theme" "$prefer_dark"; then
+		log "" "${GREEN}✅ Theme applied successfully${NC}"
+	else
+		log "ERROR" "Failed to apply theme"
+		return 1
+	fi
 }
 
 # Update icon theme while preserving the current GTK theme + prefer-dark.
 cmd_set_icons() {
-  local icon_theme="${1:-}"
-  [[ -n $icon_theme ]] || {
-    log "ERROR" "Icon theme name required"
-    log "" "Usage: $(basename "$0") set-icons <icon-theme>"
-    return 1
-  }
+	local icon_theme="${1:-}"
+	[[ -n $icon_theme ]] || {
+		log "ERROR" "Icon theme name required"
+		log "" "Usage: $(basename "$0") set-icons <icon-theme>"
+		return 1
+	}
 
-  local gtk_theme prefer_dark
-  gtk_theme="$(get_current_gtk_theme)"
-  prefer_dark="false"
-  if [[ -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
-    prefer_dark="$(grep "^gtk-application-prefer-dark-theme=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2 || echo false)"
-  fi
-  [[ $prefer_dark == "1" || $prefer_dark == "true" ]] && prefer_dark="true" || prefer_dark="false"
+	local gtk_theme prefer_dark
+	gtk_theme="$(get_current_gtk_theme)"
+	prefer_dark="false"
+	if [[ -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
+		prefer_dark="$(grep "^gtk-application-prefer-dark-theme=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2 || echo false)"
+	fi
+	[[ $prefer_dark == "1" || $prefer_dark == "true" ]] && prefer_dark="true" || prefer_dark="false"
 
-  log "" "${BLUE}🎯 Applying icon theme:${NC} $icon_theme (gtk=$gtk_theme)"
-  if apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"; then
-    log "" "${GREEN}✅ Icon theme applied successfully${NC}"
-  else
-    log "ERROR" "Failed to apply icon theme"
-    return 1
-  fi
+	log "" "${BLUE}🎯 Applying icon theme:${NC} $icon_theme (gtk=$gtk_theme)"
+	if apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"; then
+		log "" "${GREEN}✅ Icon theme applied successfully${NC}"
+	else
+		log "ERROR" "Failed to apply icon theme"
+		return 1
+	fi
 }
 
 # Sync GTK color-scheme / prefer-dark with live light|dark mode.
 cmd_color_scheme() {
-  local mode="${1:-}"
-  [[ $mode == "light" || $mode == "dark" ]] || {
-    log "ERROR" "Mode must be light or dark"
-    log "" "Usage: $(basename "$0") color-scheme <light|dark>"
-    return 1
-  }
-  if apply_gtk_color_scheme "$mode"; then
-    log "" "${GREEN}✅ GTK color-scheme synced:${NC} $mode"
-  else
-    log "ERROR" "Failed to sync GTK color-scheme"
-    return 1
-  fi
+	local mode="${1:-}"
+	[[ $mode == "light" || $mode == "dark" ]] || {
+		log "ERROR" "Mode must be light or dark"
+		log "" "Usage: $(basename "$0") color-scheme <light|dark>"
+		return 1
+	}
+	if apply_gtk_color_scheme "$mode"; then
+		log "" "${GREEN}✅ GTK color-scheme synced:${NC} $mode"
+	else
+		log "ERROR" "Failed to sync GTK color-scheme"
+		return 1
+	fi
 }
 
 # Function to detect optimal theme
 cmd_detect() {
-  local wallpaper_path="${1:-}"
+	local wallpaper_path="${1:-}"
 
-  if [[ -z $wallpaper_path ]]; then
-    # Use current wallpaper
-    wallpaper_path=$(cat "$HOME/.cache/wal/wal" 2>/dev/null || echo "")
-    if [[ -z $wallpaper_path ]]; then
-      echo -e "${RED}❌ No wallpaper specified and no current wallpaper found${NC}"
-      return 1
-    fi
-  fi
+	if [[ -z $wallpaper_path ]]; then
+		# Use current wallpaper
+		wallpaper_path=$(cat "$HOME/.cache/wal/wal" 2>/dev/null || echo "")
+		if [[ -z $wallpaper_path ]]; then
+			echo -e "${RED}❌ No wallpaper specified and no current wallpaper found${NC}"
+			return 1
+		fi
+	fi
 
-  if [[ ! -f $wallpaper_path ]]; then
-    echo -e "${RED}❌ Wallpaper file not found: $wallpaper_path${NC}"
-    return 1
-  fi
+	if [[ ! -f $wallpaper_path ]]; then
+		echo -e "${RED}❌ Wallpaper file not found: $wallpaper_path${NC}"
+		return 1
+	fi
 
-  echo -e "${BLUE}🔍 Analyzing wallpaper:${NC} $(basename "$wallpaper_path")"
+	echo -e "${BLUE}🔍 Analyzing wallpaper:${NC} $(basename "$wallpaper_path")"
 
-  local theme_info
-  theme_info=$(detect_optimal_gtk_theme "$wallpaper_path")
-  local detected_theme="${theme_info%:*}"
-  local prefer_dark="${theme_info#*:}"
+	local theme_info
+	theme_info=$(detect_optimal_gtk_theme "$wallpaper_path")
+	local detected_theme="${theme_info%:*}"
+	local prefer_dark="${theme_info#*:}"
 
-  echo -e "${GREEN}🎯 Detected optimal theme:${NC} $detected_theme"
-  echo -e "${GREEN}🌙 Dark preference:${NC} $prefer_dark"
+	echo -e "${GREEN}🎯 Detected optimal theme:${NC} $detected_theme"
+	echo -e "${GREEN}🌙 Dark preference:${NC} $prefer_dark"
 
-  # Ask if user wants to apply
-  read -p "Apply this theme? (y/N): " -n 1 -r
-  echo
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
-    cmd_apply "$detected_theme" "Numix-Circle" "$prefer_dark"
-  fi
+	# Ask if user wants to apply
+	read -p "Apply this theme? (y/N): " -n 1 -r
+	echo
+	if [[ $REPLY =~ ^[Yy]$ ]]; then
+		cmd_apply "$detected_theme" "Numix-Circle" "$prefer_dark"
+	fi
 }
 
 # Function to apply theme-pack GTK settings
 cmd_theme_pack() {
-  local theme_id="${1:-}"
+	local theme_id="${1:-}"
 
-  echo -e "${BLUE}🎨 Applying GTK theme from theme pack:${NC} ${theme_id:-auto-detect}"
+	echo -e "${BLUE}🎨 Applying GTK theme from theme pack:${NC} ${theme_id:-auto-detect}"
 
-  if apply_theme_gtk_theme "$theme_id"; then
-    echo -e "${GREEN}✅ Theme pack GTK theme applied successfully${NC}"
-  else
-    echo -e "${RED}❌ Failed to apply theme pack GTK theme${NC}"
-    return 1
-  fi
+	if apply_theme_gtk_theme "$theme_id"; then
+		echo -e "${GREEN}✅ Theme pack GTK theme applied successfully${NC}"
+	else
+		echo -e "${RED}❌ Failed to apply theme pack GTK theme${NC}"
+		return 1
+	fi
 }
 
 # Function to auto-detect and apply
 cmd_auto() {
-  echo -e "${BLUE}🤖 Auto-detecting optimal GTK theme...${NC}"
-  cmd_theme_pack ""
+	echo -e "${BLUE}🤖 Auto-detecting optimal GTK theme...${NC}"
+	cmd_theme_pack ""
 }
 
 # Function to list icon themes
 cmd_icons() {
-  local use_plain=false
-  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+	local use_plain=false
+	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-  local icon_dirs=(
-    "/usr/share/icons"
-    "/usr/local/share/icons"
-    "$HOME/.icons"
-    "${XDG_DATA_HOME:-$HOME/.local/share}/icons"
-  )
+	local icon_dirs=(
+		"/usr/share/icons"
+		"/usr/local/share/icons"
+		"$HOME/.icons"
+		"${XDG_DATA_HOME:-$HOME/.local/share}/icons"
+	)
 
-  local icons=()
-  for icon_dir in "${icon_dirs[@]}"; do
-    if [[ -d $icon_dir ]]; then
-      while IFS= read -r -d '' icon_path; do
-        local icon_name
-        icon_name=$(basename "$icon_path")
-        case "$icon_name" in
-          default | hicolor) continue ;;
-        esac
-        if [[ -f "$icon_path/index.theme" ]]; then
-          icons+=("$icon_name")
-        fi
-      done < <(find "$icon_dir" -maxdepth 1 -mindepth 1 -type d -print0 2>/dev/null)
-    fi
-  done
+	local icons=()
+	for icon_dir in "${icon_dirs[@]}"; do
+		if [[ -d $icon_dir ]]; then
+			while IFS= read -r -d '' icon_path; do
+				local icon_name
+				icon_name=$(basename "$icon_path")
+				case "$icon_name" in
+				default | hicolor) continue ;;
+				esac
+				if [[ -f "$icon_path/index.theme" ]]; then
+					icons+=("$icon_name")
+				fi
+			done < <(find "$icon_dir" -maxdepth 1 -mindepth 1 -type d -print0 2>/dev/null)
+		fi
+	done
 
-  local unique_icons
-  unique_icons=$(printf '%s\n' "${icons[@]}" | sort -u)
+	local unique_icons
+	unique_icons=$(printf '%s\n' "${icons[@]}" | sort -u)
 
-  if [[ $use_plain == true ]]; then
-    printf '%s\n' "$unique_icons"
-    return 0
-  fi
+	if [[ $use_plain == true ]]; then
+		printf '%s\n' "$unique_icons"
+		return 0
+	fi
 
-  echo -e "${BLUE}🎯 Installed Icon Themes:${NC}"
-  echo ""
+	echo -e "${BLUE}🎯 Installed Icon Themes:${NC}"
+	echo ""
 
-  local current_icon=""
-  current_icon="$(get_current_icon_theme 2>/dev/null || true)"
+	local current_icon=""
+	current_icon="$(get_current_icon_theme 2>/dev/null || true)"
 
-  while IFS= read -r icon; do
-    [[ -z $icon ]] && continue
-    if [[ $icon == "$current_icon" ]]; then
-      echo -e "  ${GREEN}✓${NC} $icon ${CYAN}(current)${NC}"
-    else
-      echo -e "    $icon"
-    fi
-  done <<<"$unique_icons"
+	while IFS= read -r icon; do
+		[[ -z $icon ]] && continue
+		if [[ $icon == "$current_icon" ]]; then
+			echo -e "  ${GREEN}✓${NC} $icon ${CYAN}(current)${NC}"
+		else
+			echo -e "    $icon"
+		fi
+	done <<<"$unique_icons"
 }
 
 # Function to show theme information
 cmd_info() {
-  local theme_name="$1"
+	local theme_name="$1"
 
-  echo -e "${BLUE}ℹ️  Theme Information: $theme_name${NC}"
-  echo ""
+	echo -e "${BLUE}ℹ️  Theme Information: $theme_name${NC}"
+	echo ""
 
-  # Find theme directories
-  local theme_dirs=(
-    "/usr/share/themes"
-    "/usr/local/share/themes"
-    "$HOME/.themes"
-    "$HOME/.local/share/themes"
-  )
+	# Find theme directories
+	local theme_dirs=(
+		"/usr/share/themes"
+		"/usr/local/share/themes"
+		"$HOME/.themes"
+		"$HOME/.local/share/themes"
+	)
 
-  local found_path=""
-  for theme_dir in "${theme_dirs[@]}"; do
-    if [[ -d "$theme_dir/$theme_name" ]]; then
-      found_path="$theme_dir/$theme_name"
-      break
-    fi
-  done
+	local found_path=""
+	for theme_dir in "${theme_dirs[@]}"; do
+		if [[ -d "$theme_dir/$theme_name" ]]; then
+			found_path="$theme_dir/$theme_name"
+			break
+		fi
+	done
 
-  if [[ -z $found_path ]]; then
-    echo -e "${RED}❌ Theme not found: $theme_name${NC}"
-    return 1
-  fi
+	if [[ -z $found_path ]]; then
+		echo -e "${RED}❌ Theme not found: $theme_name${NC}"
+		return 1
+	fi
 
-  echo -e "${GREEN}📁 Location:${NC} $found_path"
+	echo -e "${GREEN}📁 Location:${NC} $found_path"
 
-  # Check what components are available
-  echo -e "${GREEN}🧩 Available Components:${NC}"
-  if [[ -d "$found_path/gtk-2.0" ]]; then
-    echo -e "  ✅ GTK2"
-  else
-    echo -e "  ❌ GTK2"
-  fi
+	# Check what components are available
+	echo -e "${GREEN}🧩 Available Components:${NC}"
+	if [[ -d "$found_path/gtk-2.0" ]]; then
+		echo -e "  ✅ GTK2"
+	else
+		echo -e "  ❌ GTK2"
+	fi
 
-  if [[ -d "$found_path/gtk-3.0" ]]; then
-    echo -e "  ✅ GTK3"
-  else
-    echo -e "  ❌ GTK3"
-  fi
+	if [[ -d "$found_path/gtk-3.0" ]]; then
+		echo -e "  ✅ GTK3"
+	else
+		echo -e "  ❌ GTK3"
+	fi
 
-  if [[ -d "$found_path/gtk-4.0" ]]; then
-    echo -e "  ✅ GTK4"
-  else
-    echo -e "  ❌ GTK4"
-  fi
+	if [[ -d "$found_path/gtk-4.0" ]]; then
+		echo -e "  ✅ GTK4"
+	else
+		echo -e "  ❌ GTK4"
+	fi
 
-  # Show index.theme if available
-  if [[ -f "$found_path/index.theme" ]]; then
-    echo ""
-    echo -e "${GREEN}📋 Theme Metadata:${NC}"
-    while IFS= read -r line; do
-      if [[ $line =~ ^Name= ]]; then
-        echo -e "  ${BLUE}Name:${NC} ${line#Name=}"
-      elif [[ $line =~ ^Comment= ]]; then
-        echo -e "  ${BLUE}Description:${NC} ${line#Comment=}"
-      fi
-    done <"$found_path/index.theme"
-  fi
+	# Show index.theme if available
+	if [[ -f "$found_path/index.theme" ]]; then
+		echo ""
+		echo -e "${GREEN}📋 Theme Metadata:${NC}"
+		while IFS= read -r line; do
+			if [[ $line =~ ^Name= ]]; then
+				echo -e "  ${BLUE}Name:${NC} ${line#Name=}"
+			elif [[ $line =~ ^Comment= ]]; then
+				echo -e "  ${BLUE}Description:${NC} ${line#Comment=}"
+			fi
+		done <"$found_path/index.theme"
+	fi
 }
 
 # Main script logic
 main() {
-  log "DEBUG" "Starting GTK theme manager with args: ${arguments[*]}"
+	log "DEBUG" "Starting GTK theme manager with args: ${arguments[*]}"
 
-  if [[ ${#arguments[@]} -eq 0 ]]; then
-    log "ERROR" "No command specified. Use --help for usage information."
-    exit 1
-  fi
+	if [[ ${#arguments[@]} -eq 0 ]]; then
+		log "ERROR" "No command specified. Use --help for usage information."
+		exit 1
+	fi
 
-  local command="${arguments[0]}"
-  local cmd_args=("${arguments[@]:1}")
+	local command="${arguments[0]}"
+	local cmd_args=("${arguments[@]:1}")
 
-  log "DEBUG" "Command: $command, args: ${cmd_args[*]}"
+	log "DEBUG" "Command: $command, args: ${cmd_args[*]}"
 
-  case "$command" in
-    "list" | "ls")
-      cmd_list "${cmd_args[@]}"
-      ;;
-    "current" | "status")
-      cmd_current "${cmd_args[@]}"
-      ;;
-    "apply" | "set")
-      if [[ ${#cmd_args[@]} -eq 0 ]]; then
-        log "ERROR" "Theme name required for apply command"
-        log "" "Usage: $(basename "$0") apply <theme-name> [icon-theme] [prefer-dark]"
-        exit 1
-      fi
-      cmd_apply "${cmd_args[@]}"
-      ;;
-    "set-icons" | "set-icon")
-      if [[ ${#cmd_args[@]} -eq 0 ]]; then
-        log "ERROR" "Icon theme name required"
-        log "" "Usage: $(basename "$0") set-icons <icon-theme>"
-        exit 1
-      fi
-      cmd_set_icons "${cmd_args[0]}"
-      ;;
-    "color-scheme" | "scheme")
-      if [[ ${#cmd_args[@]} -eq 0 ]]; then
-        log "ERROR" "Mode required (light|dark)"
-        log "" "Usage: $(basename "$0") color-scheme <light|dark>"
-        exit 1
-      fi
-      cmd_color_scheme "${cmd_args[0]}"
-      ;;
-    "detect" | "analyze")
-      cmd_detect "${cmd_args[@]}"
-      ;;
-    "theme" | "t")
-      cmd_theme_pack "${cmd_args[@]}"
-      ;;
-    "auto" | "automatic")
-      cmd_auto
-      ;;
-    "icons" | "icon")
-      cmd_icons "${cmd_args[@]}"
-      ;;
-    "info" | "show")
-      if [[ ${#cmd_args[@]} -eq 0 ]]; then
-        log "ERROR" "Theme name required for info command"
-        log "" "Usage: $(basename "$0") info <theme-name>"
-        exit 1
-      fi
-      cmd_info "${cmd_args[0]}"
-      ;;
-    *)
-      log "ERROR" "Unknown command '$command'"
-      log "" "Use --help for available commands"
-      exit 1
-      ;;
-  esac
+	case "$command" in
+	"list" | "ls")
+		cmd_list "${cmd_args[@]}"
+		;;
+	"current" | "status")
+		cmd_current "${cmd_args[@]}"
+		;;
+	"apply" | "set")
+		if [[ ${#cmd_args[@]} -eq 0 ]]; then
+			log "ERROR" "Theme name required for apply command"
+			log "" "Usage: $(basename "$0") apply <theme-name> [icon-theme] [prefer-dark]"
+			exit 1
+		fi
+		cmd_apply "${cmd_args[@]}"
+		;;
+	"set-icons" | "set-icon")
+		if [[ ${#cmd_args[@]} -eq 0 ]]; then
+			log "ERROR" "Icon theme name required"
+			log "" "Usage: $(basename "$0") set-icons <icon-theme>"
+			exit 1
+		fi
+		cmd_set_icons "${cmd_args[0]}"
+		;;
+	"color-scheme" | "scheme")
+		if [[ ${#cmd_args[@]} -eq 0 ]]; then
+			log "ERROR" "Mode required (light|dark)"
+			log "" "Usage: $(basename "$0") color-scheme <light|dark>"
+			exit 1
+		fi
+		cmd_color_scheme "${cmd_args[0]}"
+		;;
+	"detect" | "analyze")
+		cmd_detect "${cmd_args[@]}"
+		;;
+	"theme" | "t")
+		cmd_theme_pack "${cmd_args[@]}"
+		;;
+	"auto" | "automatic")
+		cmd_auto
+		;;
+	"icons" | "icon")
+		cmd_icons "${cmd_args[@]}"
+		;;
+	"info" | "show")
+		if [[ ${#cmd_args[@]} -eq 0 ]]; then
+			log "ERROR" "Theme name required for info command"
+			log "" "Usage: $(basename "$0") info <theme-name>"
+			exit 1
+		fi
+		cmd_info "${cmd_args[0]}"
+		;;
+	*)
+		log "ERROR" "Unknown command '$command'"
+		log "" "Use --help for available commands"
+		exit 1
+		;;
+	esac
 }
 
 # Run main function

--- a/home/dot_local/bin/executable_dots-gtk-theme
+++ b/home/dot_local/bin/executable_dots-gtk-theme
@@ -52,23 +52,23 @@ source ~/.local/lib/dots/easy-options/easyoptions.sh || exit
 
 # Source the GTK theme manager - try multiple locations
 gtk_theme_manager_paths=(
-  "$HOME/.local/lib/dots/gtk-theme-manager.sh"
-  "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../lib/dots/gtk-theme-manager.sh"
+	"$HOME/.local/lib/dots/gtk-theme-manager.sh"
+	"$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../lib/dots/gtk-theme-manager.sh"
 )
 
 gtk_theme_manager_found=false
 for path in "${gtk_theme_manager_paths[@]}"; do
-  if [[ -f $path ]]; then
-    source "$path"
-    gtk_theme_manager_found=true
-    break
-  fi
+	if [[ -f $path ]]; then
+		source "$path"
+		gtk_theme_manager_found=true
+		break
+	fi
 done
 
 if [[ $gtk_theme_manager_found != "true" ]]; then
-  echo "Error: GTK theme manager not found in any of these locations:" >&2
-  printf '  %s\n' "${gtk_theme_manager_paths[@]}" >&2
-  exit 1
+	echo "Error: GTK theme manager not found in any of these locations:" >&2
+	printf '  %s\n' "${gtk_theme_manager_paths[@]}" >&2
+	exit 1
 fi
 
 # Color definitions for output
@@ -82,443 +82,443 @@ readonly NC='\033[0m' # No Color
 
 # Function to log messages with verbosity control
 log() {
-  local level="$1"
-  shift
-  local message="$*"
+	local level="$1"
+	shift
+	local message="$*"
 
-  if [[ ${quiet:-} == "yes" ]] && [[ $level != "ERROR" ]]; then
-    return 0
-  fi
+	if [[ ${quiet:-} == "yes" ]] && [[ $level != "ERROR" ]]; then
+		return 0
+	fi
 
-  local timestamp
-  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+	local timestamp
+	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-  case "$level" in
-    "ERROR")
-      echo -e "${RED}❌ [ERROR] $message${NC}" >&2
-      ;;
-    "WARN")
-      echo -e "${YELLOW}⚠️  [WARN] $message${NC}" >&2
-      ;;
-    "INFO")
-      if [[ ${verbose:-} == "yes" ]]; then
-        echo -e "${BLUE}ℹ️  [INFO] $message${NC}"
-      fi
-      ;;
-    "DEBUG")
-      if [[ ${debug:-} == "yes" ]]; then
-        echo -e "${PURPLE}🐛 [DEBUG] [$timestamp] $message${NC}" >&2
-      fi
-      ;;
-    *)
-      echo -e "$message"
-      ;;
-  esac
+	case "$level" in
+	"ERROR")
+		echo -e "${RED}❌ [ERROR] $message${NC}" >&2
+		;;
+	"WARN")
+		echo -e "${YELLOW}⚠️  [WARN] $message${NC}" >&2
+		;;
+	"INFO")
+		if [[ ${verbose:-} == "yes" ]]; then
+			echo -e "${BLUE}ℹ️  [INFO] $message${NC}"
+		fi
+		;;
+	"DEBUG")
+		if [[ ${debug:-} == "yes" ]]; then
+			echo -e "${PURPLE}🐛 [DEBUG] [$timestamp] $message${NC}" >&2
+		fi
+		;;
+	*)
+		echo -e "$message"
+		;;
+	esac
 }
 
 # Function to list installed GTK themes
 cmd_list() {
-  local use_plain=false
-  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+	local use_plain=false
+	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-  local themes
-  themes=$(list_installed_gtk_themes)
+	local themes
+	themes=$(list_installed_gtk_themes)
 
-  if [[ -z $themes ]]; then
-    [[ $use_plain == true ]] || log "WARN" "No GTK themes found"
-    return 1
-  fi
+	if [[ -z $themes ]]; then
+		[[ $use_plain == true ]] || log "WARN" "No GTK themes found"
+		return 1
+	fi
 
-  if [[ $use_plain == true ]]; then
-    printf '%s\n' "$themes"
-    return 0
-  fi
+	if [[ $use_plain == true ]]; then
+		printf '%s\n' "$themes"
+		return 0
+	fi
 
-  log "" "${BLUE}📋 Installed GTK themes:${NC}"
-  log "" ""
+	log "" "${BLUE}📋 Installed GTK themes:${NC}"
+	log "" ""
 
-  local current_theme
-  current_theme=$(get_current_gtk_theme)
-  log "DEBUG" "Current theme: $current_theme"
+	local current_theme
+	current_theme=$(get_current_gtk_theme)
+	log "DEBUG" "Current theme: $current_theme"
 
-  while IFS= read -r theme; do
-    if [[ $theme == "$current_theme" ]]; then
-      log "" "  ${GREEN}✓${NC} $theme ${CYAN}(current)${NC}"
-    else
-      log "" "    $theme"
-    fi
-  done <<<"$themes"
+	while IFS= read -r theme; do
+		if [[ $theme == "$current_theme" ]]; then
+			log "" "  ${GREEN}✓${NC} $theme ${CYAN}(current)${NC}"
+		else
+			log "" "    $theme"
+		fi
+	done <<<"$themes"
 
-  log "" ""
-  log "" "${CYAN}💡 Tip:${NC} Use 'dots gtk-theme apply <theme>' to apply a theme"
+	log "" ""
+	log "" "${CYAN}💡 Tip:${NC} Use 'dots gtk-theme apply <theme>' to apply a theme"
 }
 
 # Function to show current theme
 cmd_current() {
-  local use_plain=false
-  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+	local use_plain=false
+	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-  local current_theme
-  current_theme=$(get_current_gtk_theme)
+	local current_theme
+	current_theme=$(get_current_gtk_theme)
 
-  if [[ $use_plain == true ]]; then
-    printf '%s\n' "$current_theme"
-    return 0
-  fi
+	if [[ $use_plain == true ]]; then
+		printf '%s\n' "$current_theme"
+		return 0
+	fi
 
-  log "" "${BLUE}🎨 Current GTK Theme:${NC} $current_theme"
+	log "" "${BLUE}🎨 Current GTK Theme:${NC} $current_theme"
 
-  # Show additional info
-  if [[ -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
-    local icon_theme
-    icon_theme=$(grep "^gtk-icon-theme-name=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
-    log "" "${BLUE}🎯 Icon Theme:${NC} $icon_theme"
+	# Show additional info
+	if [[ -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
+		local icon_theme
+		icon_theme=$(grep "^gtk-icon-theme-name=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
+		log "" "${BLUE}🎯 Icon Theme:${NC} $icon_theme"
 
-    local dark_pref
-    dark_pref=$(grep "^gtk-application-prefer-dark-theme=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
-    log "" "${BLUE}🌙 Dark Theme Preference:${NC} $dark_pref"
-  fi
+		local dark_pref
+		dark_pref=$(grep "^gtk-application-prefer-dark-theme=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
+		log "" "${BLUE}🌙 Dark Theme Preference:${NC} $dark_pref"
+	fi
 }
 
 # Function to show current icon theme
 cmd_current_icon() {
-  local use_plain=false
-  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+	local use_plain=false
+	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-  local current_icon
-  current_icon="$(get_current_icon_theme 2>/dev/null || true)"
-  [[ -n $current_icon ]] || current_icon="Unknown"
+	local current_icon
+	current_icon="$(get_current_icon_theme 2>/dev/null || true)"
+	[[ -n $current_icon ]] || current_icon="Unknown"
 
-  if [[ $use_plain == true ]]; then
-    printf '%s\n' "$current_icon"
-    return 0
-  fi
+	if [[ $use_plain == true ]]; then
+		printf '%s\n' "$current_icon"
+		return 0
+	fi
 
-  log "" "${BLUE}🎯 Current Icon Theme:${NC} $current_icon"
+	log "" "${BLUE}🎯 Current Icon Theme:${NC} $current_icon"
 }
 
 # Function to apply specific theme
 cmd_apply() {
-  local theme_name="$1"
-  local icon_theme="${2:-}"
-  local prefer_dark="${3:-}"
+	local theme_name="$1"
+	local icon_theme="${2:-}"
+	local prefer_dark="${3:-}"
 
-  if [[ -z $icon_theme ]]; then
-    icon_theme="$(get_current_icon_theme 2>/dev/null || true)"
-    [[ -n $icon_theme ]] || icon_theme="Numix-Circle"
-  fi
-  if [[ -z $prefer_dark ]]; then
-    # Derive from live scheme state when callers omit prefer-dark.
-    local mode="dark"
-    local state_json="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
-    if [[ -f $state_json ]]; then
-      mode="$(python3 -c "import json;print(json.load(open('$state_json')).get('mode','dark'))" 2>/dev/null || echo dark)"
-    fi
-    prefer_dark=$([[ $mode == "light" ]] && echo false || echo true)
-  fi
+	if [[ -z $icon_theme ]]; then
+		icon_theme="$(get_current_icon_theme 2>/dev/null || true)"
+		[[ -n $icon_theme ]] || icon_theme="Numix-Circle"
+	fi
+	if [[ -z $prefer_dark ]]; then
+		# Derive from live scheme state when callers omit prefer-dark.
+		local mode="dark"
+		local state_json="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
+		if [[ -f $state_json ]]; then
+			mode="$(python3 -c "import json;print(json.load(open('$state_json')).get('mode','dark'))" 2>/dev/null || echo dark)"
+		fi
+		prefer_dark=$([[ $mode == "light" ]] && echo false || echo true)
+	fi
 
-  log "" "${BLUE}🎨 Applying GTK Theme:${NC} $theme_name"
-  log "DEBUG" "Icon theme: $icon_theme, prefer dark: $prefer_dark"
+	log "" "${BLUE}🎨 Applying GTK Theme:${NC} $theme_name"
+	log "DEBUG" "Icon theme: $icon_theme, prefer dark: $prefer_dark"
 
-  if apply_gtk_theme "$theme_name" "$icon_theme" "$prefer_dark"; then
-    log "" "${GREEN}✅ Theme applied successfully${NC}"
-  else
-    log "ERROR" "Failed to apply theme"
-    return 1
-  fi
+	if apply_gtk_theme "$theme_name" "$icon_theme" "$prefer_dark"; then
+		log "" "${GREEN}✅ Theme applied successfully${NC}"
+	else
+		log "ERROR" "Failed to apply theme"
+		return 1
+	fi
 }
 
 # Update icon theme while preserving the current GTK theme + prefer-dark.
 cmd_set_icons() {
-  local icon_theme="${1:-}"
-  [[ -n $icon_theme ]] || {
-    log "ERROR" "Icon theme name required"
-    log "" "Usage: $(basename "$0") set-icons <icon-theme>"
-    return 1
-  }
+	local icon_theme="${1:-}"
+	[[ -n $icon_theme ]] || {
+		log "ERROR" "Icon theme name required"
+		log "" "Usage: $(basename "$0") set-icons <icon-theme>"
+		return 1
+	}
 
-  local gtk_theme prefer_dark
-  gtk_theme="$(get_current_gtk_theme)"
-  prefer_dark="false"
-  if [[ -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
-    prefer_dark="$(grep "^gtk-application-prefer-dark-theme=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2 || echo false)"
-  fi
-  [[ $prefer_dark == "1" || $prefer_dark == "true" ]] && prefer_dark="true" || prefer_dark="false"
+	local gtk_theme prefer_dark
+	gtk_theme="$(get_current_gtk_theme)"
+	prefer_dark="false"
+	if [[ -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
+		prefer_dark="$(grep "^gtk-application-prefer-dark-theme=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2 || echo false)"
+	fi
+	[[ $prefer_dark == "1" || $prefer_dark == "true" ]] && prefer_dark="true" || prefer_dark="false"
 
-  log "" "${BLUE}🎯 Applying icon theme:${NC} $icon_theme (gtk=$gtk_theme)"
-  if apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"; then
-    log "" "${GREEN}✅ Icon theme applied successfully${NC}"
-  else
-    log "ERROR" "Failed to apply icon theme"
-    return 1
-  fi
+	log "" "${BLUE}🎯 Applying icon theme:${NC} $icon_theme (gtk=$gtk_theme)"
+	if apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"; then
+		log "" "${GREEN}✅ Icon theme applied successfully${NC}"
+	else
+		log "ERROR" "Failed to apply icon theme"
+		return 1
+	fi
 }
 
 # Sync GTK color-scheme / prefer-dark with live light|dark mode.
 cmd_color_scheme() {
-  local mode="${1:-}"
-  [[ $mode == "light" || $mode == "dark" ]] || {
-    log "ERROR" "Mode must be light or dark"
-    log "" "Usage: $(basename "$0") color-scheme <light|dark>"
-    return 1
-  }
-  if apply_gtk_color_scheme "$mode"; then
-    log "" "${GREEN}✅ GTK color-scheme synced:${NC} $mode"
-  else
-    log "ERROR" "Failed to sync GTK color-scheme"
-    return 1
-  fi
+	local mode="${1:-}"
+	[[ $mode == "light" || $mode == "dark" ]] || {
+		log "ERROR" "Mode must be light or dark"
+		log "" "Usage: $(basename "$0") color-scheme <light|dark>"
+		return 1
+	}
+	if apply_gtk_color_scheme "$mode"; then
+		log "" "${GREEN}✅ GTK color-scheme synced:${NC} $mode"
+	else
+		log "ERROR" "Failed to sync GTK color-scheme"
+		return 1
+	fi
 }
 
 # Function to detect optimal theme
 cmd_detect() {
-  local wallpaper_path="${1:-}"
+	local wallpaper_path="${1:-}"
 
-  if [[ -z $wallpaper_path ]]; then
-    if [[ -f $HOME/.local/lib/dots/wallpaper-resolver.sh ]]; then
-      # shellcheck source=/dev/null
-      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-      wallpaper_path="$(dots_current_wallpaper 2>/dev/null || true)"
-    fi
-    if [[ -z ${wallpaper_path:-} ]]; then
-      echo -e "${RED}❌ No wallpaper specified and no current wallpaper found${NC}"
-      return 1
-    fi
-  fi
+	if [[ -z $wallpaper_path ]]; then
+		if [[ -f $HOME/.local/lib/dots/wallpaper-resolver.sh ]]; then
+			# shellcheck source=/dev/null
+			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+			wallpaper_path="$(dots_current_wallpaper 2>/dev/null || true)"
+		fi
+		if [[ -z ${wallpaper_path:-} ]]; then
+			echo -e "${RED}❌ No wallpaper specified and no current wallpaper found${NC}"
+			return 1
+		fi
+	fi
 
-  if [[ ! -f $wallpaper_path ]]; then
-    echo -e "${RED}❌ Wallpaper file not found: $wallpaper_path${NC}"
-    return 1
-  fi
+	if [[ ! -f $wallpaper_path ]]; then
+		echo -e "${RED}❌ Wallpaper file not found: $wallpaper_path${NC}"
+		return 1
+	fi
 
-  echo -e "${BLUE}🔍 Analyzing wallpaper:${NC} $(basename "$wallpaper_path")"
+	echo -e "${BLUE}🔍 Analyzing wallpaper:${NC} $(basename "$wallpaper_path")"
 
-  local theme_info
-  theme_info=$(detect_optimal_gtk_theme "$wallpaper_path")
-  local detected_theme="${theme_info%:*}"
-  local prefer_dark="${theme_info#*:}"
+	local theme_info
+	theme_info=$(detect_optimal_gtk_theme "$wallpaper_path")
+	local detected_theme="${theme_info%:*}"
+	local prefer_dark="${theme_info#*:}"
 
-  echo -e "${GREEN}🎯 Detected optimal theme:${NC} $detected_theme"
-  echo -e "${GREEN}🌙 Dark preference:${NC} $prefer_dark"
+	echo -e "${GREEN}🎯 Detected optimal theme:${NC} $detected_theme"
+	echo -e "${GREEN}🌙 Dark preference:${NC} $prefer_dark"
 
-  # Ask if user wants to apply
-  read -p "Apply this theme? (y/N): " -n 1 -r
-  echo
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
-    cmd_apply "$detected_theme" "Numix-Circle" "$prefer_dark"
-  fi
+	# Ask if user wants to apply
+	read -p "Apply this theme? (y/N): " -n 1 -r
+	echo
+	if [[ $REPLY =~ ^[Yy]$ ]]; then
+		cmd_apply "$detected_theme" "Numix-Circle" "$prefer_dark"
+	fi
 }
 
 # Function to apply theme-pack GTK settings
 cmd_theme_pack() {
-  local theme_id="${1:-}"
+	local theme_id="${1:-}"
 
-  echo -e "${BLUE}🎨 Applying GTK theme from theme pack:${NC} ${theme_id:-auto-detect}"
+	echo -e "${BLUE}🎨 Applying GTK theme from theme pack:${NC} ${theme_id:-auto-detect}"
 
-  if apply_theme_gtk_theme "$theme_id"; then
-    echo -e "${GREEN}✅ Theme pack GTK theme applied successfully${NC}"
-  else
-    echo -e "${RED}❌ Failed to apply theme pack GTK theme${NC}"
-    return 1
-  fi
+	if apply_theme_gtk_theme "$theme_id"; then
+		echo -e "${GREEN}✅ Theme pack GTK theme applied successfully${NC}"
+	else
+		echo -e "${RED}❌ Failed to apply theme pack GTK theme${NC}"
+		return 1
+	fi
 }
 
 # Function to auto-detect and apply
 cmd_auto() {
-  echo -e "${BLUE}🤖 Auto-detecting optimal GTK theme...${NC}"
-  cmd_theme_pack ""
+	echo -e "${BLUE}🤖 Auto-detecting optimal GTK theme...${NC}"
+	cmd_theme_pack ""
 }
 
 # Function to list icon themes
 cmd_icons() {
-  local use_plain=false
-  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+	local use_plain=false
+	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-  local icon_dirs=(
-    "/usr/share/icons"
-    "/usr/local/share/icons"
-    "$HOME/.icons"
-    "${XDG_DATA_HOME:-$HOME/.local/share}/icons"
-  )
+	local icon_dirs=(
+		"/usr/share/icons"
+		"/usr/local/share/icons"
+		"$HOME/.icons"
+		"${XDG_DATA_HOME:-$HOME/.local/share}/icons"
+	)
 
-  local icons=()
-  for icon_dir in "${icon_dirs[@]}"; do
-    if [[ -d $icon_dir ]]; then
-      while IFS= read -r -d '' icon_path; do
-        local icon_name
-        icon_name=$(basename "$icon_path")
-        case "$icon_name" in
-          default | hicolor) continue ;;
-        esac
-        if [[ -f "$icon_path/index.theme" ]]; then
-          icons+=("$icon_name")
-        fi
-      done < <(find "$icon_dir" -maxdepth 1 -mindepth 1 -type d -print0 2>/dev/null)
-    fi
-  done
+	local icons=()
+	for icon_dir in "${icon_dirs[@]}"; do
+		if [[ -d $icon_dir ]]; then
+			while IFS= read -r -d '' icon_path; do
+				local icon_name
+				icon_name=$(basename "$icon_path")
+				case "$icon_name" in
+				default | hicolor) continue ;;
+				esac
+				if [[ -f "$icon_path/index.theme" ]]; then
+					icons+=("$icon_name")
+				fi
+			done < <(find "$icon_dir" -maxdepth 1 -mindepth 1 -type d -print0 2>/dev/null)
+		fi
+	done
 
-  local unique_icons
-  unique_icons=$(printf '%s\n' "${icons[@]}" | sort -u)
+	local unique_icons
+	unique_icons=$(printf '%s\n' "${icons[@]}" | sort -u)
 
-  if [[ $use_plain == true ]]; then
-    printf '%s\n' "$unique_icons"
-    return 0
-  fi
+	if [[ $use_plain == true ]]; then
+		printf '%s\n' "$unique_icons"
+		return 0
+	fi
 
-  echo -e "${BLUE}🎯 Installed Icon Themes:${NC}"
-  echo ""
+	echo -e "${BLUE}🎯 Installed Icon Themes:${NC}"
+	echo ""
 
-  local current_icon=""
-  current_icon="$(get_current_icon_theme 2>/dev/null || true)"
+	local current_icon=""
+	current_icon="$(get_current_icon_theme 2>/dev/null || true)"
 
-  while IFS= read -r icon; do
-    [[ -z $icon ]] && continue
-    if [[ $icon == "$current_icon" ]]; then
-      echo -e "  ${GREEN}✓${NC} $icon ${CYAN}(current)${NC}"
-    else
-      echo -e "    $icon"
-    fi
-  done <<<"$unique_icons"
+	while IFS= read -r icon; do
+		[[ -z $icon ]] && continue
+		if [[ $icon == "$current_icon" ]]; then
+			echo -e "  ${GREEN}✓${NC} $icon ${CYAN}(current)${NC}"
+		else
+			echo -e "    $icon"
+		fi
+	done <<<"$unique_icons"
 }
 
 # Function to show theme information
 cmd_info() {
-  local theme_name="$1"
+	local theme_name="$1"
 
-  echo -e "${BLUE}ℹ️  Theme Information: $theme_name${NC}"
-  echo ""
+	echo -e "${BLUE}ℹ️  Theme Information: $theme_name${NC}"
+	echo ""
 
-  # Find theme directories
-  local theme_dirs=(
-    "/usr/share/themes"
-    "/usr/local/share/themes"
-    "$HOME/.themes"
-    "$HOME/.local/share/themes"
-  )
+	# Find theme directories
+	local theme_dirs=(
+		"/usr/share/themes"
+		"/usr/local/share/themes"
+		"$HOME/.themes"
+		"$HOME/.local/share/themes"
+	)
 
-  local found_path=""
-  for theme_dir in "${theme_dirs[@]}"; do
-    if [[ -d "$theme_dir/$theme_name" ]]; then
-      found_path="$theme_dir/$theme_name"
-      break
-    fi
-  done
+	local found_path=""
+	for theme_dir in "${theme_dirs[@]}"; do
+		if [[ -d "$theme_dir/$theme_name" ]]; then
+			found_path="$theme_dir/$theme_name"
+			break
+		fi
+	done
 
-  if [[ -z $found_path ]]; then
-    echo -e "${RED}❌ Theme not found: $theme_name${NC}"
-    return 1
-  fi
+	if [[ -z $found_path ]]; then
+		echo -e "${RED}❌ Theme not found: $theme_name${NC}"
+		return 1
+	fi
 
-  echo -e "${GREEN}📁 Location:${NC} $found_path"
+	echo -e "${GREEN}📁 Location:${NC} $found_path"
 
-  # Check what components are available
-  echo -e "${GREEN}🧩 Available Components:${NC}"
-  if [[ -d "$found_path/gtk-2.0" ]]; then
-    echo -e "  ✅ GTK2"
-  else
-    echo -e "  ❌ GTK2"
-  fi
+	# Check what components are available
+	echo -e "${GREEN}🧩 Available Components:${NC}"
+	if [[ -d "$found_path/gtk-2.0" ]]; then
+		echo -e "  ✅ GTK2"
+	else
+		echo -e "  ❌ GTK2"
+	fi
 
-  if [[ -d "$found_path/gtk-3.0" ]]; then
-    echo -e "  ✅ GTK3"
-  else
-    echo -e "  ❌ GTK3"
-  fi
+	if [[ -d "$found_path/gtk-3.0" ]]; then
+		echo -e "  ✅ GTK3"
+	else
+		echo -e "  ❌ GTK3"
+	fi
 
-  if [[ -d "$found_path/gtk-4.0" ]]; then
-    echo -e "  ✅ GTK4"
-  else
-    echo -e "  ❌ GTK4"
-  fi
+	if [[ -d "$found_path/gtk-4.0" ]]; then
+		echo -e "  ✅ GTK4"
+	else
+		echo -e "  ❌ GTK4"
+	fi
 
-  # Show index.theme if available
-  if [[ -f "$found_path/index.theme" ]]; then
-    echo ""
-    echo -e "${GREEN}📋 Theme Metadata:${NC}"
-    while IFS= read -r line; do
-      if [[ $line =~ ^Name= ]]; then
-        echo -e "  ${BLUE}Name:${NC} ${line#Name=}"
-      elif [[ $line =~ ^Comment= ]]; then
-        echo -e "  ${BLUE}Description:${NC} ${line#Comment=}"
-      fi
-    done <"$found_path/index.theme"
-  fi
+	# Show index.theme if available
+	if [[ -f "$found_path/index.theme" ]]; then
+		echo ""
+		echo -e "${GREEN}📋 Theme Metadata:${NC}"
+		while IFS= read -r line; do
+			if [[ $line =~ ^Name= ]]; then
+				echo -e "  ${BLUE}Name:${NC} ${line#Name=}"
+			elif [[ $line =~ ^Comment= ]]; then
+				echo -e "  ${BLUE}Description:${NC} ${line#Comment=}"
+			fi
+		done <"$found_path/index.theme"
+	fi
 }
 
 # Main script logic
 main() {
-  log "DEBUG" "Starting GTK theme manager with args: ${arguments[*]}"
+	log "DEBUG" "Starting GTK theme manager with args: ${arguments[*]}"
 
-  if [[ ${#arguments[@]} -eq 0 ]]; then
-    log "ERROR" "No command specified. Use --help for usage information."
-    exit 1
-  fi
+	if [[ ${#arguments[@]} -eq 0 ]]; then
+		log "ERROR" "No command specified. Use --help for usage information."
+		exit 1
+	fi
 
-  local command="${arguments[0]}"
-  local cmd_args=("${arguments[@]:1}")
+	local command="${arguments[0]}"
+	local cmd_args=("${arguments[@]:1}")
 
-  log "DEBUG" "Command: $command, args: ${cmd_args[*]}"
+	log "DEBUG" "Command: $command, args: ${cmd_args[*]}"
 
-  case "$command" in
-    "list" | "ls")
-      cmd_list "${cmd_args[@]}"
-      ;;
-    "current" | "status")
-      cmd_current "${cmd_args[@]}"
-      ;;
-    "current-icon" | "current-icons" | "icon-current")
-      cmd_current_icon "${cmd_args[@]}"
-      ;;
-    "apply" | "set")
-      if [[ ${#cmd_args[@]} -eq 0 ]]; then
-        log "ERROR" "Theme name required for apply command"
-        log "" "Usage: $(basename "$0") apply <theme-name> [icon-theme] [prefer-dark]"
-        exit 1
-      fi
-      cmd_apply "${cmd_args[@]}"
-      ;;
-    "set-icons" | "set-icon")
-      if [[ ${#cmd_args[@]} -eq 0 ]]; then
-        log "ERROR" "Icon theme name required"
-        log "" "Usage: $(basename "$0") set-icons <icon-theme>"
-        exit 1
-      fi
-      cmd_set_icons "${cmd_args[0]}"
-      ;;
-    "color-scheme" | "scheme")
-      if [[ ${#cmd_args[@]} -eq 0 ]]; then
-        log "ERROR" "Mode required (light|dark)"
-        log "" "Usage: $(basename "$0") color-scheme <light|dark>"
-        exit 1
-      fi
-      cmd_color_scheme "${cmd_args[0]}"
-      ;;
-    "detect" | "analyze")
-      cmd_detect "${cmd_args[@]}"
-      ;;
-    "theme" | "t")
-      cmd_theme_pack "${cmd_args[@]}"
-      ;;
-    "auto" | "automatic")
-      cmd_auto
-      ;;
-    "icons" | "icon")
-      cmd_icons "${cmd_args[@]}"
-      ;;
-    "info" | "show")
-      if [[ ${#cmd_args[@]} -eq 0 ]]; then
-        log "ERROR" "Theme name required for info command"
-        log "" "Usage: $(basename "$0") info <theme-name>"
-        exit 1
-      fi
-      cmd_info "${cmd_args[0]}"
-      ;;
-    *)
-      log "ERROR" "Unknown command '$command'"
-      log "" "Use --help for available commands"
-      exit 1
-      ;;
-  esac
+	case "$command" in
+	"list" | "ls")
+		cmd_list "${cmd_args[@]}"
+		;;
+	"current" | "status")
+		cmd_current "${cmd_args[@]}"
+		;;
+	"current-icon" | "current-icons" | "icon-current")
+		cmd_current_icon "${cmd_args[@]}"
+		;;
+	"apply" | "set")
+		if [[ ${#cmd_args[@]} -eq 0 ]]; then
+			log "ERROR" "Theme name required for apply command"
+			log "" "Usage: $(basename "$0") apply <theme-name> [icon-theme] [prefer-dark]"
+			exit 1
+		fi
+		cmd_apply "${cmd_args[@]}"
+		;;
+	"set-icons" | "set-icon")
+		if [[ ${#cmd_args[@]} -eq 0 ]]; then
+			log "ERROR" "Icon theme name required"
+			log "" "Usage: $(basename "$0") set-icons <icon-theme>"
+			exit 1
+		fi
+		cmd_set_icons "${cmd_args[0]}"
+		;;
+	"color-scheme" | "scheme")
+		if [[ ${#cmd_args[@]} -eq 0 ]]; then
+			log "ERROR" "Mode required (light|dark)"
+			log "" "Usage: $(basename "$0") color-scheme <light|dark>"
+			exit 1
+		fi
+		cmd_color_scheme "${cmd_args[0]}"
+		;;
+	"detect" | "analyze")
+		cmd_detect "${cmd_args[@]}"
+		;;
+	"theme" | "t")
+		cmd_theme_pack "${cmd_args[@]}"
+		;;
+	"auto" | "automatic")
+		cmd_auto
+		;;
+	"icons" | "icon")
+		cmd_icons "${cmd_args[@]}"
+		;;
+	"info" | "show")
+		if [[ ${#cmd_args[@]} -eq 0 ]]; then
+			log "ERROR" "Theme name required for info command"
+			log "" "Usage: $(basename "$0") info <theme-name>"
+			exit 1
+		fi
+		cmd_info "${cmd_args[0]}"
+		;;
+	*)
+		log "ERROR" "Unknown command '$command'"
+		log "" "Use --help for available commands"
+		exit 1
+		;;
+	esac
 }
 
 # Run main function

--- a/home/dot_local/bin/executable_dots-gtk-theme
+++ b/home/dot_local/bin/executable_dots-gtk-theme
@@ -18,50 +18,54 @@
 ##     -v, --verbose   Enable verbose output.
 ##     -d, --debug     Enable debug mode.
 ##     -q, --quiet     Suppress output.
+##     -p, --plain     Machine-readable output (one name per line).
 ##
 ## Commands:
-##     list                    List all installed GTK themes
+##     list                    List installed GTK themes
 ##     current                 Show current GTK theme
-##     apply <theme>           Apply specific GTK theme
+##     apply <theme> [icon] [prefer-dark]
+##                             Apply GTK theme (prefer-dark: true|false)
+##     set-icons <icon>        Update icon theme (keeps current GTK theme)
+##     color-scheme <mode>     Sync gtk prefer-dark / color-scheme (light|dark)
 ##     detect [wallpaper]      Detect optimal theme for wallpaper
 ##     theme [theme-id]        Apply GTK theme from appearance theme pack
 ##     auto                    Auto-detect and apply optimal theme
 ##     icons                   List installed icon themes
 ##     info <theme>            Show information about a theme
-
-set -euo pipefail
 ##
 ## Examples:
-##     @script.name list
-##     @script.name apply Orchis-Dark-Compact
+##     @script.name list --plain
+##     @script.name apply Orchis-Dark-Compact Numix-Circle true
+##     @script.name set-icons Papirus-Dark
+##     @script.name color-scheme dark
 ##     @script.name theme vapor-dreams
 ##     @script.name detect ~/Pictures/wallpaper.jpg
 ##     @script.name auto
 
-set -e
+set -euo pipefail
 
 # Source EasyOptions for argument parsing
 source ~/.local/lib/dots/easy-options/easyoptions.sh || exit
 
 # Source the GTK theme manager - try multiple locations
 gtk_theme_manager_paths=(
-	"$HOME/.local/lib/dots/gtk-theme-manager.sh"
-	"$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../lib/dots/gtk-theme-manager.sh"
+  "$HOME/.local/lib/dots/gtk-theme-manager.sh"
+  "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../lib/dots/gtk-theme-manager.sh"
 )
 
 gtk_theme_manager_found=false
 for path in "${gtk_theme_manager_paths[@]}"; do
-	if [[ -f $path ]]; then
-		source "$path"
-		gtk_theme_manager_found=true
-		break
-	fi
+  if [[ -f $path ]]; then
+    source "$path"
+    gtk_theme_manager_found=true
+    break
+  fi
 done
 
 if [[ $gtk_theme_manager_found != "true" ]]; then
-	echo "Error: GTK theme manager not found in any of these locations:" >&2
-	printf '  %s\n' "${gtk_theme_manager_paths[@]}" >&2
-	exit 1
+  echo "Error: GTK theme manager not found in any of these locations:" >&2
+  printf '  %s\n' "${gtk_theme_manager_paths[@]}" >&2
+  exit 1
 fi
 
 # Color definitions for output
@@ -75,323 +79,420 @@ readonly NC='\033[0m' # No Color
 
 # Function to log messages with verbosity control
 log() {
-	local level="$1"
-	shift
-	local message="$*"
+  local level="$1"
+  shift
+  local message="$*"
 
-	if [[ ${quiet:-} == "yes" ]] && [[ $level != "ERROR" ]]; then
-		return 0
-	fi
+  if [[ ${quiet:-} == "yes" ]] && [[ $level != "ERROR" ]]; then
+    return 0
+  fi
 
-	local timestamp
-	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+  local timestamp
+  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-	case "$level" in
-	"ERROR")
-		echo -e "${RED}❌ [ERROR] $message${NC}" >&2
-		;;
-	"WARN")
-		echo -e "${YELLOW}⚠️  [WARN] $message${NC}" >&2
-		;;
-	"INFO")
-		if [[ ${verbose:-} == "yes" ]]; then
-			echo -e "${BLUE}ℹ️  [INFO] $message${NC}"
-		fi
-		;;
-	"DEBUG")
-		if [[ ${debug:-} == "yes" ]]; then
-			echo -e "${PURPLE}🐛 [DEBUG] [$timestamp] $message${NC}" >&2
-		fi
-		;;
-	*)
-		echo -e "$message"
-		;;
-	esac
+  case "$level" in
+    "ERROR")
+      echo -e "${RED}❌ [ERROR] $message${NC}" >&2
+      ;;
+    "WARN")
+      echo -e "${YELLOW}⚠️  [WARN] $message${NC}" >&2
+      ;;
+    "INFO")
+      if [[ ${verbose:-} == "yes" ]]; then
+        echo -e "${BLUE}ℹ️  [INFO] $message${NC}"
+      fi
+      ;;
+    "DEBUG")
+      if [[ ${debug:-} == "yes" ]]; then
+        echo -e "${PURPLE}🐛 [DEBUG] [$timestamp] $message${NC}" >&2
+      fi
+      ;;
+    *)
+      echo -e "$message"
+      ;;
+  esac
 }
 
 # Function to list installed GTK themes
 cmd_list() {
-	log "" "${BLUE}📋 Installed GTK themes:${NC}"
-	log "" ""
+  local use_plain=false
+  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-	local themes
-	themes=$(list_installed_gtk_themes)
+  local themes
+  themes=$(list_installed_gtk_themes)
 
-	if [[ -z $themes ]]; then
-		log "WARN" "No GTK themes found"
-		return 1
-	fi
+  if [[ -z $themes ]]; then
+    [[ $use_plain == true ]] || log "WARN" "No GTK themes found"
+    return 1
+  fi
 
-	local current_theme
-	current_theme=$(get_current_gtk_theme)
-	log "DEBUG" "Current theme: $current_theme"
+  if [[ $use_plain == true ]]; then
+    printf '%s\n' "$themes"
+    return 0
+  fi
 
-	while IFS= read -r theme; do
-		if [[ $theme == "$current_theme" ]]; then
-			log "" "  ${GREEN}✓${NC} $theme ${CYAN}(current)${NC}"
-		else
-			log "" "    $theme"
-		fi
-	done <<<"$themes"
+  log "" "${BLUE}📋 Installed GTK themes:${NC}"
+  log "" ""
 
-	log "" ""
-	log "" "${CYAN}💡 Tip:${NC} Use 'dots gtk-theme apply <theme>' to apply a theme"
+  local current_theme
+  current_theme=$(get_current_gtk_theme)
+  log "DEBUG" "Current theme: $current_theme"
+
+  while IFS= read -r theme; do
+    if [[ $theme == "$current_theme" ]]; then
+      log "" "  ${GREEN}✓${NC} $theme ${CYAN}(current)${NC}"
+    else
+      log "" "    $theme"
+    fi
+  done <<<"$themes"
+
+  log "" ""
+  log "" "${CYAN}💡 Tip:${NC} Use 'dots gtk-theme apply <theme>' to apply a theme"
 }
 
 # Function to show current theme
 cmd_current() {
-	local current_theme
-	current_theme=$(get_current_gtk_theme)
+  local use_plain=false
+  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-	log "" "${BLUE}🎨 Current GTK Theme:${NC} $current_theme"
+  local current_theme
+  current_theme=$(get_current_gtk_theme)
 
-	# Show additional info
-	if [[ -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
-		local icon_theme
-		icon_theme=$(grep "^gtk-icon-theme-name=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
-		log "" "${BLUE}🎯 Icon Theme:${NC} $icon_theme"
+  if [[ $use_plain == true ]]; then
+    printf '%s\n' "$current_theme"
+    return 0
+  fi
 
-		local dark_pref
-		dark_pref=$(grep "^gtk-application-prefer-dark-theme=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
-		log "" "${BLUE}🌙 Dark Theme Preference:${NC} $dark_pref"
-	fi
+  log "" "${BLUE}🎨 Current GTK Theme:${NC} $current_theme"
+
+  # Show additional info
+  if [[ -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
+    local icon_theme
+    icon_theme=$(grep "^gtk-icon-theme-name=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
+    log "" "${BLUE}🎯 Icon Theme:${NC} $icon_theme"
+
+    local dark_pref
+    dark_pref=$(grep "^gtk-application-prefer-dark-theme=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
+    log "" "${BLUE}🌙 Dark Theme Preference:${NC} $dark_pref"
+  fi
 }
 
 # Function to apply specific theme
 cmd_apply() {
-	local theme_name="$1"
-	local icon_theme="${2:-Numix-Circle}"
-	local prefer_dark="${3:-false}"
+  local theme_name="$1"
+  local icon_theme="${2:-}"
+  local prefer_dark="${3:-}"
 
-	log "" "${BLUE}🎨 Applying GTK Theme:${NC} $theme_name"
-	log "DEBUG" "Icon theme: $icon_theme, prefer dark: $prefer_dark"
+  if [[ -z $icon_theme ]]; then
+    icon_theme="$(get_current_icon_theme 2>/dev/null || true)"
+    [[ -n $icon_theme ]] || icon_theme="Numix-Circle"
+  fi
+  if [[ -z $prefer_dark ]]; then
+    # Derive from live scheme state when callers omit prefer-dark.
+    local mode="dark"
+    local state_json="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
+    if [[ -f $state_json ]]; then
+      mode="$(python3 -c "import json;print(json.load(open('$state_json')).get('mode','dark'))" 2>/dev/null || echo dark)"
+    fi
+    prefer_dark=$([[ $mode == "light" ]] && echo false || echo true)
+  fi
 
-	if apply_gtk_theme "$theme_name" "$icon_theme" "$prefer_dark"; then
-		log "" "${GREEN}✅ Theme applied successfully${NC}"
-	else
-		log "ERROR" "Failed to apply theme"
-		return 1
-	fi
+  log "" "${BLUE}🎨 Applying GTK Theme:${NC} $theme_name"
+  log "DEBUG" "Icon theme: $icon_theme, prefer dark: $prefer_dark"
+
+  if apply_gtk_theme "$theme_name" "$icon_theme" "$prefer_dark"; then
+    log "" "${GREEN}✅ Theme applied successfully${NC}"
+  else
+    log "ERROR" "Failed to apply theme"
+    return 1
+  fi
+}
+
+# Update icon theme while preserving the current GTK theme + prefer-dark.
+cmd_set_icons() {
+  local icon_theme="${1:-}"
+  [[ -n $icon_theme ]] || {
+    log "ERROR" "Icon theme name required"
+    log "" "Usage: $(basename "$0") set-icons <icon-theme>"
+    return 1
+  }
+
+  local gtk_theme prefer_dark
+  gtk_theme="$(get_current_gtk_theme)"
+  prefer_dark="false"
+  if [[ -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
+    prefer_dark="$(grep "^gtk-application-prefer-dark-theme=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2 || echo false)"
+  fi
+  [[ $prefer_dark == "1" || $prefer_dark == "true" ]] && prefer_dark="true" || prefer_dark="false"
+
+  log "" "${BLUE}🎯 Applying icon theme:${NC} $icon_theme (gtk=$gtk_theme)"
+  if apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"; then
+    log "" "${GREEN}✅ Icon theme applied successfully${NC}"
+  else
+    log "ERROR" "Failed to apply icon theme"
+    return 1
+  fi
+}
+
+# Sync GTK color-scheme / prefer-dark with live light|dark mode.
+cmd_color_scheme() {
+  local mode="${1:-}"
+  [[ $mode == "light" || $mode == "dark" ]] || {
+    log "ERROR" "Mode must be light or dark"
+    log "" "Usage: $(basename "$0") color-scheme <light|dark>"
+    return 1
+  }
+  if apply_gtk_color_scheme "$mode"; then
+    log "" "${GREEN}✅ GTK color-scheme synced:${NC} $mode"
+  else
+    log "ERROR" "Failed to sync GTK color-scheme"
+    return 1
+  fi
 }
 
 # Function to detect optimal theme
 cmd_detect() {
-	local wallpaper_path="${1:-}"
+  local wallpaper_path="${1:-}"
 
-	if [[ -z $wallpaper_path ]]; then
-		# Use current wallpaper
-		wallpaper_path=$(cat "$HOME/.cache/wal/wal" 2>/dev/null || echo "")
-		if [[ -z $wallpaper_path ]]; then
-			echo -e "${RED}❌ No wallpaper specified and no current wallpaper found${NC}"
-			return 1
-		fi
-	fi
+  if [[ -z $wallpaper_path ]]; then
+    # Use current wallpaper
+    wallpaper_path=$(cat "$HOME/.cache/wal/wal" 2>/dev/null || echo "")
+    if [[ -z $wallpaper_path ]]; then
+      echo -e "${RED}❌ No wallpaper specified and no current wallpaper found${NC}"
+      return 1
+    fi
+  fi
 
-	if [[ ! -f $wallpaper_path ]]; then
-		echo -e "${RED}❌ Wallpaper file not found: $wallpaper_path${NC}"
-		return 1
-	fi
+  if [[ ! -f $wallpaper_path ]]; then
+    echo -e "${RED}❌ Wallpaper file not found: $wallpaper_path${NC}"
+    return 1
+  fi
 
-	echo -e "${BLUE}🔍 Analyzing wallpaper:${NC} $(basename "$wallpaper_path")"
+  echo -e "${BLUE}🔍 Analyzing wallpaper:${NC} $(basename "$wallpaper_path")"
 
-	local theme_info
-	theme_info=$(detect_optimal_gtk_theme "$wallpaper_path")
-	local detected_theme="${theme_info%:*}"
-	local prefer_dark="${theme_info#*:}"
+  local theme_info
+  theme_info=$(detect_optimal_gtk_theme "$wallpaper_path")
+  local detected_theme="${theme_info%:*}"
+  local prefer_dark="${theme_info#*:}"
 
-	echo -e "${GREEN}🎯 Detected optimal theme:${NC} $detected_theme"
-	echo -e "${GREEN}🌙 Dark preference:${NC} $prefer_dark"
+  echo -e "${GREEN}🎯 Detected optimal theme:${NC} $detected_theme"
+  echo -e "${GREEN}🌙 Dark preference:${NC} $prefer_dark"
 
-	# Ask if user wants to apply
-	read -p "Apply this theme? (y/N): " -n 1 -r
-	echo
-	if [[ $REPLY =~ ^[Yy]$ ]]; then
-		cmd_apply "$detected_theme" "Numix-Circle" "$prefer_dark"
-	fi
+  # Ask if user wants to apply
+  read -p "Apply this theme? (y/N): " -n 1 -r
+  echo
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    cmd_apply "$detected_theme" "Numix-Circle" "$prefer_dark"
+  fi
 }
 
-# Function to apply rice-specific theme
+# Function to apply theme-pack GTK settings
 cmd_theme_pack() {
-	local rice_name="${1:-}"
+  local theme_id="${1:-}"
 
-	echo -e "${BLUE}🍚 Applying GTK theme from theme pack:${NC} ${rice_name:-auto-detect}"
+  echo -e "${BLUE}🎨 Applying GTK theme from theme pack:${NC} ${theme_id:-auto-detect}"
 
-	if apply_theme_gtk_theme "$rice_name"; then
-		echo -e "${GREEN}✅ Rice GTK theme applied successfully${NC}"
-	else
-		echo -e "${RED}❌ Failed to apply theme pack GTK theme${NC}"
-		return 1
-	fi
+  if apply_theme_gtk_theme "$theme_id"; then
+    echo -e "${GREEN}✅ Theme pack GTK theme applied successfully${NC}"
+  else
+    echo -e "${RED}❌ Failed to apply theme pack GTK theme${NC}"
+    return 1
+  fi
 }
 
 # Function to auto-detect and apply
 cmd_auto() {
-	echo -e "${BLUE}🤖 Auto-detecting optimal GTK theme...${NC}"
-	cmd_theme_pack ""
+  echo -e "${BLUE}🤖 Auto-detecting optimal GTK theme...${NC}"
+  cmd_theme_pack ""
 }
 
 # Function to list icon themes
 cmd_icons() {
-	echo -e "${BLUE}🎯 Installed Icon Themes:${NC}"
-	echo ""
+  local use_plain=false
+  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-	local icon_dirs=(
-		"/usr/share/icons"
-		"/usr/local/share/icons"
-		"$HOME/.icons"
-		"$HOME/.local/share/icons"
-	)
+  local icon_dirs=(
+    "/usr/share/icons"
+    "/usr/local/share/icons"
+    "$HOME/.icons"
+    "${XDG_DATA_HOME:-$HOME/.local/share}/icons"
+  )
 
-	local icons=()
-	for icon_dir in "${icon_dirs[@]}"; do
-		if [[ -d $icon_dir ]]; then
-			while IFS= read -r -d '' icon_path; do
-				local icon_name
-				icon_name=$(basename "$icon_path")
-				if [[ -f "$icon_path/index.theme" ]] || [[ -d "$icon_path/scalable" ]] || [[ -d "$icon_path/16x16" ]]; then
-					icons+=("$icon_name")
-				fi
-			done < <(find "$icon_dir" -maxdepth 1 -type d -print0)
-		fi
-	done
+  local icons=()
+  for icon_dir in "${icon_dirs[@]}"; do
+    if [[ -d $icon_dir ]]; then
+      while IFS= read -r -d '' icon_path; do
+        local icon_name
+        icon_name=$(basename "$icon_path")
+        case "$icon_name" in
+          default | hicolor) continue ;;
+        esac
+        if [[ -f "$icon_path/index.theme" ]]; then
+          icons+=("$icon_name")
+        fi
+      done < <(find "$icon_dir" -maxdepth 1 -mindepth 1 -type d -print0 2>/dev/null)
+    fi
+  done
 
-	# Remove duplicates and sort
-	local unique_icons
-	unique_icons=$(printf '%s\n' "${icons[@]}" | sort -u)
+  local unique_icons
+  unique_icons=$(printf '%s\n' "${icons[@]}" | sort -u)
 
-	local current_icon=""
-	if [[ -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
-		current_icon=$(grep "^gtk-icon-theme-name=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
-	fi
+  if [[ $use_plain == true ]]; then
+    printf '%s\n' "$unique_icons"
+    return 0
+  fi
 
-	while IFS= read -r icon; do
-		if [[ $icon == "$current_icon" ]]; then
-			echo -e "  ${GREEN}✓${NC} $icon ${CYAN}(current)${NC}"
-		else
-			echo -e "    $icon"
-		fi
-	done <<<"$unique_icons"
+  echo -e "${BLUE}🎯 Installed Icon Themes:${NC}"
+  echo ""
+
+  local current_icon=""
+  current_icon="$(get_current_icon_theme 2>/dev/null || true)"
+
+  while IFS= read -r icon; do
+    [[ -z $icon ]] && continue
+    if [[ $icon == "$current_icon" ]]; then
+      echo -e "  ${GREEN}✓${NC} $icon ${CYAN}(current)${NC}"
+    else
+      echo -e "    $icon"
+    fi
+  done <<<"$unique_icons"
 }
 
 # Function to show theme information
 cmd_info() {
-	local theme_name="$1"
+  local theme_name="$1"
 
-	echo -e "${BLUE}ℹ️  Theme Information: $theme_name${NC}"
-	echo ""
+  echo -e "${BLUE}ℹ️  Theme Information: $theme_name${NC}"
+  echo ""
 
-	# Find theme directories
-	local theme_dirs=(
-		"/usr/share/themes"
-		"/usr/local/share/themes"
-		"$HOME/.themes"
-		"$HOME/.local/share/themes"
-	)
+  # Find theme directories
+  local theme_dirs=(
+    "/usr/share/themes"
+    "/usr/local/share/themes"
+    "$HOME/.themes"
+    "$HOME/.local/share/themes"
+  )
 
-	local found_path=""
-	for theme_dir in "${theme_dirs[@]}"; do
-		if [[ -d "$theme_dir/$theme_name" ]]; then
-			found_path="$theme_dir/$theme_name"
-			break
-		fi
-	done
+  local found_path=""
+  for theme_dir in "${theme_dirs[@]}"; do
+    if [[ -d "$theme_dir/$theme_name" ]]; then
+      found_path="$theme_dir/$theme_name"
+      break
+    fi
+  done
 
-	if [[ -z $found_path ]]; then
-		echo -e "${RED}❌ Theme not found: $theme_name${NC}"
-		return 1
-	fi
+  if [[ -z $found_path ]]; then
+    echo -e "${RED}❌ Theme not found: $theme_name${NC}"
+    return 1
+  fi
 
-	echo -e "${GREEN}📁 Location:${NC} $found_path"
+  echo -e "${GREEN}📁 Location:${NC} $found_path"
 
-	# Check what components are available
-	echo -e "${GREEN}🧩 Available Components:${NC}"
-	if [[ -d "$found_path/gtk-2.0" ]]; then
-		echo -e "  ✅ GTK2"
-	else
-		echo -e "  ❌ GTK2"
-	fi
+  # Check what components are available
+  echo -e "${GREEN}🧩 Available Components:${NC}"
+  if [[ -d "$found_path/gtk-2.0" ]]; then
+    echo -e "  ✅ GTK2"
+  else
+    echo -e "  ❌ GTK2"
+  fi
 
-	if [[ -d "$found_path/gtk-3.0" ]]; then
-		echo -e "  ✅ GTK3"
-	else
-		echo -e "  ❌ GTK3"
-	fi
+  if [[ -d "$found_path/gtk-3.0" ]]; then
+    echo -e "  ✅ GTK3"
+  else
+    echo -e "  ❌ GTK3"
+  fi
 
-	if [[ -d "$found_path/gtk-4.0" ]]; then
-		echo -e "  ✅ GTK4"
-	else
-		echo -e "  ❌ GTK4"
-	fi
+  if [[ -d "$found_path/gtk-4.0" ]]; then
+    echo -e "  ✅ GTK4"
+  else
+    echo -e "  ❌ GTK4"
+  fi
 
-	# Show index.theme if available
-	if [[ -f "$found_path/index.theme" ]]; then
-		echo ""
-		echo -e "${GREEN}📋 Theme Metadata:${NC}"
-		while IFS= read -r line; do
-			if [[ $line =~ ^Name= ]]; then
-				echo -e "  ${BLUE}Name:${NC} ${line#Name=}"
-			elif [[ $line =~ ^Comment= ]]; then
-				echo -e "  ${BLUE}Description:${NC} ${line#Comment=}"
-			fi
-		done <"$found_path/index.theme"
-	fi
+  # Show index.theme if available
+  if [[ -f "$found_path/index.theme" ]]; then
+    echo ""
+    echo -e "${GREEN}📋 Theme Metadata:${NC}"
+    while IFS= read -r line; do
+      if [[ $line =~ ^Name= ]]; then
+        echo -e "  ${BLUE}Name:${NC} ${line#Name=}"
+      elif [[ $line =~ ^Comment= ]]; then
+        echo -e "  ${BLUE}Description:${NC} ${line#Comment=}"
+      fi
+    done <"$found_path/index.theme"
+  fi
 }
 
 # Main script logic
 main() {
-	log "DEBUG" "Starting GTK theme manager with args: ${arguments[*]}"
+  log "DEBUG" "Starting GTK theme manager with args: ${arguments[*]}"
 
-	if [[ ${#arguments[@]} -eq 0 ]]; then
-		log "ERROR" "No command specified. Use --help for usage information."
-		exit 1
-	fi
+  if [[ ${#arguments[@]} -eq 0 ]]; then
+    log "ERROR" "No command specified. Use --help for usage information."
+    exit 1
+  fi
 
-	local command="${arguments[0]}"
-	local cmd_args=("${arguments[@]:1}")
+  local command="${arguments[0]}"
+  local cmd_args=("${arguments[@]:1}")
 
-	log "DEBUG" "Command: $command, args: ${cmd_args[*]}"
+  log "DEBUG" "Command: $command, args: ${cmd_args[*]}"
 
-	case "$command" in
-	"list" | "ls")
-		cmd_list
-		;;
-	"current" | "status")
-		cmd_current
-		;;
-	"apply" | "set")
-		if [[ ${#cmd_args[@]} -eq 0 ]]; then
-			log "ERROR" "Theme name required for apply command"
-			log "" "Usage: $(basename "$0") apply <theme-name> [icon-theme] [prefer-dark]"
-			exit 1
-		fi
-		cmd_apply "${cmd_args[@]}"
-		;;
-	"detect" | "analyze")
-		cmd_detect "${cmd_args[@]}"
-		;;
-	"theme" | "t")
-		cmd_theme_pack "${cmd_args[@]}"
-		;;
-	"auto" | "automatic")
-		cmd_auto
-		;;
-	"icons" | "icon")
-		cmd_icons
-		;;
-	"info" | "show")
-		if [[ ${#cmd_args[@]} -eq 0 ]]; then
-			log "ERROR" "Theme name required for info command"
-			log "" "Usage: $(basename "$0") info <theme-name>"
-			exit 1
-		fi
-		cmd_info "${cmd_args[0]}"
-		;;
-	*)
-		log "ERROR" "Unknown command '$command'"
-		log "" "Use --help for available commands"
-		exit 1
-		;;
-	esac
+  case "$command" in
+    "list" | "ls")
+      cmd_list "${cmd_args[@]}"
+      ;;
+    "current" | "status")
+      cmd_current "${cmd_args[@]}"
+      ;;
+    "apply" | "set")
+      if [[ ${#cmd_args[@]} -eq 0 ]]; then
+        log "ERROR" "Theme name required for apply command"
+        log "" "Usage: $(basename "$0") apply <theme-name> [icon-theme] [prefer-dark]"
+        exit 1
+      fi
+      cmd_apply "${cmd_args[@]}"
+      ;;
+    "set-icons" | "set-icon")
+      if [[ ${#cmd_args[@]} -eq 0 ]]; then
+        log "ERROR" "Icon theme name required"
+        log "" "Usage: $(basename "$0") set-icons <icon-theme>"
+        exit 1
+      fi
+      cmd_set_icons "${cmd_args[0]}"
+      ;;
+    "color-scheme" | "scheme")
+      if [[ ${#cmd_args[@]} -eq 0 ]]; then
+        log "ERROR" "Mode required (light|dark)"
+        log "" "Usage: $(basename "$0") color-scheme <light|dark>"
+        exit 1
+      fi
+      cmd_color_scheme "${cmd_args[0]}"
+      ;;
+    "detect" | "analyze")
+      cmd_detect "${cmd_args[@]}"
+      ;;
+    "theme" | "t")
+      cmd_theme_pack "${cmd_args[@]}"
+      ;;
+    "auto" | "automatic")
+      cmd_auto
+      ;;
+    "icons" | "icon")
+      cmd_icons "${cmd_args[@]}"
+      ;;
+    "info" | "show")
+      if [[ ${#cmd_args[@]} -eq 0 ]]; then
+        log "ERROR" "Theme name required for info command"
+        log "" "Usage: $(basename "$0") info <theme-name>"
+        exit 1
+      fi
+      cmd_info "${cmd_args[0]}"
+      ;;
+    *)
+      log "ERROR" "Unknown command '$command'"
+      log "" "Use --help for available commands"
+      exit 1
+      ;;
+  esac
 }
 
 # Run main function

--- a/home/dot_local/bin/executable_dots-gtk-theme
+++ b/home/dot_local/bin/executable_dots-gtk-theme
@@ -23,6 +23,7 @@
 ## Commands:
 ##     list                    List installed GTK themes
 ##     current                 Show current GTK theme
+##     current-icon            Show current icon theme
 ##     apply <theme> [icon] [prefer-dark]
 ##                             Apply GTK theme (prefer-dark: true|false)
 ##     set-icons <icon>        Update icon theme (keeps current GTK theme)
@@ -34,7 +35,9 @@
 ##     info <theme>            Show information about a theme
 ##
 ## Examples:
-##     @script.name list --plain
+##     @script.name -p list
+##     @script.name -q -p current
+##     @script.name -q -p current-icon
 ##     @script.name apply Orchis-Dark-Compact Numix-Circle true
 ##     @script.name set-icons Papirus-Dark
 ##     @script.name color-scheme dark
@@ -49,23 +52,23 @@ source ~/.local/lib/dots/easy-options/easyoptions.sh || exit
 
 # Source the GTK theme manager - try multiple locations
 gtk_theme_manager_paths=(
-	"$HOME/.local/lib/dots/gtk-theme-manager.sh"
-	"$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../lib/dots/gtk-theme-manager.sh"
+  "$HOME/.local/lib/dots/gtk-theme-manager.sh"
+  "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../lib/dots/gtk-theme-manager.sh"
 )
 
 gtk_theme_manager_found=false
 for path in "${gtk_theme_manager_paths[@]}"; do
-	if [[ -f $path ]]; then
-		source "$path"
-		gtk_theme_manager_found=true
-		break
-	fi
+  if [[ -f $path ]]; then
+    source "$path"
+    gtk_theme_manager_found=true
+    break
+  fi
 done
 
 if [[ $gtk_theme_manager_found != "true" ]]; then
-	echo "Error: GTK theme manager not found in any of these locations:" >&2
-	printf '  %s\n' "${gtk_theme_manager_paths[@]}" >&2
-	exit 1
+  echo "Error: GTK theme manager not found in any of these locations:" >&2
+  printf '  %s\n' "${gtk_theme_manager_paths[@]}" >&2
+  exit 1
 fi
 
 # Color definitions for output
@@ -79,420 +82,443 @@ readonly NC='\033[0m' # No Color
 
 # Function to log messages with verbosity control
 log() {
-	local level="$1"
-	shift
-	local message="$*"
+  local level="$1"
+  shift
+  local message="$*"
 
-	if [[ ${quiet:-} == "yes" ]] && [[ $level != "ERROR" ]]; then
-		return 0
-	fi
+  if [[ ${quiet:-} == "yes" ]] && [[ $level != "ERROR" ]]; then
+    return 0
+  fi
 
-	local timestamp
-	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+  local timestamp
+  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-	case "$level" in
-	"ERROR")
-		echo -e "${RED}❌ [ERROR] $message${NC}" >&2
-		;;
-	"WARN")
-		echo -e "${YELLOW}⚠️  [WARN] $message${NC}" >&2
-		;;
-	"INFO")
-		if [[ ${verbose:-} == "yes" ]]; then
-			echo -e "${BLUE}ℹ️  [INFO] $message${NC}"
-		fi
-		;;
-	"DEBUG")
-		if [[ ${debug:-} == "yes" ]]; then
-			echo -e "${PURPLE}🐛 [DEBUG] [$timestamp] $message${NC}" >&2
-		fi
-		;;
-	*)
-		echo -e "$message"
-		;;
-	esac
+  case "$level" in
+    "ERROR")
+      echo -e "${RED}❌ [ERROR] $message${NC}" >&2
+      ;;
+    "WARN")
+      echo -e "${YELLOW}⚠️  [WARN] $message${NC}" >&2
+      ;;
+    "INFO")
+      if [[ ${verbose:-} == "yes" ]]; then
+        echo -e "${BLUE}ℹ️  [INFO] $message${NC}"
+      fi
+      ;;
+    "DEBUG")
+      if [[ ${debug:-} == "yes" ]]; then
+        echo -e "${PURPLE}🐛 [DEBUG] [$timestamp] $message${NC}" >&2
+      fi
+      ;;
+    *)
+      echo -e "$message"
+      ;;
+  esac
 }
 
 # Function to list installed GTK themes
 cmd_list() {
-	local use_plain=false
-	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+  local use_plain=false
+  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-	local themes
-	themes=$(list_installed_gtk_themes)
+  local themes
+  themes=$(list_installed_gtk_themes)
 
-	if [[ -z $themes ]]; then
-		[[ $use_plain == true ]] || log "WARN" "No GTK themes found"
-		return 1
-	fi
+  if [[ -z $themes ]]; then
+    [[ $use_plain == true ]] || log "WARN" "No GTK themes found"
+    return 1
+  fi
 
-	if [[ $use_plain == true ]]; then
-		printf '%s\n' "$themes"
-		return 0
-	fi
+  if [[ $use_plain == true ]]; then
+    printf '%s\n' "$themes"
+    return 0
+  fi
 
-	log "" "${BLUE}📋 Installed GTK themes:${NC}"
-	log "" ""
+  log "" "${BLUE}📋 Installed GTK themes:${NC}"
+  log "" ""
 
-	local current_theme
-	current_theme=$(get_current_gtk_theme)
-	log "DEBUG" "Current theme: $current_theme"
+  local current_theme
+  current_theme=$(get_current_gtk_theme)
+  log "DEBUG" "Current theme: $current_theme"
 
-	while IFS= read -r theme; do
-		if [[ $theme == "$current_theme" ]]; then
-			log "" "  ${GREEN}✓${NC} $theme ${CYAN}(current)${NC}"
-		else
-			log "" "    $theme"
-		fi
-	done <<<"$themes"
+  while IFS= read -r theme; do
+    if [[ $theme == "$current_theme" ]]; then
+      log "" "  ${GREEN}✓${NC} $theme ${CYAN}(current)${NC}"
+    else
+      log "" "    $theme"
+    fi
+  done <<<"$themes"
 
-	log "" ""
-	log "" "${CYAN}💡 Tip:${NC} Use 'dots gtk-theme apply <theme>' to apply a theme"
+  log "" ""
+  log "" "${CYAN}💡 Tip:${NC} Use 'dots gtk-theme apply <theme>' to apply a theme"
 }
 
 # Function to show current theme
 cmd_current() {
-	local use_plain=false
-	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+  local use_plain=false
+  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-	local current_theme
-	current_theme=$(get_current_gtk_theme)
+  local current_theme
+  current_theme=$(get_current_gtk_theme)
 
-	if [[ $use_plain == true ]]; then
-		printf '%s\n' "$current_theme"
-		return 0
-	fi
+  if [[ $use_plain == true ]]; then
+    printf '%s\n' "$current_theme"
+    return 0
+  fi
 
-	log "" "${BLUE}🎨 Current GTK Theme:${NC} $current_theme"
+  log "" "${BLUE}🎨 Current GTK Theme:${NC} $current_theme"
 
-	# Show additional info
-	if [[ -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
-		local icon_theme
-		icon_theme=$(grep "^gtk-icon-theme-name=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
-		log "" "${BLUE}🎯 Icon Theme:${NC} $icon_theme"
+  # Show additional info
+  if [[ -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
+    local icon_theme
+    icon_theme=$(grep "^gtk-icon-theme-name=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
+    log "" "${BLUE}🎯 Icon Theme:${NC} $icon_theme"
 
-		local dark_pref
-		dark_pref=$(grep "^gtk-application-prefer-dark-theme=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
-		log "" "${BLUE}🌙 Dark Theme Preference:${NC} $dark_pref"
-	fi
+    local dark_pref
+    dark_pref=$(grep "^gtk-application-prefer-dark-theme=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
+    log "" "${BLUE}🌙 Dark Theme Preference:${NC} $dark_pref"
+  fi
+}
+
+# Function to show current icon theme
+cmd_current_icon() {
+  local use_plain=false
+  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+
+  local current_icon
+  current_icon="$(get_current_icon_theme 2>/dev/null || true)"
+  [[ -n $current_icon ]] || current_icon="Unknown"
+
+  if [[ $use_plain == true ]]; then
+    printf '%s\n' "$current_icon"
+    return 0
+  fi
+
+  log "" "${BLUE}🎯 Current Icon Theme:${NC} $current_icon"
 }
 
 # Function to apply specific theme
 cmd_apply() {
-	local theme_name="$1"
-	local icon_theme="${2:-}"
-	local prefer_dark="${3:-}"
+  local theme_name="$1"
+  local icon_theme="${2:-}"
+  local prefer_dark="${3:-}"
 
-	if [[ -z $icon_theme ]]; then
-		icon_theme="$(get_current_icon_theme 2>/dev/null || true)"
-		[[ -n $icon_theme ]] || icon_theme="Numix-Circle"
-	fi
-	if [[ -z $prefer_dark ]]; then
-		# Derive from live scheme state when callers omit prefer-dark.
-		local mode="dark"
-		local state_json="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
-		if [[ -f $state_json ]]; then
-			mode="$(python3 -c "import json;print(json.load(open('$state_json')).get('mode','dark'))" 2>/dev/null || echo dark)"
-		fi
-		prefer_dark=$([[ $mode == "light" ]] && echo false || echo true)
-	fi
+  if [[ -z $icon_theme ]]; then
+    icon_theme="$(get_current_icon_theme 2>/dev/null || true)"
+    [[ -n $icon_theme ]] || icon_theme="Numix-Circle"
+  fi
+  if [[ -z $prefer_dark ]]; then
+    # Derive from live scheme state when callers omit prefer-dark.
+    local mode="dark"
+    local state_json="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
+    if [[ -f $state_json ]]; then
+      mode="$(python3 -c "import json;print(json.load(open('$state_json')).get('mode','dark'))" 2>/dev/null || echo dark)"
+    fi
+    prefer_dark=$([[ $mode == "light" ]] && echo false || echo true)
+  fi
 
-	log "" "${BLUE}🎨 Applying GTK Theme:${NC} $theme_name"
-	log "DEBUG" "Icon theme: $icon_theme, prefer dark: $prefer_dark"
+  log "" "${BLUE}🎨 Applying GTK Theme:${NC} $theme_name"
+  log "DEBUG" "Icon theme: $icon_theme, prefer dark: $prefer_dark"
 
-	if apply_gtk_theme "$theme_name" "$icon_theme" "$prefer_dark"; then
-		log "" "${GREEN}✅ Theme applied successfully${NC}"
-	else
-		log "ERROR" "Failed to apply theme"
-		return 1
-	fi
+  if apply_gtk_theme "$theme_name" "$icon_theme" "$prefer_dark"; then
+    log "" "${GREEN}✅ Theme applied successfully${NC}"
+  else
+    log "ERROR" "Failed to apply theme"
+    return 1
+  fi
 }
 
 # Update icon theme while preserving the current GTK theme + prefer-dark.
 cmd_set_icons() {
-	local icon_theme="${1:-}"
-	[[ -n $icon_theme ]] || {
-		log "ERROR" "Icon theme name required"
-		log "" "Usage: $(basename "$0") set-icons <icon-theme>"
-		return 1
-	}
+  local icon_theme="${1:-}"
+  [[ -n $icon_theme ]] || {
+    log "ERROR" "Icon theme name required"
+    log "" "Usage: $(basename "$0") set-icons <icon-theme>"
+    return 1
+  }
 
-	local gtk_theme prefer_dark
-	gtk_theme="$(get_current_gtk_theme)"
-	prefer_dark="false"
-	if [[ -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
-		prefer_dark="$(grep "^gtk-application-prefer-dark-theme=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2 || echo false)"
-	fi
-	[[ $prefer_dark == "1" || $prefer_dark == "true" ]] && prefer_dark="true" || prefer_dark="false"
+  local gtk_theme prefer_dark
+  gtk_theme="$(get_current_gtk_theme)"
+  prefer_dark="false"
+  if [[ -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
+    prefer_dark="$(grep "^gtk-application-prefer-dark-theme=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2 || echo false)"
+  fi
+  [[ $prefer_dark == "1" || $prefer_dark == "true" ]] && prefer_dark="true" || prefer_dark="false"
 
-	log "" "${BLUE}🎯 Applying icon theme:${NC} $icon_theme (gtk=$gtk_theme)"
-	if apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"; then
-		log "" "${GREEN}✅ Icon theme applied successfully${NC}"
-	else
-		log "ERROR" "Failed to apply icon theme"
-		return 1
-	fi
+  log "" "${BLUE}🎯 Applying icon theme:${NC} $icon_theme (gtk=$gtk_theme)"
+  if apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"; then
+    log "" "${GREEN}✅ Icon theme applied successfully${NC}"
+  else
+    log "ERROR" "Failed to apply icon theme"
+    return 1
+  fi
 }
 
 # Sync GTK color-scheme / prefer-dark with live light|dark mode.
 cmd_color_scheme() {
-	local mode="${1:-}"
-	[[ $mode == "light" || $mode == "dark" ]] || {
-		log "ERROR" "Mode must be light or dark"
-		log "" "Usage: $(basename "$0") color-scheme <light|dark>"
-		return 1
-	}
-	if apply_gtk_color_scheme "$mode"; then
-		log "" "${GREEN}✅ GTK color-scheme synced:${NC} $mode"
-	else
-		log "ERROR" "Failed to sync GTK color-scheme"
-		return 1
-	fi
+  local mode="${1:-}"
+  [[ $mode == "light" || $mode == "dark" ]] || {
+    log "ERROR" "Mode must be light or dark"
+    log "" "Usage: $(basename "$0") color-scheme <light|dark>"
+    return 1
+  }
+  if apply_gtk_color_scheme "$mode"; then
+    log "" "${GREEN}✅ GTK color-scheme synced:${NC} $mode"
+  else
+    log "ERROR" "Failed to sync GTK color-scheme"
+    return 1
+  fi
 }
 
 # Function to detect optimal theme
 cmd_detect() {
-	local wallpaper_path="${1:-}"
+  local wallpaper_path="${1:-}"
 
-	if [[ -z $wallpaper_path ]]; then
-		# Use current wallpaper
-		wallpaper_path=$(cat "$HOME/.cache/wal/wal" 2>/dev/null || echo "")
-		if [[ -z $wallpaper_path ]]; then
-			echo -e "${RED}❌ No wallpaper specified and no current wallpaper found${NC}"
-			return 1
-		fi
-	fi
+  if [[ -z $wallpaper_path ]]; then
+    if [[ -f $HOME/.local/lib/dots/wallpaper-resolver.sh ]]; then
+      # shellcheck source=/dev/null
+      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+      wallpaper_path="$(dots_current_wallpaper 2>/dev/null || true)"
+    fi
+    if [[ -z ${wallpaper_path:-} ]]; then
+      echo -e "${RED}❌ No wallpaper specified and no current wallpaper found${NC}"
+      return 1
+    fi
+  fi
 
-	if [[ ! -f $wallpaper_path ]]; then
-		echo -e "${RED}❌ Wallpaper file not found: $wallpaper_path${NC}"
-		return 1
-	fi
+  if [[ ! -f $wallpaper_path ]]; then
+    echo -e "${RED}❌ Wallpaper file not found: $wallpaper_path${NC}"
+    return 1
+  fi
 
-	echo -e "${BLUE}🔍 Analyzing wallpaper:${NC} $(basename "$wallpaper_path")"
+  echo -e "${BLUE}🔍 Analyzing wallpaper:${NC} $(basename "$wallpaper_path")"
 
-	local theme_info
-	theme_info=$(detect_optimal_gtk_theme "$wallpaper_path")
-	local detected_theme="${theme_info%:*}"
-	local prefer_dark="${theme_info#*:}"
+  local theme_info
+  theme_info=$(detect_optimal_gtk_theme "$wallpaper_path")
+  local detected_theme="${theme_info%:*}"
+  local prefer_dark="${theme_info#*:}"
 
-	echo -e "${GREEN}🎯 Detected optimal theme:${NC} $detected_theme"
-	echo -e "${GREEN}🌙 Dark preference:${NC} $prefer_dark"
+  echo -e "${GREEN}🎯 Detected optimal theme:${NC} $detected_theme"
+  echo -e "${GREEN}🌙 Dark preference:${NC} $prefer_dark"
 
-	# Ask if user wants to apply
-	read -p "Apply this theme? (y/N): " -n 1 -r
-	echo
-	if [[ $REPLY =~ ^[Yy]$ ]]; then
-		cmd_apply "$detected_theme" "Numix-Circle" "$prefer_dark"
-	fi
+  # Ask if user wants to apply
+  read -p "Apply this theme? (y/N): " -n 1 -r
+  echo
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    cmd_apply "$detected_theme" "Numix-Circle" "$prefer_dark"
+  fi
 }
 
 # Function to apply theme-pack GTK settings
 cmd_theme_pack() {
-	local theme_id="${1:-}"
+  local theme_id="${1:-}"
 
-	echo -e "${BLUE}🎨 Applying GTK theme from theme pack:${NC} ${theme_id:-auto-detect}"
+  echo -e "${BLUE}🎨 Applying GTK theme from theme pack:${NC} ${theme_id:-auto-detect}"
 
-	if apply_theme_gtk_theme "$theme_id"; then
-		echo -e "${GREEN}✅ Theme pack GTK theme applied successfully${NC}"
-	else
-		echo -e "${RED}❌ Failed to apply theme pack GTK theme${NC}"
-		return 1
-	fi
+  if apply_theme_gtk_theme "$theme_id"; then
+    echo -e "${GREEN}✅ Theme pack GTK theme applied successfully${NC}"
+  else
+    echo -e "${RED}❌ Failed to apply theme pack GTK theme${NC}"
+    return 1
+  fi
 }
 
 # Function to auto-detect and apply
 cmd_auto() {
-	echo -e "${BLUE}🤖 Auto-detecting optimal GTK theme...${NC}"
-	cmd_theme_pack ""
+  echo -e "${BLUE}🤖 Auto-detecting optimal GTK theme...${NC}"
+  cmd_theme_pack ""
 }
 
 # Function to list icon themes
 cmd_icons() {
-	local use_plain=false
-	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+  local use_plain=false
+  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-	local icon_dirs=(
-		"/usr/share/icons"
-		"/usr/local/share/icons"
-		"$HOME/.icons"
-		"${XDG_DATA_HOME:-$HOME/.local/share}/icons"
-	)
+  local icon_dirs=(
+    "/usr/share/icons"
+    "/usr/local/share/icons"
+    "$HOME/.icons"
+    "${XDG_DATA_HOME:-$HOME/.local/share}/icons"
+  )
 
-	local icons=()
-	for icon_dir in "${icon_dirs[@]}"; do
-		if [[ -d $icon_dir ]]; then
-			while IFS= read -r -d '' icon_path; do
-				local icon_name
-				icon_name=$(basename "$icon_path")
-				case "$icon_name" in
-				default | hicolor) continue ;;
-				esac
-				if [[ -f "$icon_path/index.theme" ]]; then
-					icons+=("$icon_name")
-				fi
-			done < <(find "$icon_dir" -maxdepth 1 -mindepth 1 -type d -print0 2>/dev/null)
-		fi
-	done
+  local icons=()
+  for icon_dir in "${icon_dirs[@]}"; do
+    if [[ -d $icon_dir ]]; then
+      while IFS= read -r -d '' icon_path; do
+        local icon_name
+        icon_name=$(basename "$icon_path")
+        case "$icon_name" in
+          default | hicolor) continue ;;
+        esac
+        if [[ -f "$icon_path/index.theme" ]]; then
+          icons+=("$icon_name")
+        fi
+      done < <(find "$icon_dir" -maxdepth 1 -mindepth 1 -type d -print0 2>/dev/null)
+    fi
+  done
 
-	local unique_icons
-	unique_icons=$(printf '%s\n' "${icons[@]}" | sort -u)
+  local unique_icons
+  unique_icons=$(printf '%s\n' "${icons[@]}" | sort -u)
 
-	if [[ $use_plain == true ]]; then
-		printf '%s\n' "$unique_icons"
-		return 0
-	fi
+  if [[ $use_plain == true ]]; then
+    printf '%s\n' "$unique_icons"
+    return 0
+  fi
 
-	echo -e "${BLUE}🎯 Installed Icon Themes:${NC}"
-	echo ""
+  echo -e "${BLUE}🎯 Installed Icon Themes:${NC}"
+  echo ""
 
-	local current_icon=""
-	current_icon="$(get_current_icon_theme 2>/dev/null || true)"
+  local current_icon=""
+  current_icon="$(get_current_icon_theme 2>/dev/null || true)"
 
-	while IFS= read -r icon; do
-		[[ -z $icon ]] && continue
-		if [[ $icon == "$current_icon" ]]; then
-			echo -e "  ${GREEN}✓${NC} $icon ${CYAN}(current)${NC}"
-		else
-			echo -e "    $icon"
-		fi
-	done <<<"$unique_icons"
+  while IFS= read -r icon; do
+    [[ -z $icon ]] && continue
+    if [[ $icon == "$current_icon" ]]; then
+      echo -e "  ${GREEN}✓${NC} $icon ${CYAN}(current)${NC}"
+    else
+      echo -e "    $icon"
+    fi
+  done <<<"$unique_icons"
 }
 
 # Function to show theme information
 cmd_info() {
-	local theme_name="$1"
+  local theme_name="$1"
 
-	echo -e "${BLUE}ℹ️  Theme Information: $theme_name${NC}"
-	echo ""
+  echo -e "${BLUE}ℹ️  Theme Information: $theme_name${NC}"
+  echo ""
 
-	# Find theme directories
-	local theme_dirs=(
-		"/usr/share/themes"
-		"/usr/local/share/themes"
-		"$HOME/.themes"
-		"$HOME/.local/share/themes"
-	)
+  # Find theme directories
+  local theme_dirs=(
+    "/usr/share/themes"
+    "/usr/local/share/themes"
+    "$HOME/.themes"
+    "$HOME/.local/share/themes"
+  )
 
-	local found_path=""
-	for theme_dir in "${theme_dirs[@]}"; do
-		if [[ -d "$theme_dir/$theme_name" ]]; then
-			found_path="$theme_dir/$theme_name"
-			break
-		fi
-	done
+  local found_path=""
+  for theme_dir in "${theme_dirs[@]}"; do
+    if [[ -d "$theme_dir/$theme_name" ]]; then
+      found_path="$theme_dir/$theme_name"
+      break
+    fi
+  done
 
-	if [[ -z $found_path ]]; then
-		echo -e "${RED}❌ Theme not found: $theme_name${NC}"
-		return 1
-	fi
+  if [[ -z $found_path ]]; then
+    echo -e "${RED}❌ Theme not found: $theme_name${NC}"
+    return 1
+  fi
 
-	echo -e "${GREEN}📁 Location:${NC} $found_path"
+  echo -e "${GREEN}📁 Location:${NC} $found_path"
 
-	# Check what components are available
-	echo -e "${GREEN}🧩 Available Components:${NC}"
-	if [[ -d "$found_path/gtk-2.0" ]]; then
-		echo -e "  ✅ GTK2"
-	else
-		echo -e "  ❌ GTK2"
-	fi
+  # Check what components are available
+  echo -e "${GREEN}🧩 Available Components:${NC}"
+  if [[ -d "$found_path/gtk-2.0" ]]; then
+    echo -e "  ✅ GTK2"
+  else
+    echo -e "  ❌ GTK2"
+  fi
 
-	if [[ -d "$found_path/gtk-3.0" ]]; then
-		echo -e "  ✅ GTK3"
-	else
-		echo -e "  ❌ GTK3"
-	fi
+  if [[ -d "$found_path/gtk-3.0" ]]; then
+    echo -e "  ✅ GTK3"
+  else
+    echo -e "  ❌ GTK3"
+  fi
 
-	if [[ -d "$found_path/gtk-4.0" ]]; then
-		echo -e "  ✅ GTK4"
-	else
-		echo -e "  ❌ GTK4"
-	fi
+  if [[ -d "$found_path/gtk-4.0" ]]; then
+    echo -e "  ✅ GTK4"
+  else
+    echo -e "  ❌ GTK4"
+  fi
 
-	# Show index.theme if available
-	if [[ -f "$found_path/index.theme" ]]; then
-		echo ""
-		echo -e "${GREEN}📋 Theme Metadata:${NC}"
-		while IFS= read -r line; do
-			if [[ $line =~ ^Name= ]]; then
-				echo -e "  ${BLUE}Name:${NC} ${line#Name=}"
-			elif [[ $line =~ ^Comment= ]]; then
-				echo -e "  ${BLUE}Description:${NC} ${line#Comment=}"
-			fi
-		done <"$found_path/index.theme"
-	fi
+  # Show index.theme if available
+  if [[ -f "$found_path/index.theme" ]]; then
+    echo ""
+    echo -e "${GREEN}📋 Theme Metadata:${NC}"
+    while IFS= read -r line; do
+      if [[ $line =~ ^Name= ]]; then
+        echo -e "  ${BLUE}Name:${NC} ${line#Name=}"
+      elif [[ $line =~ ^Comment= ]]; then
+        echo -e "  ${BLUE}Description:${NC} ${line#Comment=}"
+      fi
+    done <"$found_path/index.theme"
+  fi
 }
 
 # Main script logic
 main() {
-	log "DEBUG" "Starting GTK theme manager with args: ${arguments[*]}"
+  log "DEBUG" "Starting GTK theme manager with args: ${arguments[*]}"
 
-	if [[ ${#arguments[@]} -eq 0 ]]; then
-		log "ERROR" "No command specified. Use --help for usage information."
-		exit 1
-	fi
+  if [[ ${#arguments[@]} -eq 0 ]]; then
+    log "ERROR" "No command specified. Use --help for usage information."
+    exit 1
+  fi
 
-	local command="${arguments[0]}"
-	local cmd_args=("${arguments[@]:1}")
+  local command="${arguments[0]}"
+  local cmd_args=("${arguments[@]:1}")
 
-	log "DEBUG" "Command: $command, args: ${cmd_args[*]}"
+  log "DEBUG" "Command: $command, args: ${cmd_args[*]}"
 
-	case "$command" in
-	"list" | "ls")
-		cmd_list "${cmd_args[@]}"
-		;;
-	"current" | "status")
-		cmd_current "${cmd_args[@]}"
-		;;
-	"apply" | "set")
-		if [[ ${#cmd_args[@]} -eq 0 ]]; then
-			log "ERROR" "Theme name required for apply command"
-			log "" "Usage: $(basename "$0") apply <theme-name> [icon-theme] [prefer-dark]"
-			exit 1
-		fi
-		cmd_apply "${cmd_args[@]}"
-		;;
-	"set-icons" | "set-icon")
-		if [[ ${#cmd_args[@]} -eq 0 ]]; then
-			log "ERROR" "Icon theme name required"
-			log "" "Usage: $(basename "$0") set-icons <icon-theme>"
-			exit 1
-		fi
-		cmd_set_icons "${cmd_args[0]}"
-		;;
-	"color-scheme" | "scheme")
-		if [[ ${#cmd_args[@]} -eq 0 ]]; then
-			log "ERROR" "Mode required (light|dark)"
-			log "" "Usage: $(basename "$0") color-scheme <light|dark>"
-			exit 1
-		fi
-		cmd_color_scheme "${cmd_args[0]}"
-		;;
-	"detect" | "analyze")
-		cmd_detect "${cmd_args[@]}"
-		;;
-	"theme" | "t")
-		cmd_theme_pack "${cmd_args[@]}"
-		;;
-	"auto" | "automatic")
-		cmd_auto
-		;;
-	"icons" | "icon")
-		cmd_icons "${cmd_args[@]}"
-		;;
-	"info" | "show")
-		if [[ ${#cmd_args[@]} -eq 0 ]]; then
-			log "ERROR" "Theme name required for info command"
-			log "" "Usage: $(basename "$0") info <theme-name>"
-			exit 1
-		fi
-		cmd_info "${cmd_args[0]}"
-		;;
-	*)
-		log "ERROR" "Unknown command '$command'"
-		log "" "Use --help for available commands"
-		exit 1
-		;;
-	esac
+  case "$command" in
+    "list" | "ls")
+      cmd_list "${cmd_args[@]}"
+      ;;
+    "current" | "status")
+      cmd_current "${cmd_args[@]}"
+      ;;
+    "current-icon" | "current-icons" | "icon-current")
+      cmd_current_icon "${cmd_args[@]}"
+      ;;
+    "apply" | "set")
+      if [[ ${#cmd_args[@]} -eq 0 ]]; then
+        log "ERROR" "Theme name required for apply command"
+        log "" "Usage: $(basename "$0") apply <theme-name> [icon-theme] [prefer-dark]"
+        exit 1
+      fi
+      cmd_apply "${cmd_args[@]}"
+      ;;
+    "set-icons" | "set-icon")
+      if [[ ${#cmd_args[@]} -eq 0 ]]; then
+        log "ERROR" "Icon theme name required"
+        log "" "Usage: $(basename "$0") set-icons <icon-theme>"
+        exit 1
+      fi
+      cmd_set_icons "${cmd_args[0]}"
+      ;;
+    "color-scheme" | "scheme")
+      if [[ ${#cmd_args[@]} -eq 0 ]]; then
+        log "ERROR" "Mode required (light|dark)"
+        log "" "Usage: $(basename "$0") color-scheme <light|dark>"
+        exit 1
+      fi
+      cmd_color_scheme "${cmd_args[0]}"
+      ;;
+    "detect" | "analyze")
+      cmd_detect "${cmd_args[@]}"
+      ;;
+    "theme" | "t")
+      cmd_theme_pack "${cmd_args[@]}"
+      ;;
+    "auto" | "automatic")
+      cmd_auto
+      ;;
+    "icons" | "icon")
+      cmd_icons "${cmd_args[@]}"
+      ;;
+    "info" | "show")
+      if [[ ${#cmd_args[@]} -eq 0 ]]; then
+        log "ERROR" "Theme name required for info command"
+        log "" "Usage: $(basename "$0") info <theme-name>"
+        exit 1
+      fi
+      cmd_info "${cmd_args[0]}"
+      ;;
+    *)
+      log "ERROR" "Unknown command '$command'"
+      log "" "Use --help for available commands"
+      exit 1
+      ;;
+  esac
 }
 
 # Run main function

--- a/home/dot_local/bin/executable_dots-gtk-theme
+++ b/home/dot_local/bin/executable_dots-gtk-theme
@@ -357,6 +357,14 @@ cmd_icons() {
 		fi
 	done
 
+	if ((${#icons[@]} == 0)); then
+		if [[ $use_plain == true ]]; then
+			return 1
+		fi
+		echo -e "${YELLOW}⚠️  No icon themes found${NC}"
+		return 1
+	fi
+
 	local unique_icons
 	unique_icons=$(printf '%s\n' "${icons[@]}" | sort -u)
 

--- a/home/dot_local/bin/executable_dots-theme-selector
+++ b/home/dot_local/bin/executable_dots-theme-selector
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-## Copyright (C) 2019-2025 Ulises Jeremias Cornejo Fandos
+## Copyright (C) 2019-2026 Ulises Jeremias Cornejo Fandos
 ## Licensed under MIT.
 ##
 ## Program: dots-theme-selector
-## Description: GTK theme selector for Quickshell-first setup
+## Description: GTK theme selector (opens Appearance CC when Quickshell is up)
 ##
 ## Usage: dots-theme-selector [OPTIONS]
 ##
@@ -12,10 +12,10 @@
 ##   -h, --help          Show this help message
 ##
 ## Examples:
-##   dots-theme-selector             # Launch theme selector (terminal picker)
+##   dots-theme-selector             # Launch theme selector
 ##
 ## Notes:
-##   Scans ~/.themes and /usr/share/themes for available themes
+##   Uses dots-gtk-theme as the canonical apply path.
 
 set -euo pipefail
 
@@ -25,18 +25,13 @@ if pgrep -x quickshell >/dev/null 2>&1; then
   exec ~/.local/bin/dots-settings-gui --pane=appearance menu
 fi
 
-# Minimal list-based selector for GTK theme
-THEMES=$( (
-  ls -1 ~/.themes 2>/dev/null
-  ls -1 /usr/share/themes 2>/dev/null
-) | sort -u) || true
-if [[ -z ${THEMES} ]]; then
-  notify-send "Themes" "No themes found in ~/.themes or /usr/share/themes"
+# Terminal fallback — list via dots-gtk-theme, apply via dots-gtk-theme.
+mapfile -t THEME_LIST < <(dots-gtk-theme -q -p list 2>/dev/null || true)
+if [[ ${#THEME_LIST[@]} -eq 0 ]]; then
+  notify-send "Themes" "No GTK themes found"
   exit 1
 fi
 
-mapfile -t THEME_LIST < <(printf '%s\n' "$THEMES" | awk 'NF')
-[[ ${#THEME_LIST[@]} -eq 0 ]] && exit 1
 echo "GTK themes:"
 i=1
 for t in "${THEME_LIST[@]}"; do
@@ -46,13 +41,14 @@ done
 printf "Select theme [1-%d, empty to cancel]: " "${#THEME_LIST[@]}"
 read -r idx || exit 1
 [[ -z ${idx:-} ]] && exit 0
-[[ "$idx" =~ ^[0-9]+$ ]] || exit 1
-(( idx >= 1 && idx <= ${#THEME_LIST[@]} )) || exit 1
+[[ $idx =~ ^[0-9]+$ ]] || exit 1
+((idx >= 1 && idx <= ${#THEME_LIST[@]})) || exit 1
 SELECTED="${THEME_LIST[$((idx - 1))]}"
 [[ -z $SELECTED ]] && exit 0
 
-gsettings set org.gnome.desktop.interface gtk-theme "$SELECTED" || {
+if dots-gtk-theme -q apply "$SELECTED"; then
+  notify-send "Theme" "Applied $SELECTED"
+else
   notify-send "Theme" "Failed to apply $SELECTED"
   exit 1
-}
-notify-send "Theme" "Applied $SELECTED"
+fi

--- a/home/dot_local/bin/executable_dots-theme-selector
+++ b/home/dot_local/bin/executable_dots-theme-selector
@@ -22,21 +22,21 @@ set -euo pipefail
 source ~/.local/lib/dots/easy-options/easyoptions.sh || exit
 
 if pgrep -x quickshell >/dev/null 2>&1; then
-  exec ~/.local/bin/dots-settings-gui --pane=appearance menu
+	exec ~/.local/bin/dots-settings-gui --pane=appearance menu
 fi
 
 # Terminal fallback — list via dots-gtk-theme, apply via dots-gtk-theme.
 mapfile -t THEME_LIST < <(dots-gtk-theme -q -p list 2>/dev/null || true)
 if [[ ${#THEME_LIST[@]} -eq 0 ]]; then
-  notify-send "Themes" "No GTK themes found"
-  exit 1
+	notify-send "Themes" "No GTK themes found"
+	exit 1
 fi
 
 echo "GTK themes:"
 i=1
 for t in "${THEME_LIST[@]}"; do
-  printf "%2d) %s\n" "$i" "$t"
-  i=$((i + 1))
+	printf "%2d) %s\n" "$i" "$t"
+	i=$((i + 1))
 done
 printf "Select theme [1-%d, empty to cancel]: " "${#THEME_LIST[@]}"
 read -r idx || exit 1
@@ -47,8 +47,8 @@ SELECTED="${THEME_LIST[$((idx - 1))]}"
 [[ -z $SELECTED ]] && exit 0
 
 if dots-gtk-theme -q apply "$SELECTED"; then
-  notify-send "Theme" "Applied $SELECTED"
+	notify-send "Theme" "Applied $SELECTED"
 else
-  notify-send "Theme" "Failed to apply $SELECTED"
-  exit 1
+	notify-send "Theme" "Failed to apply $SELECTED"
+	exit 1
 fi

--- a/home/dot_local/bin/executable_dots-wal-reload
+++ b/home/dot_local/bin/executable_dots-wal-reload
@@ -9,31 +9,31 @@
 set -euo pipefail
 
 if pgrep -x quickshell >/dev/null 2>&1; then
-  if quickshell ipc call appearance reload >/dev/null 2>&1; then
-    busy=""
-    for _i in $(seq 1 120); do
-      if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
-        echo "Error: could not read appearance job status via Quickshell IPC" >&2
-        exit 1
-      fi
-      busy="${busy//$'\r'/}"
-      busy="${busy//$'\n'/}"
-      [[ $busy == "1" ]] || break
-      sleep 0.5
-    done
-    if [[ $busy == "1" ]]; then
-      echo "Error: appearance reload timed out" >&2
-      exit 1
-    fi
-    last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
-    last_error="${last_error//$'\r'/}"
-    last_error="${last_error//$'\n'/}"
-    if [[ -n $last_error ]]; then
-      echo "Error: appearance reload failed: $last_error" >&2
-      exit 1
-    fi
-    exit 0
-  fi
+	if quickshell ipc call appearance reload >/dev/null 2>&1; then
+		busy=""
+		for _i in $(seq 1 120); do
+			if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
+				echo "Error: could not read appearance job status via Quickshell IPC" >&2
+				exit 1
+			fi
+			busy="${busy//$'\r'/}"
+			busy="${busy//$'\n'/}"
+			[[ $busy == "1" ]] || break
+			sleep 0.5
+		done
+		if [[ $busy == "1" ]]; then
+			echo "Error: appearance reload timed out" >&2
+			exit 1
+		fi
+		last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
+		last_error="${last_error//$'\r'/}"
+		last_error="${last_error//$'\n'/}"
+		if [[ -n $last_error ]]; then
+			echo "Error: appearance reload failed: $last_error" >&2
+			exit 1
+		fi
+		exit 0
+	fi
 fi
 
 # Fallback: direct wal reload + M3 from live state prefs
@@ -44,48 +44,48 @@ STATE_JSON="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
 
 wallpaper=""
 if [[ -f $WALL_POINTER ]]; then
-  wallpaper="$(head -n 1 "$WALL_POINTER" 2>/dev/null | tr -d '\r' || true)"
+	wallpaper="$(head -n 1 "$WALL_POINTER" 2>/dev/null | tr -d '\r' || true)"
 fi
 
 if command -v wal >/dev/null 2>&1; then
-  wal -R -q 2>/dev/null || true
+	wal -R -q 2>/dev/null || true
 fi
 
 # wal -R may recreate ~/.cache/wal/wal as an image symlink; writers that
 # echo into that path would truncate the wallpaper. Keep a text path file.
 if [[ -n ${wallpaper:-} && -f $wallpaper ]]; then
-  mkdir -p "$HOME/.cache/wal"
-  rm -f "$HOME/.cache/wal/wal"
-  printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
+	mkdir -p "$HOME/.cache/wal"
+	rm -f "$HOME/.cache/wal/wal"
+	printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
 fi
 
 mode="dark"
 flavour="tonal-spot"
 if [[ -f $STATE_JSON ]]; then
-  mode="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('mode','dark'))" 2>/dev/null || echo dark)"
-  flavour="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('flavour','tonal-spot'))" 2>/dev/null || echo tonal-spot)"
+	mode="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('mode','dark'))" 2>/dev/null || echo dark)"
+	flavour="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('flavour','tonal-spot'))" 2>/dev/null || echo tonal-spot)"
 fi
 [[ $mode == "light" || $mode == "dark" ]] || mode="dark"
 
 if [[ -n ${wallpaper:-} && -f $wallpaper && -f $M3_SCRIPT ]] && command -v python3 >/dev/null 2>&1; then
-  python3 "$M3_SCRIPT" \
-    --image "$wallpaper" \
-    --scheme-type "$flavour" \
-    --mode "$mode" \
-    --output "$SCHEME_JSON" 2>/dev/null || true
-  if command -v dots-color-scheme >/dev/null 2>&1; then
-    dots-color-scheme sync-state >/dev/null 2>&1 || true
-  fi
-  if [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
-    # shellcheck source=/dev/null
-    source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
-    if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
-      apply_gtk_color_scheme "$mode" >/dev/null 2>&1 || true
-    fi
-  elif command -v dots-gtk-theme >/dev/null 2>&1; then
-    dots-gtk-theme -q color-scheme "$mode" >/dev/null 2>&1 || true
-  fi
-  if command -v dots-hyprlock-theme >/dev/null 2>&1; then
-    dots-hyprlock-theme >/dev/null 2>&1 || true
-  fi
+	python3 "$M3_SCRIPT" \
+		--image "$wallpaper" \
+		--scheme-type "$flavour" \
+		--mode "$mode" \
+		--output "$SCHEME_JSON" 2>/dev/null || true
+	if command -v dots-color-scheme >/dev/null 2>&1; then
+		dots-color-scheme sync-state >/dev/null 2>&1 || true
+	fi
+	if [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
+		# shellcheck source=/dev/null
+		source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
+		if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
+			apply_gtk_color_scheme "$mode" >/dev/null 2>&1 || true
+		fi
+	elif command -v dots-gtk-theme >/dev/null 2>&1; then
+		dots-gtk-theme -q color-scheme "$mode" >/dev/null 2>&1 || true
+	fi
+	if command -v dots-hyprlock-theme >/dev/null 2>&1; then
+		dots-hyprlock-theme >/dev/null 2>&1 || true
+	fi
 fi

--- a/home/dot_local/bin/executable_dots-wal-reload
+++ b/home/dot_local/bin/executable_dots-wal-reload
@@ -9,31 +9,31 @@
 set -euo pipefail
 
 if pgrep -x quickshell >/dev/null 2>&1; then
-  if quickshell ipc call appearance reload >/dev/null 2>&1; then
-    busy=""
-    for _i in $(seq 1 120); do
-      if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
-        echo "Error: could not read appearance job status via Quickshell IPC" >&2
-        exit 1
-      fi
-      busy="${busy//$'\r'/}"
-      busy="${busy//$'\n'/}"
-      [[ $busy == "1" ]] || break
-      sleep 0.5
-    done
-    if [[ $busy == "1" ]]; then
-      echo "Error: appearance reload timed out" >&2
-      exit 1
-    fi
-    last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
-    last_error="${last_error//$'\r'/}"
-    last_error="${last_error//$'\n'/}"
-    if [[ -n $last_error ]]; then
-      echo "Error: appearance reload failed: $last_error" >&2
-      exit 1
-    fi
-    exit 0
-  fi
+	if quickshell ipc call appearance reload >/dev/null 2>&1; then
+		busy=""
+		for _i in $(seq 1 120); do
+			if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
+				echo "Error: could not read appearance job status via Quickshell IPC" >&2
+				exit 1
+			fi
+			busy="${busy//$'\r'/}"
+			busy="${busy//$'\n'/}"
+			[[ $busy == "1" ]] || break
+			sleep 0.5
+		done
+		if [[ $busy == "1" ]]; then
+			echo "Error: appearance reload timed out" >&2
+			exit 1
+		fi
+		last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
+		last_error="${last_error//$'\r'/}"
+		last_error="${last_error//$'\n'/}"
+		if [[ -n $last_error ]]; then
+			echo "Error: appearance reload failed: $last_error" >&2
+			exit 1
+		fi
+		exit 0
+	fi
 fi
 
 # Fallback: direct wal reload + M3 from live state prefs
@@ -44,48 +44,48 @@ STATE_JSON="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
 
 wallpaper=""
 if [[ -f $WALL_POINTER ]]; then
-  wallpaper="$(head -n 1 "$WALL_POINTER" 2>/dev/null | tr -d '\r' || true)"
+	wallpaper="$(head -n 1 "$WALL_POINTER" 2>/dev/null | tr -d '\r' || true)"
 fi
 
 if command -v wal >/dev/null 2>&1; then
-  wal -R -q 2>/dev/null || true
+	wal -R -q 2>/dev/null || true
 fi
 
 # wal -R may recreate ~/.cache/wal/wal as an image symlink; writers that
 # echo into that path would truncate the wallpaper. Keep a text path file.
 if [[ -n ${wallpaper:-} && -f $wallpaper ]]; then
-  mkdir -p "$HOME/.cache/wal"
-  rm -f "$HOME/.cache/wal/wal"
-  printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
+	mkdir -p "$HOME/.cache/wal"
+	rm -f "$HOME/.cache/wal/wal"
+	printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
 fi
 
 mode="dark"
 flavour="tonal-spot"
 if [[ -f $STATE_JSON ]]; then
-  mode="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('mode','dark'))" 2>/dev/null || echo dark)"
-  flavour="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('flavour','tonal-spot'))" 2>/dev/null || echo tonal-spot)"
+	mode="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('mode','dark'))" 2>/dev/null || echo dark)"
+	flavour="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('flavour','tonal-spot'))" 2>/dev/null || echo tonal-spot)"
 fi
 [[ $mode == "light" || $mode == "dark" ]] || mode="dark"
 
 if [[ -n ${wallpaper:-} && -f $wallpaper && -f $M3_SCRIPT ]] && command -v python3 >/dev/null 2>&1; then
-  python3 "$M3_SCRIPT" \
-    --image "$wallpaper" \
-    --scheme-type "$flavour" \
-    --mode "$mode" \
-    --output "$SCHEME_JSON" 2>/dev/null || true
-  if command -v dots-color-scheme >/dev/null 2>&1; then
-    dots-color-scheme sync-state >/dev/null 2>&1 || true
-  fi
-  if command -v dots-gtk-theme >/dev/null 2>&1; then
-    dots-gtk-theme -q color-scheme "$mode" >/dev/null 2>&1 || true
-  elif [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
-    # shellcheck source=/dev/null
-    source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
-    if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
-      apply_gtk_color_scheme "$mode" >/dev/null 2>&1 || true
-    fi
-  fi
-  if command -v dots-hyprlock-theme >/dev/null 2>&1; then
-    dots-hyprlock-theme >/dev/null 2>&1 || true
-  fi
+	python3 "$M3_SCRIPT" \
+		--image "$wallpaper" \
+		--scheme-type "$flavour" \
+		--mode "$mode" \
+		--output "$SCHEME_JSON" 2>/dev/null || true
+	if command -v dots-color-scheme >/dev/null 2>&1; then
+		dots-color-scheme sync-state >/dev/null 2>&1 || true
+	fi
+	if command -v dots-gtk-theme >/dev/null 2>&1; then
+		dots-gtk-theme -q color-scheme "$mode" >/dev/null 2>&1 || true
+	elif [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
+		# shellcheck source=/dev/null
+		source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
+		if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
+			apply_gtk_color_scheme "$mode" >/dev/null 2>&1 || true
+		fi
+	fi
+	if command -v dots-hyprlock-theme >/dev/null 2>&1; then
+		dots-hyprlock-theme >/dev/null 2>&1 || true
+	fi
 fi

--- a/home/dot_local/bin/executable_dots-wal-reload
+++ b/home/dot_local/bin/executable_dots-wal-reload
@@ -9,31 +9,31 @@
 set -euo pipefail
 
 if pgrep -x quickshell >/dev/null 2>&1; then
-	if quickshell ipc call appearance reload >/dev/null 2>&1; then
-		busy=""
-		for _i in $(seq 1 120); do
-			if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
-				echo "Error: could not read appearance job status via Quickshell IPC" >&2
-				exit 1
-			fi
-			busy="${busy//$'\r'/}"
-			busy="${busy//$'\n'/}"
-			[[ $busy == "1" ]] || break
-			sleep 0.5
-		done
-		if [[ $busy == "1" ]]; then
-			echo "Error: appearance reload timed out" >&2
-			exit 1
-		fi
-		last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
-		last_error="${last_error//$'\r'/}"
-		last_error="${last_error//$'\n'/}"
-		if [[ -n $last_error ]]; then
-			echo "Error: appearance reload failed: $last_error" >&2
-			exit 1
-		fi
-		exit 0
-	fi
+  if quickshell ipc call appearance reload >/dev/null 2>&1; then
+    busy=""
+    for _i in $(seq 1 120); do
+      if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
+        echo "Error: could not read appearance job status via Quickshell IPC" >&2
+        exit 1
+      fi
+      busy="${busy//$'\r'/}"
+      busy="${busy//$'\n'/}"
+      [[ $busy == "1" ]] || break
+      sleep 0.5
+    done
+    if [[ $busy == "1" ]]; then
+      echo "Error: appearance reload timed out" >&2
+      exit 1
+    fi
+    last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
+    last_error="${last_error//$'\r'/}"
+    last_error="${last_error//$'\n'/}"
+    if [[ -n $last_error ]]; then
+      echo "Error: appearance reload failed: $last_error" >&2
+      exit 1
+    fi
+    exit 0
+  fi
 fi
 
 # Fallback: direct wal reload + M3 from live state prefs
@@ -44,46 +44,48 @@ STATE_JSON="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
 
 wallpaper=""
 if [[ -f $WALL_POINTER ]]; then
-	wallpaper="$(head -n 1 "$WALL_POINTER" 2>/dev/null | tr -d '\r' || true)"
+  wallpaper="$(head -n 1 "$WALL_POINTER" 2>/dev/null | tr -d '\r' || true)"
 fi
 
 if command -v wal >/dev/null 2>&1; then
-	wal -R -q 2>/dev/null || true
+  wal -R -q 2>/dev/null || true
 fi
 
 # wal -R may recreate ~/.cache/wal/wal as an image symlink; writers that
 # echo into that path would truncate the wallpaper. Keep a text path file.
 if [[ -n ${wallpaper:-} && -f $wallpaper ]]; then
-	mkdir -p "$HOME/.cache/wal"
-	rm -f "$HOME/.cache/wal/wal"
-	printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
+  mkdir -p "$HOME/.cache/wal"
+  rm -f "$HOME/.cache/wal/wal"
+  printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
 fi
 
 mode="dark"
 flavour="tonal-spot"
 if [[ -f $STATE_JSON ]]; then
-	mode="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('mode','dark'))" 2>/dev/null || echo dark)"
-	flavour="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('flavour','tonal-spot'))" 2>/dev/null || echo tonal-spot)"
+  mode="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('mode','dark'))" 2>/dev/null || echo dark)"
+  flavour="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('flavour','tonal-spot'))" 2>/dev/null || echo tonal-spot)"
 fi
 [[ $mode == "light" || $mode == "dark" ]] || mode="dark"
 
 if [[ -n ${wallpaper:-} && -f $wallpaper && -f $M3_SCRIPT ]] && command -v python3 >/dev/null 2>&1; then
-	python3 "$M3_SCRIPT" \
-		--image "$wallpaper" \
-		--scheme-type "$flavour" \
-		--mode "$mode" \
-		--output "$SCHEME_JSON" 2>/dev/null || true
-	if command -v dots-color-scheme >/dev/null 2>&1; then
-		dots-color-scheme sync-state >/dev/null 2>&1 || true
-	fi
-	if [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
-		# shellcheck source=/dev/null
-		source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
-		if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
-			apply_gtk_color_scheme "$mode" >/dev/null 2>&1 || true
-		fi
-	fi
-	if command -v dots-hyprlock-theme >/dev/null 2>&1; then
-		dots-hyprlock-theme >/dev/null 2>&1 || true
-	fi
+  python3 "$M3_SCRIPT" \
+    --image "$wallpaper" \
+    --scheme-type "$flavour" \
+    --mode "$mode" \
+    --output "$SCHEME_JSON" 2>/dev/null || true
+  if command -v dots-color-scheme >/dev/null 2>&1; then
+    dots-color-scheme sync-state >/dev/null 2>&1 || true
+  fi
+  if [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
+    if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
+      apply_gtk_color_scheme "$mode" >/dev/null 2>&1 || true
+    fi
+  elif command -v dots-gtk-theme >/dev/null 2>&1; then
+    dots-gtk-theme -q color-scheme "$mode" >/dev/null 2>&1 || true
+  fi
+  if command -v dots-hyprlock-theme >/dev/null 2>&1; then
+    dots-hyprlock-theme >/dev/null 2>&1 || true
+  fi
 fi

--- a/home/dot_local/bin/executable_dots-wal-reload
+++ b/home/dot_local/bin/executable_dots-wal-reload
@@ -9,31 +9,31 @@
 set -euo pipefail
 
 if pgrep -x quickshell >/dev/null 2>&1; then
-	if quickshell ipc call appearance reload >/dev/null 2>&1; then
-		busy=""
-		for _i in $(seq 1 120); do
-			if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
-				echo "Error: could not read appearance job status via Quickshell IPC" >&2
-				exit 1
-			fi
-			busy="${busy//$'\r'/}"
-			busy="${busy//$'\n'/}"
-			[[ $busy == "1" ]] || break
-			sleep 0.5
-		done
-		if [[ $busy == "1" ]]; then
-			echo "Error: appearance reload timed out" >&2
-			exit 1
-		fi
-		last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
-		last_error="${last_error//$'\r'/}"
-		last_error="${last_error//$'\n'/}"
-		if [[ -n $last_error ]]; then
-			echo "Error: appearance reload failed: $last_error" >&2
-			exit 1
-		fi
-		exit 0
-	fi
+  if quickshell ipc call appearance reload >/dev/null 2>&1; then
+    busy=""
+    for _i in $(seq 1 120); do
+      if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
+        echo "Error: could not read appearance job status via Quickshell IPC" >&2
+        exit 1
+      fi
+      busy="${busy//$'\r'/}"
+      busy="${busy//$'\n'/}"
+      [[ $busy == "1" ]] || break
+      sleep 0.5
+    done
+    if [[ $busy == "1" ]]; then
+      echo "Error: appearance reload timed out" >&2
+      exit 1
+    fi
+    last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
+    last_error="${last_error//$'\r'/}"
+    last_error="${last_error//$'\n'/}"
+    if [[ -n $last_error ]]; then
+      echo "Error: appearance reload failed: $last_error" >&2
+      exit 1
+    fi
+    exit 0
+  fi
 fi
 
 # Fallback: direct wal reload + M3 from live state prefs
@@ -44,48 +44,48 @@ STATE_JSON="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
 
 wallpaper=""
 if [[ -f $WALL_POINTER ]]; then
-	wallpaper="$(head -n 1 "$WALL_POINTER" 2>/dev/null | tr -d '\r' || true)"
+  wallpaper="$(head -n 1 "$WALL_POINTER" 2>/dev/null | tr -d '\r' || true)"
 fi
 
 if command -v wal >/dev/null 2>&1; then
-	wal -R -q 2>/dev/null || true
+  wal -R -q 2>/dev/null || true
 fi
 
 # wal -R may recreate ~/.cache/wal/wal as an image symlink; writers that
 # echo into that path would truncate the wallpaper. Keep a text path file.
 if [[ -n ${wallpaper:-} && -f $wallpaper ]]; then
-	mkdir -p "$HOME/.cache/wal"
-	rm -f "$HOME/.cache/wal/wal"
-	printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
+  mkdir -p "$HOME/.cache/wal"
+  rm -f "$HOME/.cache/wal/wal"
+  printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
 fi
 
 mode="dark"
 flavour="tonal-spot"
 if [[ -f $STATE_JSON ]]; then
-	mode="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('mode','dark'))" 2>/dev/null || echo dark)"
-	flavour="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('flavour','tonal-spot'))" 2>/dev/null || echo tonal-spot)"
+  mode="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('mode','dark'))" 2>/dev/null || echo dark)"
+  flavour="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('flavour','tonal-spot'))" 2>/dev/null || echo tonal-spot)"
 fi
 [[ $mode == "light" || $mode == "dark" ]] || mode="dark"
 
 if [[ -n ${wallpaper:-} && -f $wallpaper && -f $M3_SCRIPT ]] && command -v python3 >/dev/null 2>&1; then
-	python3 "$M3_SCRIPT" \
-		--image "$wallpaper" \
-		--scheme-type "$flavour" \
-		--mode "$mode" \
-		--output "$SCHEME_JSON" 2>/dev/null || true
-	if command -v dots-color-scheme >/dev/null 2>&1; then
-		dots-color-scheme sync-state >/dev/null 2>&1 || true
-	fi
-	if [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
-		# shellcheck source=/dev/null
-		source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
-		if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
-			apply_gtk_color_scheme "$mode" >/dev/null 2>&1 || true
-		fi
-	elif command -v dots-gtk-theme >/dev/null 2>&1; then
-		dots-gtk-theme -q color-scheme "$mode" >/dev/null 2>&1 || true
-	fi
-	if command -v dots-hyprlock-theme >/dev/null 2>&1; then
-		dots-hyprlock-theme >/dev/null 2>&1 || true
-	fi
+  python3 "$M3_SCRIPT" \
+    --image "$wallpaper" \
+    --scheme-type "$flavour" \
+    --mode "$mode" \
+    --output "$SCHEME_JSON" 2>/dev/null || true
+  if command -v dots-color-scheme >/dev/null 2>&1; then
+    dots-color-scheme sync-state >/dev/null 2>&1 || true
+  fi
+  if command -v dots-gtk-theme >/dev/null 2>&1; then
+    dots-gtk-theme -q color-scheme "$mode" >/dev/null 2>&1 || true
+  elif [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
+    if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
+      apply_gtk_color_scheme "$mode" >/dev/null 2>&1 || true
+    fi
+  fi
+  if command -v dots-hyprlock-theme >/dev/null 2>&1; then
+    dots-hyprlock-theme >/dev/null 2>&1 || true
+  fi
 fi

--- a/home/dot_local/lib/dots/apply-appearance.sh
+++ b/home/dot_local/lib/dots/apply-appearance.sh
@@ -12,8 +12,8 @@ DOTS_M3_SCRIPT="${DOTS_M3_SCRIPT:-$HOME/.local/lib/dots/generate-m3-colors.py}"
 DOTS_PICTURES_WALLPAPERS="${DOTS_PICTURES_WALLPAPERS:-$HOME/Pictures/Wallpapers}"
 
 _dots_aa_json_get() {
-  local file="$1" key="$2" default="${3:-}"
-  python3 - "$file" "$key" "$default" <<'PY'
+	local file="$1" key="$2" default="${3:-}"
+	python3 - "$file" "$key" "$default" << 'PY'
 import json, sys
 path, key, default = sys.argv[1], sys.argv[2], sys.argv[3]
 try:
@@ -33,254 +33,254 @@ PY
 }
 
 _dots_aa_write_pointer() {
-  local path="$1"
-  mkdir -p "$(dirname "$DOTS_WALLPAPER_POINTER_FILE")"
-  printf '%s\n' "$path" >"$DOTS_WALLPAPER_POINTER_FILE"
+	local path="$1"
+	mkdir -p "$(dirname "$DOTS_WALLPAPER_POINTER_FILE")"
+	printf '%s\n' "$path" > "$DOTS_WALLPAPER_POINTER_FILE"
 }
 
 _dots_aa_normalize_scheme_type() {
-  local raw="${1:-tonal-spot}"
-  raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
-  case "$raw" in
-    vibrant | expressive | fidelity | content | neutral | monochrome) printf '%s\n' "$raw" ;;
-    tonalspot | tonal-spot) printf 'tonal-spot\n' ;;
-    *) printf 'tonal-spot\n' ;;
-  esac
+	local raw="${1:-tonal-spot}"
+	raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
+	case "$raw" in
+		vibrant | expressive | fidelity | content | neutral | monochrome) printf '%s\n' "$raw" ;;
+		tonalspot | tonal-spot) printf 'tonal-spot\n' ;;
+		*) printf 'tonal-spot\n' ;;
+	esac
 }
 
 # Resolve gtk-application-prefer-dark independently of shell darkMode when possible.
 # Priority: theme.json gtkPreferDark → Light/Dark in gtk theme name → shell mode.
 _dots_aa_resolve_gtk_prefer() {
-  local config_json="${1:-}"
-  local dark_mode="${2:-dark}"
-  local gtk_theme="${3:-}"
-  local explicit=""
+	local config_json="${1:-}"
+	local dark_mode="${2:-dark}"
+	local gtk_theme="${3:-}"
+	local explicit=""
 
-  if [[ -n $config_json && -f $config_json ]]; then
-    explicit="$(_dots_aa_json_get "$config_json" gtkPreferDark "")"
-  fi
-  case "$explicit" in
-    true | false)
-      printf '%s\n' "$explicit"
-      return 0
-      ;;
-  esac
+	if [[ -n $config_json && -f $config_json ]]; then
+		explicit="$(_dots_aa_json_get "$config_json" gtkPreferDark "")"
+	fi
+	case "$explicit" in
+		true | false)
+			printf '%s\n' "$explicit"
+			return 0
+			;;
+	esac
 
-  local gtk_lc
-  gtk_lc=$(printf '%s' "$gtk_theme" | tr '[:upper:]' '[:lower:]')
-  case "$gtk_lc" in
-    *light*)
-      printf 'false\n'
-      ;;
-    *dark*)
-      printf 'true\n'
-      ;;
-    *)
-      if [[ $dark_mode == "light" ]]; then
-        printf 'false\n'
-      else
-        printf 'true\n'
-      fi
-      ;;
-  esac
+	local gtk_lc
+	gtk_lc=$(printf '%s' "$gtk_theme" | tr '[:upper:]' '[:lower:]')
+	case "$gtk_lc" in
+		*light*)
+			printf 'false\n'
+			;;
+		*dark*)
+			printf 'true\n'
+			;;
+		*)
+			if [[ $dark_mode == "light" ]]; then
+				printf 'false\n'
+			else
+				printf 'true\n'
+			fi
+			;;
+	esac
 }
 
 _dots_aa_resolve_theme_wallpaper() {
-  local theme_id="$1"
-  local wallpaper_dir="$2"
-  local default_name="$3"
-  local override="${4:-}"
-  local candidate=""
+	local theme_id="$1"
+	local wallpaper_dir="$2"
+	local default_name="$3"
+	local override="${4:-}"
+	local candidate=""
 
-  if [[ -n $override ]]; then
-    candidate="$(readlink -f "$override" 2>/dev/null || true)"
-    [[ -n ${candidate:-} && -f $candidate ]] && {
-      printf '%s\n' "$candidate"
-      return 0
-    }
-  fi
+	if [[ -n $override ]]; then
+		candidate="$(readlink -f "$override" 2> /dev/null || true)"
+		[[ -n ${candidate:-} && -f $candidate ]] && {
+			printf '%s\n' "$candidate"
+			return 0
+		}
+	fi
 
-  for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
-    if [[ -n $default_name && -f $base/$default_name ]]; then
-      readlink -f "$base/$default_name"
-      return 0
-    fi
-  done
+	for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
+		if [[ -n $default_name && -f $base/$default_name ]]; then
+			readlink -f "$base/$default_name"
+			return 0
+		fi
+	done
 
-  for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
-    [[ -d $base ]] || continue
-    candidate="$(
-      find -L "$base" -maxdepth 1 \( -type f -o -type l \) \
-        \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" \
-        -o -iname "*.gif" -o -iname "*.bmp" \) 2>/dev/null | sort | head -n 1 || true
-    )"
-    [[ -n ${candidate:-} && -f $candidate ]] && {
-      printf '%s\n' "$candidate"
-      return 0
-    }
-  done
-  return 1
+	for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
+		[[ -d $base ]] || continue
+		candidate="$(
+			find -L "$base" -maxdepth 1 \( -type f -o -type l \) \
+				\( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" \
+				-o -iname "*.gif" -o -iname "*.bmp" \) 2> /dev/null | sort | head -n 1 || true
+		)"
+		[[ -n ${candidate:-} && -f $candidate ]] && {
+			printf '%s\n' "$candidate"
+			return 0
+		}
+	done
+	return 1
 }
 
 _dots_aa_sync_gtk_color_scheme() {
-  local mode="${1:-dark}"
-  if command -v dots-gtk-theme >/dev/null 2>&1; then
-    dots-gtk-theme -q color-scheme "$mode" >/dev/null 2>&1 || true
-  elif [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
-    # shellcheck source=/dev/null
-    source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
-    if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
-      apply_gtk_color_scheme "$mode" >/dev/null 2>&1 || true
-    fi
-  fi
+	local mode="${1:-dark}"
+	if command -v dots-gtk-theme > /dev/null 2>&1; then
+		dots-gtk-theme -q color-scheme "$mode" > /dev/null 2>&1 || true
+	elif [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
+		# shellcheck source=/dev/null
+		source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2> /dev/null || true
+		if declare -f apply_gtk_color_scheme > /dev/null 2>&1; then
+			apply_gtk_color_scheme "$mode" > /dev/null 2>&1 || true
+		fi
+	fi
 }
 
 _dots_aa_run_palette() {
-  local wallpaper="$1"
-  local scheme_type="$2"
-  local dark_mode="$3"
+	local wallpaper="$1"
+	local scheme_type="$2"
+	local dark_mode="$3"
 
-  if ! command -v wal >/dev/null 2>&1; then
-    echo "apply-appearance: wal not found" >&2
-    return 1
-  fi
-  # Drop any prior wal→image symlink before wal runs; echoing a path through
-  # that symlink would truncate the wallpaper file itself.
-  mkdir -p "$HOME/.cache/wal"
-  rm -f "$HOME/.cache/wal/wal"
-  if [[ $dark_mode == "light" ]]; then
-    wal -i "$wallpaper" -q -l || return 1
-  else
-    wal -i "$wallpaper" -q || return 1
-  fi
+	if ! command -v wal > /dev/null 2>&1; then
+		echo "apply-appearance: wal not found" >&2
+		return 1
+	fi
+	# Drop any prior wal→image symlink before wal runs; echoing a path through
+	# that symlink would truncate the wallpaper file itself.
+	mkdir -p "$HOME/.cache/wal"
+	rm -f "$HOME/.cache/wal/wal"
+	if [[ $dark_mode == "light" ]]; then
+		wal -i "$wallpaper" -q -l || return 1
+	else
+		wal -i "$wallpaper" -q || return 1
+	fi
 
-  _dots_aa_write_pointer "$wallpaper"
-  rm -f "$HOME/.cache/wal/wal"
-  printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
+	_dots_aa_write_pointer "$wallpaper"
+	rm -f "$HOME/.cache/wal/wal"
+	printf '%s\n' "$wallpaper" > "$HOME/.cache/wal/wal"
 
-  [[ -f $DOTS_M3_SCRIPT ]] || {
-    echo "apply-appearance: missing generate-m3-colors.py" >&2
-    return 1
-  }
-  mkdir -p "$(dirname "$DOTS_SCHEME_FILE")"
-  python3 "$DOTS_M3_SCRIPT" \
-    --image "$wallpaper" \
-    --scheme-type "$scheme_type" \
-    --mode "$dark_mode" \
-    --output "$DOTS_SCHEME_FILE" || return 1
+	[[ -f $DOTS_M3_SCRIPT ]] || {
+		echo "apply-appearance: missing generate-m3-colors.py" >&2
+		return 1
+	}
+	mkdir -p "$(dirname "$DOTS_SCHEME_FILE")"
+	python3 "$DOTS_M3_SCRIPT" \
+		--image "$wallpaper" \
+		--scheme-type "$scheme_type" \
+		--mode "$dark_mode" \
+		--output "$DOTS_SCHEME_FILE" || return 1
 
-  if command -v dots-color-scheme >/dev/null 2>&1; then
-    dots-color-scheme sync-state >/dev/null 2>&1 || return 1
-  fi
-  _dots_aa_sync_gtk_color_scheme "$dark_mode"
-  if command -v dots-hyprlock-theme >/dev/null 2>&1; then
-    dots-hyprlock-theme >/dev/null 2>&1 || true
-  fi
-  if command -v hyprctl >/dev/null 2>&1; then
-    hyprctl reload >/dev/null 2>&1 || true
-  fi
-  return 0
+	if command -v dots-color-scheme > /dev/null 2>&1; then
+		dots-color-scheme sync-state > /dev/null 2>&1 || return 1
+	fi
+	_dots_aa_sync_gtk_color_scheme "$dark_mode"
+	if command -v dots-hyprlock-theme > /dev/null 2>&1; then
+		dots-hyprlock-theme > /dev/null 2>&1 || true
+	fi
+	if command -v hyprctl > /dev/null 2>&1; then
+		hyprctl reload > /dev/null 2>&1 || true
+	fi
+	return 0
 }
 
 # Apply a theme pack once (no persistent current-theme state).
 dots_apply_theme() {
-  local theme_id="${1:-}"
-  local wallpaper_override="${2:-}"
+	local theme_id="${1:-}"
+	local wallpaper_override="${2:-}"
 
-  [[ -n $theme_id ]] || {
-    echo "dots_apply_theme: theme id required" >&2
-    return 1
-  }
-  local config_json="$DOTS_THEMES_DIR/$theme_id/theme.json"
-  [[ -f $config_json ]] || {
-    echo "dots_apply_theme: theme not found: $theme_id" >&2
-    return 1
-  }
+	[[ -n $theme_id ]] || {
+		echo "dots_apply_theme: theme id required" >&2
+		return 1
+	}
+	local config_json="$DOTS_THEMES_DIR/$theme_id/theme.json"
+	[[ -f $config_json ]] || {
+		echo "dots_apply_theme: theme not found: $theme_id" >&2
+		return 1
+	}
 
-  local scheme_type dark_mode_raw dark_mode gtk_theme icon_theme theme_name wallpaper_dir default_wp wallpaper
-  scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$config_json" schemeType tonal-spot)")"
-  dark_mode_raw="$(_dots_aa_json_get "$config_json" darkMode true)"
-  if [[ $dark_mode_raw == "false" ]]; then
-    dark_mode="light"
-  else
-    dark_mode="dark"
-  fi
-  gtk_theme="$(_dots_aa_json_get "$config_json" gtkTheme Orchis-Light-Compact)"
-  icon_theme="$(_dots_aa_json_get "$config_json" iconTheme Numix-Circle)"
-  theme_name="$(_dots_aa_json_get "$config_json" name "$theme_id")"
-  wallpaper_dir="$(_dots_aa_json_get "$config_json" wallpaperDir "$theme_id")"
-  default_wp="$(_dots_aa_json_get "$config_json" defaultWallpaper "")"
+	local scheme_type dark_mode_raw dark_mode gtk_theme icon_theme theme_name wallpaper_dir default_wp wallpaper
+	scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$config_json" schemeType tonal-spot)")"
+	dark_mode_raw="$(_dots_aa_json_get "$config_json" darkMode true)"
+	if [[ $dark_mode_raw == "false" ]]; then
+		dark_mode="light"
+	else
+		dark_mode="dark"
+	fi
+	gtk_theme="$(_dots_aa_json_get "$config_json" gtkTheme Orchis-Light-Compact)"
+	icon_theme="$(_dots_aa_json_get "$config_json" iconTheme Numix-Circle)"
+	theme_name="$(_dots_aa_json_get "$config_json" name "$theme_id")"
+	wallpaper_dir="$(_dots_aa_json_get "$config_json" wallpaperDir "$theme_id")"
+	default_wp="$(_dots_aa_json_get "$config_json" defaultWallpaper "")"
 
-  wallpaper="$(_dots_aa_resolve_theme_wallpaper "$theme_id" "$wallpaper_dir" "$default_wp" "$wallpaper_override" || true)"
-  [[ -n ${wallpaper:-} && -f $wallpaper ]] || {
-    echo "dots_apply_theme: no wallpaper for theme $theme_id" >&2
-    return 1
-  }
+	wallpaper="$(_dots_aa_resolve_theme_wallpaper "$theme_id" "$wallpaper_dir" "$default_wp" "$wallpaper_override" || true)"
+	[[ -n ${wallpaper:-} && -f $wallpaper ]] || {
+		echo "dots_apply_theme: no wallpaper for theme $theme_id" >&2
+		return 1
+	}
 
-  _dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode" || return 1
+	_dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode" || return 1
 
-  if command -v dots-gtk-theme >/dev/null 2>&1; then
-    if [[ -n $gtk_theme && $gtk_theme != "auto" ]]; then
-      local prefer
-      prefer="$(_dots_aa_resolve_gtk_prefer "$config_json" "$dark_mode" "$gtk_theme")"
-      dots-gtk-theme -q apply "$gtk_theme" "${icon_theme:-Numix-Circle}" "$prefer" >/dev/null 2>&1 || true
-    elif [[ $gtk_theme == "auto" ]]; then
-      dots-gtk-theme -q theme "$theme_id" >/dev/null 2>&1 || true
-      local prefer_auto
-      prefer_auto="$(_dots_aa_resolve_gtk_prefer "$config_json" "$dark_mode" "")"
-      if [[ $prefer_auto == "false" ]]; then
-        dots-gtk-theme -q color-scheme light >/dev/null 2>&1 || true
-      else
-        dots-gtk-theme -q color-scheme dark >/dev/null 2>&1 || true
-      fi
-    elif [[ -n $icon_theme ]]; then
-      dots-gtk-theme -q set-icons "$icon_theme" >/dev/null 2>&1 || true
-      dots-gtk-theme -q color-scheme "$dark_mode" >/dev/null 2>&1 || true
-    else
-      dots-gtk-theme -q color-scheme "$dark_mode" >/dev/null 2>&1 || true
-    fi
-  elif [[ -n $icon_theme ]] && command -v gsettings >/dev/null 2>&1; then
-    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" >/dev/null 2>&1 || true
-    _dots_aa_sync_gtk_color_scheme "$dark_mode"
-  else
-    _dots_aa_sync_gtk_color_scheme "$dark_mode"
-  fi
+	if command -v dots-gtk-theme > /dev/null 2>&1; then
+		if [[ -n $gtk_theme && $gtk_theme != "auto" ]]; then
+			local prefer
+			prefer="$(_dots_aa_resolve_gtk_prefer "$config_json" "$dark_mode" "$gtk_theme")"
+			dots-gtk-theme -q apply "$gtk_theme" "${icon_theme:-Numix-Circle}" "$prefer" > /dev/null 2>&1 || true
+		elif [[ $gtk_theme == "auto" ]]; then
+			dots-gtk-theme -q theme "$theme_id" > /dev/null 2>&1 || true
+			local prefer_auto
+			prefer_auto="$(_dots_aa_resolve_gtk_prefer "$config_json" "$dark_mode" "")"
+			if [[ $prefer_auto == "false" ]]; then
+				dots-gtk-theme -q color-scheme light > /dev/null 2>&1 || true
+			else
+				dots-gtk-theme -q color-scheme dark > /dev/null 2>&1 || true
+			fi
+		elif [[ -n $icon_theme ]]; then
+			dots-gtk-theme -q set-icons "$icon_theme" > /dev/null 2>&1 || true
+			dots-gtk-theme -q color-scheme "$dark_mode" > /dev/null 2>&1 || true
+		else
+			dots-gtk-theme -q color-scheme "$dark_mode" > /dev/null 2>&1 || true
+		fi
+	elif [[ -n $icon_theme ]] && command -v gsettings > /dev/null 2>&1; then
+		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" > /dev/null 2>&1 || true
+		_dots_aa_sync_gtk_color_scheme "$dark_mode"
+	else
+		_dots_aa_sync_gtk_color_scheme "$dark_mode"
+	fi
 
-  if [[ -f $HOME/.local/lib/dots/snappy-switcher-manager.sh ]]; then
-    # shellcheck source=/dev/null
-    source "$HOME/.local/lib/dots/snappy-switcher-manager.sh" 2>/dev/null || true
-    if declare -f apply_theme_snappy_switcher_theme >/dev/null 2>&1; then
-      apply_theme_snappy_switcher_theme "$theme_id" >/dev/null 2>&1 || true
-    fi
-  fi
+	if [[ -f $HOME/.local/lib/dots/snappy-switcher-manager.sh ]]; then
+		# shellcheck source=/dev/null
+		source "$HOME/.local/lib/dots/snappy-switcher-manager.sh" 2> /dev/null || true
+		if declare -f apply_theme_snappy_switcher_theme > /dev/null 2>&1; then
+			apply_theme_snappy_switcher_theme "$theme_id" > /dev/null 2>&1 || true
+		fi
+	fi
 
-  if command -v notify-send >/dev/null 2>&1; then
-    notify-send "HorneroConfig" "${theme_name} theme applied" >/dev/null 2>&1 || true
-  fi
-  return 0
+	if command -v notify-send > /dev/null 2>&1; then
+		notify-send "HorneroConfig" "${theme_name} theme applied" > /dev/null 2>&1 || true
+	fi
+	return 0
 }
 
 # Back-compat name used by older callers during transition.
 dots_apply_appearance() {
-  dots_apply_theme "$@"
+	dots_apply_theme "$@"
 }
 
 # Wallpaper-only: live mode/flavour from scheme state.
 dots_apply_wallpaper_only() {
-  local wallpaper="${1:-}"
-  wallpaper="$(readlink -f "$wallpaper" 2>/dev/null || true)"
-  [[ -n ${wallpaper:-} && -f $wallpaper ]] || {
-    echo "dots_apply_wallpaper_only: wallpaper not found" >&2
-    return 1
-  }
+	local wallpaper="${1:-}"
+	wallpaper="$(readlink -f "$wallpaper" 2> /dev/null || true)"
+	[[ -n ${wallpaper:-} && -f $wallpaper ]] || {
+		echo "dots_apply_wallpaper_only: wallpaper not found" >&2
+		return 1
+	}
 
-  local scheme_type="tonal-spot" dark_mode="dark"
-  local state_file="$DOTS_STATE_DIR/scheme/state.json"
-  if [[ -f $state_file ]]; then
-    scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$state_file" flavour tonal-spot)")"
-    dark_mode="$(_dots_aa_json_get "$state_file" mode dark)"
-    [[ $dark_mode == "light" || $dark_mode == "dark" ]] || dark_mode="dark"
-  fi
+	local scheme_type="tonal-spot" dark_mode="dark"
+	local state_file="$DOTS_STATE_DIR/scheme/state.json"
+	if [[ -f $state_file ]]; then
+		scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$state_file" flavour tonal-spot)")"
+		dark_mode="$(_dots_aa_json_get "$state_file" mode dark)"
+		[[ $dark_mode == "light" || $dark_mode == "dark" ]] || dark_mode="dark"
+	fi
 
-  _dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode"
+	_dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode"
 }

--- a/home/dot_local/lib/dots/apply-appearance.sh
+++ b/home/dot_local/lib/dots/apply-appearance.sh
@@ -12,8 +12,8 @@ DOTS_M3_SCRIPT="${DOTS_M3_SCRIPT:-$HOME/.local/lib/dots/generate-m3-colors.py}"
 DOTS_PICTURES_WALLPAPERS="${DOTS_PICTURES_WALLPAPERS:-$HOME/Pictures/Wallpapers}"
 
 _dots_aa_json_get() {
-	local file="$1" key="$2" default="${3:-}"
-	python3 - "$file" "$key" "$default" << 'PY'
+  local file="$1" key="$2" default="${3:-}"
+  python3 - "$file" "$key" "$default" <<'PY'
 import json, sys
 path, key, default = sys.argv[1], sys.argv[2], sys.argv[3]
 try:
@@ -33,211 +33,254 @@ PY
 }
 
 _dots_aa_write_pointer() {
-	local path="$1"
-	mkdir -p "$(dirname "$DOTS_WALLPAPER_POINTER_FILE")"
-	printf '%s\n' "$path" > "$DOTS_WALLPAPER_POINTER_FILE"
+  local path="$1"
+  mkdir -p "$(dirname "$DOTS_WALLPAPER_POINTER_FILE")"
+  printf '%s\n' "$path" >"$DOTS_WALLPAPER_POINTER_FILE"
 }
 
 _dots_aa_normalize_scheme_type() {
-	local raw="${1:-tonal-spot}"
-	raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
-	case "$raw" in
-		vibrant | expressive | fidelity | content | neutral | monochrome) printf '%s\n' "$raw" ;;
-		tonalspot | tonal-spot) printf 'tonal-spot\n' ;;
-		*) printf 'tonal-spot\n' ;;
-	esac
+  local raw="${1:-tonal-spot}"
+  raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
+  case "$raw" in
+    vibrant | expressive | fidelity | content | neutral | monochrome) printf '%s\n' "$raw" ;;
+    tonalspot | tonal-spot) printf 'tonal-spot\n' ;;
+    *) printf 'tonal-spot\n' ;;
+  esac
+}
+
+# Resolve gtk-application-prefer-dark independently of shell darkMode when possible.
+# Priority: theme.json gtkPreferDark → Light/Dark in gtk theme name → shell mode.
+_dots_aa_resolve_gtk_prefer() {
+  local config_json="${1:-}"
+  local dark_mode="${2:-dark}"
+  local gtk_theme="${3:-}"
+  local explicit=""
+
+  if [[ -n $config_json && -f $config_json ]]; then
+    explicit="$(_dots_aa_json_get "$config_json" gtkPreferDark "")"
+  fi
+  case "$explicit" in
+    true | false)
+      printf '%s\n' "$explicit"
+      return 0
+      ;;
+  esac
+
+  local gtk_lc
+  gtk_lc=$(printf '%s' "$gtk_theme" | tr '[:upper:]' '[:lower:]')
+  case "$gtk_lc" in
+    *light*)
+      printf 'false\n'
+      ;;
+    *dark*)
+      printf 'true\n'
+      ;;
+    *)
+      if [[ $dark_mode == "light" ]]; then
+        printf 'false\n'
+      else
+        printf 'true\n'
+      fi
+      ;;
+  esac
 }
 
 _dots_aa_resolve_theme_wallpaper() {
-	local theme_id="$1"
-	local wallpaper_dir="$2"
-	local default_name="$3"
-	local override="${4:-}"
-	local candidate=""
+  local theme_id="$1"
+  local wallpaper_dir="$2"
+  local default_name="$3"
+  local override="${4:-}"
+  local candidate=""
 
-	if [[ -n $override ]]; then
-		candidate="$(readlink -f "$override" 2> /dev/null || true)"
-		[[ -n ${candidate:-} && -f $candidate ]] && {
-			printf '%s\n' "$candidate"
-			return 0
-		}
-	fi
+  if [[ -n $override ]]; then
+    candidate="$(readlink -f "$override" 2>/dev/null || true)"
+    [[ -n ${candidate:-} && -f $candidate ]] && {
+      printf '%s\n' "$candidate"
+      return 0
+    }
+  fi
 
-	for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
-		if [[ -n $default_name && -f $base/$default_name ]]; then
-			readlink -f "$base/$default_name"
-			return 0
-		fi
-	done
+  for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
+    if [[ -n $default_name && -f $base/$default_name ]]; then
+      readlink -f "$base/$default_name"
+      return 0
+    fi
+  done
 
-	for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
-		[[ -d $base ]] || continue
-		candidate="$(
-			find -L "$base" -maxdepth 1 \( -type f -o -type l \) \
-				\( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" \
-				-o -iname "*.gif" -o -iname "*.bmp" \) 2> /dev/null | sort | head -n 1 || true
-		)"
-		[[ -n ${candidate:-} && -f $candidate ]] && {
-			printf '%s\n' "$candidate"
-			return 0
-		}
-	done
-	return 1
+  for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
+    [[ -d $base ]] || continue
+    candidate="$(
+      find -L "$base" -maxdepth 1 \( -type f -o -type l \) \
+        \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" \
+        -o -iname "*.gif" -o -iname "*.bmp" \) 2>/dev/null | sort | head -n 1 || true
+    )"
+    [[ -n ${candidate:-} && -f $candidate ]] && {
+      printf '%s\n' "$candidate"
+      return 0
+    }
+  done
+  return 1
 }
 
 _dots_aa_sync_gtk_color_scheme() {
-	local mode="${1:-dark}"
-	if command -v dots-gtk-theme > /dev/null 2>&1; then
-		dots-gtk-theme -q color-scheme "$mode" > /dev/null 2>&1 || true
-	elif [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
-		# shellcheck source=/dev/null
-		source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2> /dev/null || true
-		if declare -f apply_gtk_color_scheme > /dev/null 2>&1; then
-			apply_gtk_color_scheme "$mode" > /dev/null 2>&1 || true
-		fi
-	fi
+  local mode="${1:-dark}"
+  if command -v dots-gtk-theme >/dev/null 2>&1; then
+    dots-gtk-theme -q color-scheme "$mode" >/dev/null 2>&1 || true
+  elif [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
+    if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
+      apply_gtk_color_scheme "$mode" >/dev/null 2>&1 || true
+    fi
+  fi
 }
 
 _dots_aa_run_palette() {
-	local wallpaper="$1"
-	local scheme_type="$2"
-	local dark_mode="$3"
+  local wallpaper="$1"
+  local scheme_type="$2"
+  local dark_mode="$3"
 
-	if ! command -v wal > /dev/null 2>&1; then
-		echo "apply-appearance: wal not found" >&2
-		return 1
-	fi
-	# Drop any prior wal→image symlink before wal runs; echoing a path through
-	# that symlink would truncate the wallpaper file itself.
-	mkdir -p "$HOME/.cache/wal"
-	rm -f "$HOME/.cache/wal/wal"
-	if [[ $dark_mode == "light" ]]; then
-		wal -i "$wallpaper" -q -l || return 1
-	else
-		wal -i "$wallpaper" -q || return 1
-	fi
+  if ! command -v wal >/dev/null 2>&1; then
+    echo "apply-appearance: wal not found" >&2
+    return 1
+  fi
+  # Drop any prior wal→image symlink before wal runs; echoing a path through
+  # that symlink would truncate the wallpaper file itself.
+  mkdir -p "$HOME/.cache/wal"
+  rm -f "$HOME/.cache/wal/wal"
+  if [[ $dark_mode == "light" ]]; then
+    wal -i "$wallpaper" -q -l || return 1
+  else
+    wal -i "$wallpaper" -q || return 1
+  fi
 
-	_dots_aa_write_pointer "$wallpaper"
-	rm -f "$HOME/.cache/wal/wal"
-	printf '%s\n' "$wallpaper" > "$HOME/.cache/wal/wal"
+  _dots_aa_write_pointer "$wallpaper"
+  rm -f "$HOME/.cache/wal/wal"
+  printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
 
-	[[ -f $DOTS_M3_SCRIPT ]] || {
-		echo "apply-appearance: missing generate-m3-colors.py" >&2
-		return 1
-	}
-	mkdir -p "$(dirname "$DOTS_SCHEME_FILE")"
-	python3 "$DOTS_M3_SCRIPT" \
-		--image "$wallpaper" \
-		--scheme-type "$scheme_type" \
-		--mode "$dark_mode" \
-		--output "$DOTS_SCHEME_FILE" || return 1
+  [[ -f $DOTS_M3_SCRIPT ]] || {
+    echo "apply-appearance: missing generate-m3-colors.py" >&2
+    return 1
+  }
+  mkdir -p "$(dirname "$DOTS_SCHEME_FILE")"
+  python3 "$DOTS_M3_SCRIPT" \
+    --image "$wallpaper" \
+    --scheme-type "$scheme_type" \
+    --mode "$dark_mode" \
+    --output "$DOTS_SCHEME_FILE" || return 1
 
-	if command -v dots-color-scheme > /dev/null 2>&1; then
-		dots-color-scheme sync-state > /dev/null 2>&1 || return 1
-	fi
-	_dots_aa_sync_gtk_color_scheme "$dark_mode"
-	if command -v dots-hyprlock-theme > /dev/null 2>&1; then
-		dots-hyprlock-theme > /dev/null 2>&1 || true
-	fi
-	if command -v hyprctl > /dev/null 2>&1; then
-		hyprctl reload > /dev/null 2>&1 || true
-	fi
-	return 0
+  if command -v dots-color-scheme >/dev/null 2>&1; then
+    dots-color-scheme sync-state >/dev/null 2>&1 || return 1
+  fi
+  _dots_aa_sync_gtk_color_scheme "$dark_mode"
+  if command -v dots-hyprlock-theme >/dev/null 2>&1; then
+    dots-hyprlock-theme >/dev/null 2>&1 || true
+  fi
+  if command -v hyprctl >/dev/null 2>&1; then
+    hyprctl reload >/dev/null 2>&1 || true
+  fi
+  return 0
 }
 
 # Apply a theme pack once (no persistent current-theme state).
 dots_apply_theme() {
-	local theme_id="${1:-}"
-	local wallpaper_override="${2:-}"
+  local theme_id="${1:-}"
+  local wallpaper_override="${2:-}"
 
-	[[ -n $theme_id ]] || {
-		echo "dots_apply_theme: theme id required" >&2
-		return 1
-	}
-	local config_json="$DOTS_THEMES_DIR/$theme_id/theme.json"
-	[[ -f $config_json ]] || {
-		echo "dots_apply_theme: theme not found: $theme_id" >&2
-		return 1
-	}
+  [[ -n $theme_id ]] || {
+    echo "dots_apply_theme: theme id required" >&2
+    return 1
+  }
+  local config_json="$DOTS_THEMES_DIR/$theme_id/theme.json"
+  [[ -f $config_json ]] || {
+    echo "dots_apply_theme: theme not found: $theme_id" >&2
+    return 1
+  }
 
-	local scheme_type dark_mode_raw dark_mode gtk_theme icon_theme theme_name wallpaper_dir default_wp wallpaper
-	scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$config_json" schemeType tonal-spot)")"
-	dark_mode_raw="$(_dots_aa_json_get "$config_json" darkMode true)"
-	if [[ $dark_mode_raw == "false" ]]; then
-		dark_mode="light"
-	else
-		dark_mode="dark"
-	fi
-	gtk_theme="$(_dots_aa_json_get "$config_json" gtkTheme Orchis-Dark)"
-	icon_theme="$(_dots_aa_json_get "$config_json" iconTheme Numix-Circle)"
-	theme_name="$(_dots_aa_json_get "$config_json" name "$theme_id")"
-	wallpaper_dir="$(_dots_aa_json_get "$config_json" wallpaperDir "$theme_id")"
-	default_wp="$(_dots_aa_json_get "$config_json" defaultWallpaper "")"
+  local scheme_type dark_mode_raw dark_mode gtk_theme icon_theme theme_name wallpaper_dir default_wp wallpaper
+  scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$config_json" schemeType tonal-spot)")"
+  dark_mode_raw="$(_dots_aa_json_get "$config_json" darkMode true)"
+  if [[ $dark_mode_raw == "false" ]]; then
+    dark_mode="light"
+  else
+    dark_mode="dark"
+  fi
+  gtk_theme="$(_dots_aa_json_get "$config_json" gtkTheme Orchis-Light-Compact)"
+  icon_theme="$(_dots_aa_json_get "$config_json" iconTheme Numix-Circle)"
+  theme_name="$(_dots_aa_json_get "$config_json" name "$theme_id")"
+  wallpaper_dir="$(_dots_aa_json_get "$config_json" wallpaperDir "$theme_id")"
+  default_wp="$(_dots_aa_json_get "$config_json" defaultWallpaper "")"
 
-	wallpaper="$(_dots_aa_resolve_theme_wallpaper "$theme_id" "$wallpaper_dir" "$default_wp" "$wallpaper_override" || true)"
-	[[ -n ${wallpaper:-} && -f $wallpaper ]] || {
-		echo "dots_apply_theme: no wallpaper for theme $theme_id" >&2
-		return 1
-	}
+  wallpaper="$(_dots_aa_resolve_theme_wallpaper "$theme_id" "$wallpaper_dir" "$default_wp" "$wallpaper_override" || true)"
+  [[ -n ${wallpaper:-} && -f $wallpaper ]] || {
+    echo "dots_apply_theme: no wallpaper for theme $theme_id" >&2
+    return 1
+  }
 
-	_dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode" || return 1
+  _dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode" || return 1
 
-	if command -v dots-gtk-theme > /dev/null 2>&1; then
-		if [[ -n $gtk_theme && $gtk_theme != "auto" ]]; then
-			local prefer
-			prefer=$([[ $dark_mode == "light" ]] && echo false || echo true)
-			dots-gtk-theme -q apply "$gtk_theme" "${icon_theme:-Numix-Circle}" "$prefer" > /dev/null 2>&1 || true
-		elif [[ $gtk_theme == "auto" ]]; then
-			dots-gtk-theme -q theme "$theme_id" > /dev/null 2>&1 || true
-			dots-gtk-theme -q color-scheme "$dark_mode" > /dev/null 2>&1 || true
-		elif [[ -n $icon_theme ]]; then
-			dots-gtk-theme -q set-icons "$icon_theme" > /dev/null 2>&1 || true
-			dots-gtk-theme -q color-scheme "$dark_mode" > /dev/null 2>&1 || true
-		else
-			dots-gtk-theme -q color-scheme "$dark_mode" > /dev/null 2>&1 || true
-		fi
-	elif [[ -n $icon_theme ]] && command -v gsettings > /dev/null 2>&1; then
-		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" > /dev/null 2>&1 || true
-		_dots_aa_sync_gtk_color_scheme "$dark_mode"
-	else
-		_dots_aa_sync_gtk_color_scheme "$dark_mode"
-	fi
+  if command -v dots-gtk-theme >/dev/null 2>&1; then
+    if [[ -n $gtk_theme && $gtk_theme != "auto" ]]; then
+      local prefer
+      prefer="$(_dots_aa_resolve_gtk_prefer "$config_json" "$dark_mode" "$gtk_theme")"
+      dots-gtk-theme -q apply "$gtk_theme" "${icon_theme:-Numix-Circle}" "$prefer" >/dev/null 2>&1 || true
+    elif [[ $gtk_theme == "auto" ]]; then
+      dots-gtk-theme -q theme "$theme_id" >/dev/null 2>&1 || true
+      local prefer_auto
+      prefer_auto="$(_dots_aa_resolve_gtk_prefer "$config_json" "$dark_mode" "")"
+      if [[ $prefer_auto == "false" ]]; then
+        dots-gtk-theme -q color-scheme light >/dev/null 2>&1 || true
+      else
+        dots-gtk-theme -q color-scheme dark >/dev/null 2>&1 || true
+      fi
+    elif [[ -n $icon_theme ]]; then
+      dots-gtk-theme -q set-icons "$icon_theme" >/dev/null 2>&1 || true
+      dots-gtk-theme -q color-scheme "$dark_mode" >/dev/null 2>&1 || true
+    else
+      dots-gtk-theme -q color-scheme "$dark_mode" >/dev/null 2>&1 || true
+    fi
+  elif [[ -n $icon_theme ]] && command -v gsettings >/dev/null 2>&1; then
+    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" >/dev/null 2>&1 || true
+    _dots_aa_sync_gtk_color_scheme "$dark_mode"
+  else
+    _dots_aa_sync_gtk_color_scheme "$dark_mode"
+  fi
 
-	if [[ -f $HOME/.local/lib/dots/snappy-switcher-manager.sh ]]; then
-		# shellcheck source=/dev/null
-		source "$HOME/.local/lib/dots/snappy-switcher-manager.sh" 2> /dev/null || true
-		if declare -f apply_theme_snappy_switcher_theme > /dev/null 2>&1; then
-			apply_theme_snappy_switcher_theme "$theme_id" > /dev/null 2>&1 || true
-		fi
-	fi
+  if [[ -f $HOME/.local/lib/dots/snappy-switcher-manager.sh ]]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.local/lib/dots/snappy-switcher-manager.sh" 2>/dev/null || true
+    if declare -f apply_theme_snappy_switcher_theme >/dev/null 2>&1; then
+      apply_theme_snappy_switcher_theme "$theme_id" >/dev/null 2>&1 || true
+    fi
+  fi
 
-	if command -v notify-send > /dev/null 2>&1; then
-		notify-send "HorneroConfig" "${theme_name} theme applied" > /dev/null 2>&1 || true
-	fi
-	return 0
+  if command -v notify-send >/dev/null 2>&1; then
+    notify-send "HorneroConfig" "${theme_name} theme applied" >/dev/null 2>&1 || true
+  fi
+  return 0
 }
 
 # Back-compat name used by older callers during transition.
 dots_apply_appearance() {
-	dots_apply_theme "$@"
+  dots_apply_theme "$@"
 }
 
 # Wallpaper-only: live mode/flavour from scheme state.
 dots_apply_wallpaper_only() {
-	local wallpaper="${1:-}"
-	wallpaper="$(readlink -f "$wallpaper" 2> /dev/null || true)"
-	[[ -n ${wallpaper:-} && -f $wallpaper ]] || {
-		echo "dots_apply_wallpaper_only: wallpaper not found" >&2
-		return 1
-	}
+  local wallpaper="${1:-}"
+  wallpaper="$(readlink -f "$wallpaper" 2>/dev/null || true)"
+  [[ -n ${wallpaper:-} && -f $wallpaper ]] || {
+    echo "dots_apply_wallpaper_only: wallpaper not found" >&2
+    return 1
+  }
 
-	local scheme_type="tonal-spot" dark_mode="dark"
-	local state_file="$DOTS_STATE_DIR/scheme/state.json"
-	if [[ -f $state_file ]]; then
-		scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$state_file" flavour tonal-spot)")"
-		dark_mode="$(_dots_aa_json_get "$state_file" mode dark)"
-		[[ $dark_mode == "light" || $dark_mode == "dark" ]] || dark_mode="dark"
-	fi
+  local scheme_type="tonal-spot" dark_mode="dark"
+  local state_file="$DOTS_STATE_DIR/scheme/state.json"
+  if [[ -f $state_file ]]; then
+    scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$state_file" flavour tonal-spot)")"
+    dark_mode="$(_dots_aa_json_get "$state_file" mode dark)"
+    [[ $dark_mode == "light" || $dark_mode == "dark" ]] || dark_mode="dark"
+  fi
 
-	_dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode"
+  _dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode"
 }

--- a/home/dot_local/lib/dots/apply-appearance.sh
+++ b/home/dot_local/lib/dots/apply-appearance.sh
@@ -12,8 +12,8 @@ DOTS_M3_SCRIPT="${DOTS_M3_SCRIPT:-$HOME/.local/lib/dots/generate-m3-colors.py}"
 DOTS_PICTURES_WALLPAPERS="${DOTS_PICTURES_WALLPAPERS:-$HOME/Pictures/Wallpapers}"
 
 _dots_aa_json_get() {
-  local file="$1" key="$2" default="${3:-}"
-  python3 - "$file" "$key" "$default" <<'PY'
+	local file="$1" key="$2" default="${3:-}"
+	python3 - "$file" "$key" "$default" << 'PY'
 import json, sys
 path, key, default = sys.argv[1], sys.argv[2], sys.argv[3]
 try:
@@ -33,211 +33,211 @@ PY
 }
 
 _dots_aa_write_pointer() {
-  local path="$1"
-  mkdir -p "$(dirname "$DOTS_WALLPAPER_POINTER_FILE")"
-  printf '%s\n' "$path" >"$DOTS_WALLPAPER_POINTER_FILE"
+	local path="$1"
+	mkdir -p "$(dirname "$DOTS_WALLPAPER_POINTER_FILE")"
+	printf '%s\n' "$path" > "$DOTS_WALLPAPER_POINTER_FILE"
 }
 
 _dots_aa_normalize_scheme_type() {
-  local raw="${1:-tonal-spot}"
-  raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
-  case "$raw" in
-    vibrant | expressive | fidelity | content | neutral | monochrome) printf '%s\n' "$raw" ;;
-    tonalspot | tonal-spot) printf 'tonal-spot\n' ;;
-    *) printf 'tonal-spot\n' ;;
-  esac
+	local raw="${1:-tonal-spot}"
+	raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
+	case "$raw" in
+		vibrant | expressive | fidelity | content | neutral | monochrome) printf '%s\n' "$raw" ;;
+		tonalspot | tonal-spot) printf 'tonal-spot\n' ;;
+		*) printf 'tonal-spot\n' ;;
+	esac
 }
 
 _dots_aa_resolve_theme_wallpaper() {
-  local theme_id="$1"
-  local wallpaper_dir="$2"
-  local default_name="$3"
-  local override="${4:-}"
-  local candidate=""
+	local theme_id="$1"
+	local wallpaper_dir="$2"
+	local default_name="$3"
+	local override="${4:-}"
+	local candidate=""
 
-  if [[ -n $override ]]; then
-    candidate="$(readlink -f "$override" 2>/dev/null || true)"
-    [[ -n ${candidate:-} && -f $candidate ]] && {
-      printf '%s\n' "$candidate"
-      return 0
-    }
-  fi
+	if [[ -n $override ]]; then
+		candidate="$(readlink -f "$override" 2> /dev/null || true)"
+		[[ -n ${candidate:-} && -f $candidate ]] && {
+			printf '%s\n' "$candidate"
+			return 0
+		}
+	fi
 
-  for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
-    if [[ -n $default_name && -f $base/$default_name ]]; then
-      readlink -f "$base/$default_name"
-      return 0
-    fi
-  done
+	for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
+		if [[ -n $default_name && -f $base/$default_name ]]; then
+			readlink -f "$base/$default_name"
+			return 0
+		fi
+	done
 
-  for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
-    [[ -d $base ]] || continue
-    candidate="$(
-      find -L "$base" -maxdepth 1 \( -type f -o -type l \) \
-        \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" \
-        -o -iname "*.gif" -o -iname "*.bmp" \) 2>/dev/null | sort | head -n 1 || true
-    )"
-    [[ -n ${candidate:-} && -f $candidate ]] && {
-      printf '%s\n' "$candidate"
-      return 0
-    }
-  done
-  return 1
+	for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
+		[[ -d $base ]] || continue
+		candidate="$(
+			find -L "$base" -maxdepth 1 \( -type f -o -type l \) \
+				\( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" \
+				-o -iname "*.gif" -o -iname "*.bmp" \) 2> /dev/null | sort | head -n 1 || true
+		)"
+		[[ -n ${candidate:-} && -f $candidate ]] && {
+			printf '%s\n' "$candidate"
+			return 0
+		}
+	done
+	return 1
 }
 
 _dots_aa_sync_gtk_color_scheme() {
-  local mode="${1:-dark}"
-  if command -v dots-gtk-theme >/dev/null 2>&1; then
-    dots-gtk-theme -q color-scheme "$mode" >/dev/null 2>&1 || true
-  elif [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
-    # shellcheck source=/dev/null
-    source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
-    if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
-      apply_gtk_color_scheme "$mode" >/dev/null 2>&1 || true
-    fi
-  fi
+	local mode="${1:-dark}"
+	if command -v dots-gtk-theme > /dev/null 2>&1; then
+		dots-gtk-theme -q color-scheme "$mode" > /dev/null 2>&1 || true
+	elif [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
+		# shellcheck source=/dev/null
+		source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2> /dev/null || true
+		if declare -f apply_gtk_color_scheme > /dev/null 2>&1; then
+			apply_gtk_color_scheme "$mode" > /dev/null 2>&1 || true
+		fi
+	fi
 }
 
 _dots_aa_run_palette() {
-  local wallpaper="$1"
-  local scheme_type="$2"
-  local dark_mode="$3"
+	local wallpaper="$1"
+	local scheme_type="$2"
+	local dark_mode="$3"
 
-  if ! command -v wal >/dev/null 2>&1; then
-    echo "apply-appearance: wal not found" >&2
-    return 1
-  fi
-  # Drop any prior wal→image symlink before wal runs; echoing a path through
-  # that symlink would truncate the wallpaper file itself.
-  mkdir -p "$HOME/.cache/wal"
-  rm -f "$HOME/.cache/wal/wal"
-  if [[ $dark_mode == "light" ]]; then
-    wal -i "$wallpaper" -q -l || return 1
-  else
-    wal -i "$wallpaper" -q || return 1
-  fi
+	if ! command -v wal > /dev/null 2>&1; then
+		echo "apply-appearance: wal not found" >&2
+		return 1
+	fi
+	# Drop any prior wal→image symlink before wal runs; echoing a path through
+	# that symlink would truncate the wallpaper file itself.
+	mkdir -p "$HOME/.cache/wal"
+	rm -f "$HOME/.cache/wal/wal"
+	if [[ $dark_mode == "light" ]]; then
+		wal -i "$wallpaper" -q -l || return 1
+	else
+		wal -i "$wallpaper" -q || return 1
+	fi
 
-  _dots_aa_write_pointer "$wallpaper"
-  rm -f "$HOME/.cache/wal/wal"
-  printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
+	_dots_aa_write_pointer "$wallpaper"
+	rm -f "$HOME/.cache/wal/wal"
+	printf '%s\n' "$wallpaper" > "$HOME/.cache/wal/wal"
 
-  [[ -f $DOTS_M3_SCRIPT ]] || {
-    echo "apply-appearance: missing generate-m3-colors.py" >&2
-    return 1
-  }
-  mkdir -p "$(dirname "$DOTS_SCHEME_FILE")"
-  python3 "$DOTS_M3_SCRIPT" \
-    --image "$wallpaper" \
-    --scheme-type "$scheme_type" \
-    --mode "$dark_mode" \
-    --output "$DOTS_SCHEME_FILE" || return 1
+	[[ -f $DOTS_M3_SCRIPT ]] || {
+		echo "apply-appearance: missing generate-m3-colors.py" >&2
+		return 1
+	}
+	mkdir -p "$(dirname "$DOTS_SCHEME_FILE")"
+	python3 "$DOTS_M3_SCRIPT" \
+		--image "$wallpaper" \
+		--scheme-type "$scheme_type" \
+		--mode "$dark_mode" \
+		--output "$DOTS_SCHEME_FILE" || return 1
 
-  if command -v dots-color-scheme >/dev/null 2>&1; then
-    dots-color-scheme sync-state >/dev/null 2>&1 || return 1
-  fi
-  _dots_aa_sync_gtk_color_scheme "$dark_mode"
-  if command -v dots-hyprlock-theme >/dev/null 2>&1; then
-    dots-hyprlock-theme >/dev/null 2>&1 || true
-  fi
-  if command -v hyprctl >/dev/null 2>&1; then
-    hyprctl reload >/dev/null 2>&1 || true
-  fi
-  return 0
+	if command -v dots-color-scheme > /dev/null 2>&1; then
+		dots-color-scheme sync-state > /dev/null 2>&1 || return 1
+	fi
+	_dots_aa_sync_gtk_color_scheme "$dark_mode"
+	if command -v dots-hyprlock-theme > /dev/null 2>&1; then
+		dots-hyprlock-theme > /dev/null 2>&1 || true
+	fi
+	if command -v hyprctl > /dev/null 2>&1; then
+		hyprctl reload > /dev/null 2>&1 || true
+	fi
+	return 0
 }
 
 # Apply a theme pack once (no persistent current-theme state).
 dots_apply_theme() {
-  local theme_id="${1:-}"
-  local wallpaper_override="${2:-}"
+	local theme_id="${1:-}"
+	local wallpaper_override="${2:-}"
 
-  [[ -n $theme_id ]] || {
-    echo "dots_apply_theme: theme id required" >&2
-    return 1
-  }
-  local config_json="$DOTS_THEMES_DIR/$theme_id/theme.json"
-  [[ -f $config_json ]] || {
-    echo "dots_apply_theme: theme not found: $theme_id" >&2
-    return 1
-  }
+	[[ -n $theme_id ]] || {
+		echo "dots_apply_theme: theme id required" >&2
+		return 1
+	}
+	local config_json="$DOTS_THEMES_DIR/$theme_id/theme.json"
+	[[ -f $config_json ]] || {
+		echo "dots_apply_theme: theme not found: $theme_id" >&2
+		return 1
+	}
 
-  local scheme_type dark_mode_raw dark_mode gtk_theme icon_theme theme_name wallpaper_dir default_wp wallpaper
-  scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$config_json" schemeType tonal-spot)")"
-  dark_mode_raw="$(_dots_aa_json_get "$config_json" darkMode true)"
-  if [[ $dark_mode_raw == "false" ]]; then
-    dark_mode="light"
-  else
-    dark_mode="dark"
-  fi
-  gtk_theme="$(_dots_aa_json_get "$config_json" gtkTheme Orchis-Dark)"
-  icon_theme="$(_dots_aa_json_get "$config_json" iconTheme Numix-Circle)"
-  theme_name="$(_dots_aa_json_get "$config_json" name "$theme_id")"
-  wallpaper_dir="$(_dots_aa_json_get "$config_json" wallpaperDir "$theme_id")"
-  default_wp="$(_dots_aa_json_get "$config_json" defaultWallpaper "")"
+	local scheme_type dark_mode_raw dark_mode gtk_theme icon_theme theme_name wallpaper_dir default_wp wallpaper
+	scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$config_json" schemeType tonal-spot)")"
+	dark_mode_raw="$(_dots_aa_json_get "$config_json" darkMode true)"
+	if [[ $dark_mode_raw == "false" ]]; then
+		dark_mode="light"
+	else
+		dark_mode="dark"
+	fi
+	gtk_theme="$(_dots_aa_json_get "$config_json" gtkTheme Orchis-Dark)"
+	icon_theme="$(_dots_aa_json_get "$config_json" iconTheme Numix-Circle)"
+	theme_name="$(_dots_aa_json_get "$config_json" name "$theme_id")"
+	wallpaper_dir="$(_dots_aa_json_get "$config_json" wallpaperDir "$theme_id")"
+	default_wp="$(_dots_aa_json_get "$config_json" defaultWallpaper "")"
 
-  wallpaper="$(_dots_aa_resolve_theme_wallpaper "$theme_id" "$wallpaper_dir" "$default_wp" "$wallpaper_override" || true)"
-  [[ -n ${wallpaper:-} && -f $wallpaper ]] || {
-    echo "dots_apply_theme: no wallpaper for theme $theme_id" >&2
-    return 1
-  }
+	wallpaper="$(_dots_aa_resolve_theme_wallpaper "$theme_id" "$wallpaper_dir" "$default_wp" "$wallpaper_override" || true)"
+	[[ -n ${wallpaper:-} && -f $wallpaper ]] || {
+		echo "dots_apply_theme: no wallpaper for theme $theme_id" >&2
+		return 1
+	}
 
-  _dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode" || return 1
+	_dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode" || return 1
 
-  if command -v dots-gtk-theme >/dev/null 2>&1; then
-    if [[ -n $gtk_theme && $gtk_theme != "auto" ]]; then
-      local prefer
-      prefer=$([[ $dark_mode == "light" ]] && echo false || echo true)
-      dots-gtk-theme -q apply "$gtk_theme" "${icon_theme:-Numix-Circle}" "$prefer" >/dev/null 2>&1 || true
-    elif [[ $gtk_theme == "auto" ]]; then
-      dots-gtk-theme -q theme "$theme_id" >/dev/null 2>&1 || true
-      dots-gtk-theme -q color-scheme "$dark_mode" >/dev/null 2>&1 || true
-    elif [[ -n $icon_theme ]]; then
-      dots-gtk-theme -q set-icons "$icon_theme" >/dev/null 2>&1 || true
-      dots-gtk-theme -q color-scheme "$dark_mode" >/dev/null 2>&1 || true
-    else
-      dots-gtk-theme -q color-scheme "$dark_mode" >/dev/null 2>&1 || true
-    fi
-  elif [[ -n $icon_theme ]] && command -v gsettings >/dev/null 2>&1; then
-    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" >/dev/null 2>&1 || true
-    _dots_aa_sync_gtk_color_scheme "$dark_mode"
-  else
-    _dots_aa_sync_gtk_color_scheme "$dark_mode"
-  fi
+	if command -v dots-gtk-theme > /dev/null 2>&1; then
+		if [[ -n $gtk_theme && $gtk_theme != "auto" ]]; then
+			local prefer
+			prefer=$([[ $dark_mode == "light" ]] && echo false || echo true)
+			dots-gtk-theme -q apply "$gtk_theme" "${icon_theme:-Numix-Circle}" "$prefer" > /dev/null 2>&1 || true
+		elif [[ $gtk_theme == "auto" ]]; then
+			dots-gtk-theme -q theme "$theme_id" > /dev/null 2>&1 || true
+			dots-gtk-theme -q color-scheme "$dark_mode" > /dev/null 2>&1 || true
+		elif [[ -n $icon_theme ]]; then
+			dots-gtk-theme -q set-icons "$icon_theme" > /dev/null 2>&1 || true
+			dots-gtk-theme -q color-scheme "$dark_mode" > /dev/null 2>&1 || true
+		else
+			dots-gtk-theme -q color-scheme "$dark_mode" > /dev/null 2>&1 || true
+		fi
+	elif [[ -n $icon_theme ]] && command -v gsettings > /dev/null 2>&1; then
+		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" > /dev/null 2>&1 || true
+		_dots_aa_sync_gtk_color_scheme "$dark_mode"
+	else
+		_dots_aa_sync_gtk_color_scheme "$dark_mode"
+	fi
 
-  if [[ -f $HOME/.local/lib/dots/snappy-switcher-manager.sh ]]; then
-    # shellcheck source=/dev/null
-    source "$HOME/.local/lib/dots/snappy-switcher-manager.sh" 2>/dev/null || true
-    if declare -f apply_theme_snappy_switcher_theme >/dev/null 2>&1; then
-      apply_theme_snappy_switcher_theme "$theme_id" >/dev/null 2>&1 || true
-    fi
-  fi
+	if [[ -f $HOME/.local/lib/dots/snappy-switcher-manager.sh ]]; then
+		# shellcheck source=/dev/null
+		source "$HOME/.local/lib/dots/snappy-switcher-manager.sh" 2> /dev/null || true
+		if declare -f apply_theme_snappy_switcher_theme > /dev/null 2>&1; then
+			apply_theme_snappy_switcher_theme "$theme_id" > /dev/null 2>&1 || true
+		fi
+	fi
 
-  if command -v notify-send >/dev/null 2>&1; then
-    notify-send "HorneroConfig" "${theme_name} theme applied" >/dev/null 2>&1 || true
-  fi
-  return 0
+	if command -v notify-send > /dev/null 2>&1; then
+		notify-send "HorneroConfig" "${theme_name} theme applied" > /dev/null 2>&1 || true
+	fi
+	return 0
 }
 
 # Back-compat name used by older callers during transition.
 dots_apply_appearance() {
-  dots_apply_theme "$@"
+	dots_apply_theme "$@"
 }
 
 # Wallpaper-only: live mode/flavour from scheme state.
 dots_apply_wallpaper_only() {
-  local wallpaper="${1:-}"
-  wallpaper="$(readlink -f "$wallpaper" 2>/dev/null || true)"
-  [[ -n ${wallpaper:-} && -f $wallpaper ]] || {
-    echo "dots_apply_wallpaper_only: wallpaper not found" >&2
-    return 1
-  }
+	local wallpaper="${1:-}"
+	wallpaper="$(readlink -f "$wallpaper" 2> /dev/null || true)"
+	[[ -n ${wallpaper:-} && -f $wallpaper ]] || {
+		echo "dots_apply_wallpaper_only: wallpaper not found" >&2
+		return 1
+	}
 
-  local scheme_type="tonal-spot" dark_mode="dark"
-  local state_file="$DOTS_STATE_DIR/scheme/state.json"
-  if [[ -f $state_file ]]; then
-    scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$state_file" flavour tonal-spot)")"
-    dark_mode="$(_dots_aa_json_get "$state_file" mode dark)"
-    [[ $dark_mode == "light" || $dark_mode == "dark" ]] || dark_mode="dark"
-  fi
+	local scheme_type="tonal-spot" dark_mode="dark"
+	local state_file="$DOTS_STATE_DIR/scheme/state.json"
+	if [[ -f $state_file ]]; then
+		scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$state_file" flavour tonal-spot)")"
+		dark_mode="$(_dots_aa_json_get "$state_file" mode dark)"
+		[[ $dark_mode == "light" || $dark_mode == "dark" ]] || dark_mode="dark"
+	fi
 
-  _dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode"
+	_dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode"
 }

--- a/home/dot_local/lib/dots/apply-appearance.sh
+++ b/home/dot_local/lib/dots/apply-appearance.sh
@@ -12,8 +12,8 @@ DOTS_M3_SCRIPT="${DOTS_M3_SCRIPT:-$HOME/.local/lib/dots/generate-m3-colors.py}"
 DOTS_PICTURES_WALLPAPERS="${DOTS_PICTURES_WALLPAPERS:-$HOME/Pictures/Wallpapers}"
 
 _dots_aa_json_get() {
-	local file="$1" key="$2" default="${3:-}"
-	python3 - "$file" "$key" "$default" << 'PY'
+  local file="$1" key="$2" default="${3:-}"
+  python3 - "$file" "$key" "$default" <<'PY'
 import json, sys
 path, key, default = sys.argv[1], sys.argv[2], sys.argv[3]
 try:
@@ -33,209 +33,211 @@ PY
 }
 
 _dots_aa_write_pointer() {
-	local path="$1"
-	mkdir -p "$(dirname "$DOTS_WALLPAPER_POINTER_FILE")"
-	printf '%s\n' "$path" > "$DOTS_WALLPAPER_POINTER_FILE"
+  local path="$1"
+  mkdir -p "$(dirname "$DOTS_WALLPAPER_POINTER_FILE")"
+  printf '%s\n' "$path" >"$DOTS_WALLPAPER_POINTER_FILE"
 }
 
 _dots_aa_normalize_scheme_type() {
-	local raw="${1:-tonal-spot}"
-	raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
-	case "$raw" in
-		vibrant | expressive | fidelity | content | neutral | monochrome) printf '%s\n' "$raw" ;;
-		tonalspot | tonal-spot) printf 'tonal-spot\n' ;;
-		*) printf 'tonal-spot\n' ;;
-	esac
+  local raw="${1:-tonal-spot}"
+  raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
+  case "$raw" in
+    vibrant | expressive | fidelity | content | neutral | monochrome) printf '%s\n' "$raw" ;;
+    tonalspot | tonal-spot) printf 'tonal-spot\n' ;;
+    *) printf 'tonal-spot\n' ;;
+  esac
 }
 
 _dots_aa_resolve_theme_wallpaper() {
-	local theme_id="$1"
-	local wallpaper_dir="$2"
-	local default_name="$3"
-	local override="${4:-}"
-	local candidate=""
+  local theme_id="$1"
+  local wallpaper_dir="$2"
+  local default_name="$3"
+  local override="${4:-}"
+  local candidate=""
 
-	if [[ -n $override ]]; then
-		candidate="$(readlink -f "$override" 2> /dev/null || true)"
-		[[ -n ${candidate:-} && -f $candidate ]] && {
-			printf '%s\n' "$candidate"
-			return 0
-		}
-	fi
+  if [[ -n $override ]]; then
+    candidate="$(readlink -f "$override" 2>/dev/null || true)"
+    [[ -n ${candidate:-} && -f $candidate ]] && {
+      printf '%s\n' "$candidate"
+      return 0
+    }
+  fi
 
-	for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
-		if [[ -n $default_name && -f $base/$default_name ]]; then
-			readlink -f "$base/$default_name"
-			return 0
-		fi
-	done
+  for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
+    if [[ -n $default_name && -f $base/$default_name ]]; then
+      readlink -f "$base/$default_name"
+      return 0
+    fi
+  done
 
-	for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
-		[[ -d $base ]] || continue
-		candidate="$(
-			find -L "$base" -maxdepth 1 \( -type f -o -type l \) \
-				\( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" \
-				-o -iname "*.gif" -o -iname "*.bmp" \) 2> /dev/null | sort | head -n 1 || true
-		)"
-		[[ -n ${candidate:-} && -f $candidate ]] && {
-			printf '%s\n' "$candidate"
-			return 0
-		}
-	done
-	return 1
+  for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
+    [[ -d $base ]] || continue
+    candidate="$(
+      find -L "$base" -maxdepth 1 \( -type f -o -type l \) \
+        \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" \
+        -o -iname "*.gif" -o -iname "*.bmp" \) 2>/dev/null | sort | head -n 1 || true
+    )"
+    [[ -n ${candidate:-} && -f $candidate ]] && {
+      printf '%s\n' "$candidate"
+      return 0
+    }
+  done
+  return 1
 }
 
 _dots_aa_sync_gtk_color_scheme() {
-	local mode="${1:-dark}"
-	if [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
-		# shellcheck source=/dev/null
-		source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2> /dev/null || true
-		if declare -f apply_gtk_color_scheme > /dev/null 2>&1; then
-			apply_gtk_color_scheme "$mode" > /dev/null 2>&1 || true
-		fi
-	fi
+  local mode="${1:-dark}"
+  if command -v dots-gtk-theme >/dev/null 2>&1; then
+    dots-gtk-theme -q color-scheme "$mode" >/dev/null 2>&1 || true
+  elif [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
+    if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
+      apply_gtk_color_scheme "$mode" >/dev/null 2>&1 || true
+    fi
+  fi
 }
 
 _dots_aa_run_palette() {
-	local wallpaper="$1"
-	local scheme_type="$2"
-	local dark_mode="$3"
+  local wallpaper="$1"
+  local scheme_type="$2"
+  local dark_mode="$3"
 
-	if ! command -v wal > /dev/null 2>&1; then
-		echo "apply-appearance: wal not found" >&2
-		return 1
-	fi
-	# Drop any prior wal→image symlink before wal runs; echoing a path through
-	# that symlink would truncate the wallpaper file itself.
-	mkdir -p "$HOME/.cache/wal"
-	rm -f "$HOME/.cache/wal/wal"
-	if [[ $dark_mode == "light" ]]; then
-		wal -i "$wallpaper" -q -l || return 1
-	else
-		wal -i "$wallpaper" -q || return 1
-	fi
+  if ! command -v wal >/dev/null 2>&1; then
+    echo "apply-appearance: wal not found" >&2
+    return 1
+  fi
+  # Drop any prior wal→image symlink before wal runs; echoing a path through
+  # that symlink would truncate the wallpaper file itself.
+  mkdir -p "$HOME/.cache/wal"
+  rm -f "$HOME/.cache/wal/wal"
+  if [[ $dark_mode == "light" ]]; then
+    wal -i "$wallpaper" -q -l || return 1
+  else
+    wal -i "$wallpaper" -q || return 1
+  fi
 
-	_dots_aa_write_pointer "$wallpaper"
-	rm -f "$HOME/.cache/wal/wal"
-	printf '%s\n' "$wallpaper" > "$HOME/.cache/wal/wal"
+  _dots_aa_write_pointer "$wallpaper"
+  rm -f "$HOME/.cache/wal/wal"
+  printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
 
-	[[ -f $DOTS_M3_SCRIPT ]] || {
-		echo "apply-appearance: missing generate-m3-colors.py" >&2
-		return 1
-	}
-	mkdir -p "$(dirname "$DOTS_SCHEME_FILE")"
-	python3 "$DOTS_M3_SCRIPT" \
-		--image "$wallpaper" \
-		--scheme-type "$scheme_type" \
-		--mode "$dark_mode" \
-		--output "$DOTS_SCHEME_FILE" || return 1
+  [[ -f $DOTS_M3_SCRIPT ]] || {
+    echo "apply-appearance: missing generate-m3-colors.py" >&2
+    return 1
+  }
+  mkdir -p "$(dirname "$DOTS_SCHEME_FILE")"
+  python3 "$DOTS_M3_SCRIPT" \
+    --image "$wallpaper" \
+    --scheme-type "$scheme_type" \
+    --mode "$dark_mode" \
+    --output "$DOTS_SCHEME_FILE" || return 1
 
-	if command -v dots-color-scheme > /dev/null 2>&1; then
-		dots-color-scheme sync-state > /dev/null 2>&1 || return 1
-	fi
-	_dots_aa_sync_gtk_color_scheme "$dark_mode"
-	if command -v dots-hyprlock-theme > /dev/null 2>&1; then
-		dots-hyprlock-theme > /dev/null 2>&1 || true
-	fi
-	if command -v hyprctl > /dev/null 2>&1; then
-		hyprctl reload > /dev/null 2>&1 || true
-	fi
-	return 0
+  if command -v dots-color-scheme >/dev/null 2>&1; then
+    dots-color-scheme sync-state >/dev/null 2>&1 || return 1
+  fi
+  _dots_aa_sync_gtk_color_scheme "$dark_mode"
+  if command -v dots-hyprlock-theme >/dev/null 2>&1; then
+    dots-hyprlock-theme >/dev/null 2>&1 || true
+  fi
+  if command -v hyprctl >/dev/null 2>&1; then
+    hyprctl reload >/dev/null 2>&1 || true
+  fi
+  return 0
 }
 
 # Apply a theme pack once (no persistent current-theme state).
 dots_apply_theme() {
-	local theme_id="${1:-}"
-	local wallpaper_override="${2:-}"
+  local theme_id="${1:-}"
+  local wallpaper_override="${2:-}"
 
-	[[ -n $theme_id ]] || {
-		echo "dots_apply_theme: theme id required" >&2
-		return 1
-	}
-	local config_json="$DOTS_THEMES_DIR/$theme_id/theme.json"
-	[[ -f $config_json ]] || {
-		echo "dots_apply_theme: theme not found: $theme_id" >&2
-		return 1
-	}
+  [[ -n $theme_id ]] || {
+    echo "dots_apply_theme: theme id required" >&2
+    return 1
+  }
+  local config_json="$DOTS_THEMES_DIR/$theme_id/theme.json"
+  [[ -f $config_json ]] || {
+    echo "dots_apply_theme: theme not found: $theme_id" >&2
+    return 1
+  }
 
-	local scheme_type dark_mode_raw dark_mode gtk_theme icon_theme theme_name wallpaper_dir default_wp wallpaper
-	scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$config_json" schemeType tonal-spot)")"
-	dark_mode_raw="$(_dots_aa_json_get "$config_json" darkMode true)"
-	if [[ $dark_mode_raw == "false" ]]; then
-		dark_mode="light"
-	else
-		dark_mode="dark"
-	fi
-	gtk_theme="$(_dots_aa_json_get "$config_json" gtkTheme Orchis-Dark)"
-	icon_theme="$(_dots_aa_json_get "$config_json" iconTheme Numix-Circle)"
-	theme_name="$(_dots_aa_json_get "$config_json" name "$theme_id")"
-	wallpaper_dir="$(_dots_aa_json_get "$config_json" wallpaperDir "$theme_id")"
-	default_wp="$(_dots_aa_json_get "$config_json" defaultWallpaper "")"
+  local scheme_type dark_mode_raw dark_mode gtk_theme icon_theme theme_name wallpaper_dir default_wp wallpaper
+  scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$config_json" schemeType tonal-spot)")"
+  dark_mode_raw="$(_dots_aa_json_get "$config_json" darkMode true)"
+  if [[ $dark_mode_raw == "false" ]]; then
+    dark_mode="light"
+  else
+    dark_mode="dark"
+  fi
+  gtk_theme="$(_dots_aa_json_get "$config_json" gtkTheme Orchis-Dark)"
+  icon_theme="$(_dots_aa_json_get "$config_json" iconTheme Numix-Circle)"
+  theme_name="$(_dots_aa_json_get "$config_json" name "$theme_id")"
+  wallpaper_dir="$(_dots_aa_json_get "$config_json" wallpaperDir "$theme_id")"
+  default_wp="$(_dots_aa_json_get "$config_json" defaultWallpaper "")"
 
-	wallpaper="$(_dots_aa_resolve_theme_wallpaper "$theme_id" "$wallpaper_dir" "$default_wp" "$wallpaper_override" || true)"
-	[[ -n ${wallpaper:-} && -f $wallpaper ]] || {
-		echo "dots_apply_theme: no wallpaper for theme $theme_id" >&2
-		return 1
-	}
+  wallpaper="$(_dots_aa_resolve_theme_wallpaper "$theme_id" "$wallpaper_dir" "$default_wp" "$wallpaper_override" || true)"
+  [[ -n ${wallpaper:-} && -f $wallpaper ]] || {
+    echo "dots_apply_theme: no wallpaper for theme $theme_id" >&2
+    return 1
+  }
 
-	_dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode" || return 1
+  _dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode" || return 1
 
-	if command -v dots-gtk-theme > /dev/null 2>&1; then
-		if [[ -n $gtk_theme && $gtk_theme != "auto" ]]; then
-			local prefer
-			prefer=$([[ $dark_mode == "light" ]] && echo false || echo true)
-			dots-gtk-theme -q apply "$gtk_theme" "${icon_theme:-Numix-Circle}" "$prefer" > /dev/null 2>&1 || true
-		elif [[ $gtk_theme == "auto" ]]; then
-			dots-gtk-theme -q theme "$theme_id" > /dev/null 2>&1 || true
-			dots-gtk-theme -q color-scheme "$dark_mode" > /dev/null 2>&1 || true
-		elif [[ -n $icon_theme ]]; then
-			dots-gtk-theme -q set-icons "$icon_theme" > /dev/null 2>&1 || true
-			dots-gtk-theme -q color-scheme "$dark_mode" > /dev/null 2>&1 || true
-		else
-			dots-gtk-theme -q color-scheme "$dark_mode" > /dev/null 2>&1 || true
-		fi
-	elif [[ -n $icon_theme ]] && command -v gsettings > /dev/null 2>&1; then
-		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" > /dev/null 2>&1 || true
-		_dots_aa_sync_gtk_color_scheme "$dark_mode"
-	else
-		_dots_aa_sync_gtk_color_scheme "$dark_mode"
-	fi
+  if command -v dots-gtk-theme >/dev/null 2>&1; then
+    if [[ -n $gtk_theme && $gtk_theme != "auto" ]]; then
+      local prefer
+      prefer=$([[ $dark_mode == "light" ]] && echo false || echo true)
+      dots-gtk-theme -q apply "$gtk_theme" "${icon_theme:-Numix-Circle}" "$prefer" >/dev/null 2>&1 || true
+    elif [[ $gtk_theme == "auto" ]]; then
+      dots-gtk-theme -q theme "$theme_id" >/dev/null 2>&1 || true
+      dots-gtk-theme -q color-scheme "$dark_mode" >/dev/null 2>&1 || true
+    elif [[ -n $icon_theme ]]; then
+      dots-gtk-theme -q set-icons "$icon_theme" >/dev/null 2>&1 || true
+      dots-gtk-theme -q color-scheme "$dark_mode" >/dev/null 2>&1 || true
+    else
+      dots-gtk-theme -q color-scheme "$dark_mode" >/dev/null 2>&1 || true
+    fi
+  elif [[ -n $icon_theme ]] && command -v gsettings >/dev/null 2>&1; then
+    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" >/dev/null 2>&1 || true
+    _dots_aa_sync_gtk_color_scheme "$dark_mode"
+  else
+    _dots_aa_sync_gtk_color_scheme "$dark_mode"
+  fi
 
-	if [[ -f $HOME/.local/lib/dots/snappy-switcher-manager.sh ]]; then
-		# shellcheck source=/dev/null
-		source "$HOME/.local/lib/dots/snappy-switcher-manager.sh" 2> /dev/null || true
-		if declare -f apply_theme_snappy_switcher_theme > /dev/null 2>&1; then
-			apply_theme_snappy_switcher_theme "$theme_id" > /dev/null 2>&1 || true
-		fi
-	fi
+  if [[ -f $HOME/.local/lib/dots/snappy-switcher-manager.sh ]]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.local/lib/dots/snappy-switcher-manager.sh" 2>/dev/null || true
+    if declare -f apply_theme_snappy_switcher_theme >/dev/null 2>&1; then
+      apply_theme_snappy_switcher_theme "$theme_id" >/dev/null 2>&1 || true
+    fi
+  fi
 
-	if command -v notify-send > /dev/null 2>&1; then
-		notify-send "HorneroConfig" "${theme_name} theme applied" > /dev/null 2>&1 || true
-	fi
-	return 0
+  if command -v notify-send >/dev/null 2>&1; then
+    notify-send "HorneroConfig" "${theme_name} theme applied" >/dev/null 2>&1 || true
+  fi
+  return 0
 }
 
 # Back-compat name used by older callers during transition.
 dots_apply_appearance() {
-	dots_apply_theme "$@"
+  dots_apply_theme "$@"
 }
 
 # Wallpaper-only: live mode/flavour from scheme state.
 dots_apply_wallpaper_only() {
-	local wallpaper="${1:-}"
-	wallpaper="$(readlink -f "$wallpaper" 2> /dev/null || true)"
-	[[ -n ${wallpaper:-} && -f $wallpaper ]] || {
-		echo "dots_apply_wallpaper_only: wallpaper not found" >&2
-		return 1
-	}
+  local wallpaper="${1:-}"
+  wallpaper="$(readlink -f "$wallpaper" 2>/dev/null || true)"
+  [[ -n ${wallpaper:-} && -f $wallpaper ]] || {
+    echo "dots_apply_wallpaper_only: wallpaper not found" >&2
+    return 1
+  }
 
-	local scheme_type="tonal-spot" dark_mode="dark"
-	local state_file="$DOTS_STATE_DIR/scheme/state.json"
-	if [[ -f $state_file ]]; then
-		scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$state_file" flavour tonal-spot)")"
-		dark_mode="$(_dots_aa_json_get "$state_file" mode dark)"
-		[[ $dark_mode == "light" || $dark_mode == "dark" ]] || dark_mode="dark"
-	fi
+  local scheme_type="tonal-spot" dark_mode="dark"
+  local state_file="$DOTS_STATE_DIR/scheme/state.json"
+  if [[ -f $state_file ]]; then
+    scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$state_file" flavour tonal-spot)")"
+    dark_mode="$(_dots_aa_json_get "$state_file" mode dark)"
+    [[ $dark_mode == "light" || $dark_mode == "dark" ]] || dark_mode="dark"
+  fi
 
-	_dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode"
+  _dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode"
 }

--- a/home/dot_local/lib/dots/apply-appearance.sh
+++ b/home/dot_local/lib/dots/apply-appearance.sh
@@ -12,8 +12,8 @@ DOTS_M3_SCRIPT="${DOTS_M3_SCRIPT:-$HOME/.local/lib/dots/generate-m3-colors.py}"
 DOTS_PICTURES_WALLPAPERS="${DOTS_PICTURES_WALLPAPERS:-$HOME/Pictures/Wallpapers}"
 
 _dots_aa_json_get() {
-	local file="$1" key="$2" default="${3:-}"
-	python3 - "$file" "$key" "$default" << 'PY'
+  local file="$1" key="$2" default="${3:-}"
+  python3 - "$file" "$key" "$default" <<'PY'
 import json, sys
 path, key, default = sys.argv[1], sys.argv[2], sys.argv[3]
 try:
@@ -33,198 +33,209 @@ PY
 }
 
 _dots_aa_write_pointer() {
-	local path="$1"
-	mkdir -p "$(dirname "$DOTS_WALLPAPER_POINTER_FILE")"
-	printf '%s\n' "$path" > "$DOTS_WALLPAPER_POINTER_FILE"
+  local path="$1"
+  mkdir -p "$(dirname "$DOTS_WALLPAPER_POINTER_FILE")"
+  printf '%s\n' "$path" >"$DOTS_WALLPAPER_POINTER_FILE"
 }
 
 _dots_aa_normalize_scheme_type() {
-	local raw="${1:-tonal-spot}"
-	raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
-	case "$raw" in
-		vibrant | expressive | fidelity | content | neutral | monochrome) printf '%s\n' "$raw" ;;
-		tonalspot | tonal-spot) printf 'tonal-spot\n' ;;
-		*) printf 'tonal-spot\n' ;;
-	esac
+  local raw="${1:-tonal-spot}"
+  raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
+  case "$raw" in
+    vibrant | expressive | fidelity | content | neutral | monochrome) printf '%s\n' "$raw" ;;
+    tonalspot | tonal-spot) printf 'tonal-spot\n' ;;
+    *) printf 'tonal-spot\n' ;;
+  esac
 }
 
 _dots_aa_resolve_theme_wallpaper() {
-	local theme_id="$1"
-	local wallpaper_dir="$2"
-	local default_name="$3"
-	local override="${4:-}"
-	local candidate=""
+  local theme_id="$1"
+  local wallpaper_dir="$2"
+  local default_name="$3"
+  local override="${4:-}"
+  local candidate=""
 
-	if [[ -n $override ]]; then
-		candidate="$(readlink -f "$override" 2> /dev/null || true)"
-		[[ -n ${candidate:-} && -f $candidate ]] && {
-			printf '%s\n' "$candidate"
-			return 0
-		}
-	fi
+  if [[ -n $override ]]; then
+    candidate="$(readlink -f "$override" 2>/dev/null || true)"
+    [[ -n ${candidate:-} && -f $candidate ]] && {
+      printf '%s\n' "$candidate"
+      return 0
+    }
+  fi
 
-	for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
-		if [[ -n $default_name && -f $base/$default_name ]]; then
-			readlink -f "$base/$default_name"
-			return 0
-		fi
-	done
+  for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
+    if [[ -n $default_name && -f $base/$default_name ]]; then
+      readlink -f "$base/$default_name"
+      return 0
+    fi
+  done
 
-	for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
-		[[ -d $base ]] || continue
-		candidate="$(
-			find -L "$base" -maxdepth 1 \( -type f -o -type l \) \
-				\( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" \
-				-o -iname "*.gif" -o -iname "*.bmp" \) 2> /dev/null | sort | head -n 1 || true
-		)"
-		[[ -n ${candidate:-} && -f $candidate ]] && {
-			printf '%s\n' "$candidate"
-			return 0
-		}
-	done
-	return 1
+  for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
+    [[ -d $base ]] || continue
+    candidate="$(
+      find -L "$base" -maxdepth 1 \( -type f -o -type l \) \
+        \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" \
+        -o -iname "*.gif" -o -iname "*.bmp" \) 2>/dev/null | sort | head -n 1 || true
+    )"
+    [[ -n ${candidate:-} && -f $candidate ]] && {
+      printf '%s\n' "$candidate"
+      return 0
+    }
+  done
+  return 1
 }
 
 _dots_aa_sync_gtk_color_scheme() {
-	local mode="${1:-dark}"
-	if [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
-		# shellcheck source=/dev/null
-		source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2> /dev/null || true
-		if declare -f apply_gtk_color_scheme > /dev/null 2>&1; then
-			apply_gtk_color_scheme "$mode" > /dev/null 2>&1 || true
-		fi
-	fi
+  local mode="${1:-dark}"
+  if [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
+    if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
+      apply_gtk_color_scheme "$mode" >/dev/null 2>&1 || true
+    fi
+  fi
 }
 
 _dots_aa_run_palette() {
-	local wallpaper="$1"
-	local scheme_type="$2"
-	local dark_mode="$3"
+  local wallpaper="$1"
+  local scheme_type="$2"
+  local dark_mode="$3"
 
-	if ! command -v wal > /dev/null 2>&1; then
-		echo "apply-appearance: wal not found" >&2
-		return 1
-	fi
-	# Drop any prior wal→image symlink before wal runs; echoing a path through
-	# that symlink would truncate the wallpaper file itself.
-	mkdir -p "$HOME/.cache/wal"
-	rm -f "$HOME/.cache/wal/wal"
-	if [[ $dark_mode == "light" ]]; then
-		wal -i "$wallpaper" -q -l || return 1
-	else
-		wal -i "$wallpaper" -q || return 1
-	fi
+  if ! command -v wal >/dev/null 2>&1; then
+    echo "apply-appearance: wal not found" >&2
+    return 1
+  fi
+  # Drop any prior wal→image symlink before wal runs; echoing a path through
+  # that symlink would truncate the wallpaper file itself.
+  mkdir -p "$HOME/.cache/wal"
+  rm -f "$HOME/.cache/wal/wal"
+  if [[ $dark_mode == "light" ]]; then
+    wal -i "$wallpaper" -q -l || return 1
+  else
+    wal -i "$wallpaper" -q || return 1
+  fi
 
-	_dots_aa_write_pointer "$wallpaper"
-	rm -f "$HOME/.cache/wal/wal"
-	printf '%s\n' "$wallpaper" > "$HOME/.cache/wal/wal"
+  _dots_aa_write_pointer "$wallpaper"
+  rm -f "$HOME/.cache/wal/wal"
+  printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
 
-	[[ -f $DOTS_M3_SCRIPT ]] || {
-		echo "apply-appearance: missing generate-m3-colors.py" >&2
-		return 1
-	}
-	mkdir -p "$(dirname "$DOTS_SCHEME_FILE")"
-	python3 "$DOTS_M3_SCRIPT" \
-		--image "$wallpaper" \
-		--scheme-type "$scheme_type" \
-		--mode "$dark_mode" \
-		--output "$DOTS_SCHEME_FILE" || return 1
+  [[ -f $DOTS_M3_SCRIPT ]] || {
+    echo "apply-appearance: missing generate-m3-colors.py" >&2
+    return 1
+  }
+  mkdir -p "$(dirname "$DOTS_SCHEME_FILE")"
+  python3 "$DOTS_M3_SCRIPT" \
+    --image "$wallpaper" \
+    --scheme-type "$scheme_type" \
+    --mode "$dark_mode" \
+    --output "$DOTS_SCHEME_FILE" || return 1
 
-	if command -v dots-color-scheme > /dev/null 2>&1; then
-		dots-color-scheme sync-state > /dev/null 2>&1 || return 1
-	fi
-	_dots_aa_sync_gtk_color_scheme "$dark_mode"
-	if command -v dots-hyprlock-theme > /dev/null 2>&1; then
-		dots-hyprlock-theme > /dev/null 2>&1 || true
-	fi
-	if command -v hyprctl > /dev/null 2>&1; then
-		hyprctl reload > /dev/null 2>&1 || true
-	fi
-	return 0
+  if command -v dots-color-scheme >/dev/null 2>&1; then
+    dots-color-scheme sync-state >/dev/null 2>&1 || return 1
+  fi
+  _dots_aa_sync_gtk_color_scheme "$dark_mode"
+  if command -v dots-hyprlock-theme >/dev/null 2>&1; then
+    dots-hyprlock-theme >/dev/null 2>&1 || true
+  fi
+  if command -v hyprctl >/dev/null 2>&1; then
+    hyprctl reload >/dev/null 2>&1 || true
+  fi
+  return 0
 }
 
 # Apply a theme pack once (no persistent current-theme state).
 dots_apply_theme() {
-	local theme_id="${1:-}"
-	local wallpaper_override="${2:-}"
+  local theme_id="${1:-}"
+  local wallpaper_override="${2:-}"
 
-	[[ -n $theme_id ]] || {
-		echo "dots_apply_theme: theme id required" >&2
-		return 1
-	}
-	local config_json="$DOTS_THEMES_DIR/$theme_id/theme.json"
-	[[ -f $config_json ]] || {
-		echo "dots_apply_theme: theme not found: $theme_id" >&2
-		return 1
-	}
+  [[ -n $theme_id ]] || {
+    echo "dots_apply_theme: theme id required" >&2
+    return 1
+  }
+  local config_json="$DOTS_THEMES_DIR/$theme_id/theme.json"
+  [[ -f $config_json ]] || {
+    echo "dots_apply_theme: theme not found: $theme_id" >&2
+    return 1
+  }
 
-	local scheme_type dark_mode_raw dark_mode gtk_theme icon_theme theme_name wallpaper_dir default_wp wallpaper
-	scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$config_json" schemeType tonal-spot)")"
-	dark_mode_raw="$(_dots_aa_json_get "$config_json" darkMode true)"
-	if [[ $dark_mode_raw == "false" ]]; then
-		dark_mode="light"
-	else
-		dark_mode="dark"
-	fi
-	gtk_theme="$(_dots_aa_json_get "$config_json" gtkTheme Orchis-Dark)"
-	icon_theme="$(_dots_aa_json_get "$config_json" iconTheme Numix-Circle)"
-	theme_name="$(_dots_aa_json_get "$config_json" name "$theme_id")"
-	wallpaper_dir="$(_dots_aa_json_get "$config_json" wallpaperDir "$theme_id")"
-	default_wp="$(_dots_aa_json_get "$config_json" defaultWallpaper "")"
+  local scheme_type dark_mode_raw dark_mode gtk_theme icon_theme theme_name wallpaper_dir default_wp wallpaper
+  scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$config_json" schemeType tonal-spot)")"
+  dark_mode_raw="$(_dots_aa_json_get "$config_json" darkMode true)"
+  if [[ $dark_mode_raw == "false" ]]; then
+    dark_mode="light"
+  else
+    dark_mode="dark"
+  fi
+  gtk_theme="$(_dots_aa_json_get "$config_json" gtkTheme Orchis-Dark)"
+  icon_theme="$(_dots_aa_json_get "$config_json" iconTheme Numix-Circle)"
+  theme_name="$(_dots_aa_json_get "$config_json" name "$theme_id")"
+  wallpaper_dir="$(_dots_aa_json_get "$config_json" wallpaperDir "$theme_id")"
+  default_wp="$(_dots_aa_json_get "$config_json" defaultWallpaper "")"
 
-	wallpaper="$(_dots_aa_resolve_theme_wallpaper "$theme_id" "$wallpaper_dir" "$default_wp" "$wallpaper_override" || true)"
-	[[ -n ${wallpaper:-} && -f $wallpaper ]] || {
-		echo "dots_apply_theme: no wallpaper for theme $theme_id" >&2
-		return 1
-	}
+  wallpaper="$(_dots_aa_resolve_theme_wallpaper "$theme_id" "$wallpaper_dir" "$default_wp" "$wallpaper_override" || true)"
+  [[ -n ${wallpaper:-} && -f $wallpaper ]] || {
+    echo "dots_apply_theme: no wallpaper for theme $theme_id" >&2
+    return 1
+  }
 
-	_dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode" || return 1
+  _dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode" || return 1
 
-	if command -v dots-gtk-theme > /dev/null 2>&1; then
-		if [[ -n $gtk_theme && $gtk_theme != "auto" ]]; then
-			dots-gtk-theme apply "$gtk_theme" > /dev/null 2>&1 || true
-		fi
-	fi
-	if [[ -n $icon_theme ]] && command -v gsettings > /dev/null 2>&1; then
-		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" > /dev/null 2>&1 || true
-	fi
-	_dots_aa_sync_gtk_color_scheme "$dark_mode"
+  if command -v dots-gtk-theme >/dev/null 2>&1; then
+    if [[ -n $gtk_theme && $gtk_theme != "auto" ]]; then
+      local prefer
+      prefer=$([[ $dark_mode == "light" ]] && echo false || echo true)
+      dots-gtk-theme -q apply "$gtk_theme" "${icon_theme:-Numix-Circle}" "$prefer" >/dev/null 2>&1 || true
+    elif [[ $gtk_theme == "auto" ]]; then
+      dots-gtk-theme -q theme "$theme_id" >/dev/null 2>&1 || true
+      dots-gtk-theme -q color-scheme "$dark_mode" >/dev/null 2>&1 || true
+    elif [[ -n $icon_theme ]]; then
+      dots-gtk-theme -q set-icons "$icon_theme" >/dev/null 2>&1 || true
+      dots-gtk-theme -q color-scheme "$dark_mode" >/dev/null 2>&1 || true
+    else
+      dots-gtk-theme -q color-scheme "$dark_mode" >/dev/null 2>&1 || true
+    fi
+  elif [[ -n $icon_theme ]] && command -v gsettings >/dev/null 2>&1; then
+    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" >/dev/null 2>&1 || true
+    _dots_aa_sync_gtk_color_scheme "$dark_mode"
+  else
+    _dots_aa_sync_gtk_color_scheme "$dark_mode"
+  fi
 
-	if [[ -f $HOME/.local/lib/dots/snappy-switcher-manager.sh ]]; then
-		# shellcheck source=/dev/null
-		source "$HOME/.local/lib/dots/snappy-switcher-manager.sh" 2> /dev/null || true
-		if declare -f apply_theme_snappy_switcher_theme > /dev/null 2>&1; then
-			apply_theme_snappy_switcher_theme "$theme_id" > /dev/null 2>&1 || true
-		fi
-	fi
+  if [[ -f $HOME/.local/lib/dots/snappy-switcher-manager.sh ]]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.local/lib/dots/snappy-switcher-manager.sh" 2>/dev/null || true
+    if declare -f apply_theme_snappy_switcher_theme >/dev/null 2>&1; then
+      apply_theme_snappy_switcher_theme "$theme_id" >/dev/null 2>&1 || true
+    fi
+  fi
 
-	if command -v notify-send > /dev/null 2>&1; then
-		notify-send "HorneroConfig" "${theme_name} theme applied" > /dev/null 2>&1 || true
-	fi
-	return 0
+  if command -v notify-send >/dev/null 2>&1; then
+    notify-send "HorneroConfig" "${theme_name} theme applied" >/dev/null 2>&1 || true
+  fi
+  return 0
 }
 
 # Back-compat name used by older callers during transition.
 dots_apply_appearance() {
-	dots_apply_theme "$@"
+  dots_apply_theme "$@"
 }
 
 # Wallpaper-only: live mode/flavour from scheme state.
 dots_apply_wallpaper_only() {
-	local wallpaper="${1:-}"
-	wallpaper="$(readlink -f "$wallpaper" 2> /dev/null || true)"
-	[[ -n ${wallpaper:-} && -f $wallpaper ]] || {
-		echo "dots_apply_wallpaper_only: wallpaper not found" >&2
-		return 1
-	}
+  local wallpaper="${1:-}"
+  wallpaper="$(readlink -f "$wallpaper" 2>/dev/null || true)"
+  [[ -n ${wallpaper:-} && -f $wallpaper ]] || {
+    echo "dots_apply_wallpaper_only: wallpaper not found" >&2
+    return 1
+  }
 
-	local scheme_type="tonal-spot" dark_mode="dark"
-	local state_file="$DOTS_STATE_DIR/scheme/state.json"
-	if [[ -f $state_file ]]; then
-		scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$state_file" flavour tonal-spot)")"
-		dark_mode="$(_dots_aa_json_get "$state_file" mode dark)"
-		[[ $dark_mode == "light" || $dark_mode == "dark" ]] || dark_mode="dark"
-	fi
+  local scheme_type="tonal-spot" dark_mode="dark"
+  local state_file="$DOTS_STATE_DIR/scheme/state.json"
+  if [[ -f $state_file ]]; then
+    scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$state_file" flavour tonal-spot)")"
+    dark_mode="$(_dots_aa_json_get "$state_file" mode dark)"
+    [[ $dark_mode == "light" || $dark_mode == "dark" ]] || dark_mode="dark"
+  fi
 
-	_dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode"
+  _dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode"
 }

--- a/home/dot_local/lib/dots/apply-appearance.sh
+++ b/home/dot_local/lib/dots/apply-appearance.sh
@@ -12,8 +12,8 @@ DOTS_M3_SCRIPT="${DOTS_M3_SCRIPT:-$HOME/.local/lib/dots/generate-m3-colors.py}"
 DOTS_PICTURES_WALLPAPERS="${DOTS_PICTURES_WALLPAPERS:-$HOME/Pictures/Wallpapers}"
 
 _dots_aa_json_get() {
-  local file="$1" key="$2" default="${3:-}"
-  python3 - "$file" "$key" "$default" <<'PY'
+	local file="$1" key="$2" default="${3:-}"
+	python3 - "$file" "$key" "$default" << 'PY'
 import json, sys
 path, key, default = sys.argv[1], sys.argv[2], sys.argv[3]
 try:
@@ -33,209 +33,209 @@ PY
 }
 
 _dots_aa_write_pointer() {
-  local path="$1"
-  mkdir -p "$(dirname "$DOTS_WALLPAPER_POINTER_FILE")"
-  printf '%s\n' "$path" >"$DOTS_WALLPAPER_POINTER_FILE"
+	local path="$1"
+	mkdir -p "$(dirname "$DOTS_WALLPAPER_POINTER_FILE")"
+	printf '%s\n' "$path" > "$DOTS_WALLPAPER_POINTER_FILE"
 }
 
 _dots_aa_normalize_scheme_type() {
-  local raw="${1:-tonal-spot}"
-  raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
-  case "$raw" in
-    vibrant | expressive | fidelity | content | neutral | monochrome) printf '%s\n' "$raw" ;;
-    tonalspot | tonal-spot) printf 'tonal-spot\n' ;;
-    *) printf 'tonal-spot\n' ;;
-  esac
+	local raw="${1:-tonal-spot}"
+	raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
+	case "$raw" in
+		vibrant | expressive | fidelity | content | neutral | monochrome) printf '%s\n' "$raw" ;;
+		tonalspot | tonal-spot) printf 'tonal-spot\n' ;;
+		*) printf 'tonal-spot\n' ;;
+	esac
 }
 
 _dots_aa_resolve_theme_wallpaper() {
-  local theme_id="$1"
-  local wallpaper_dir="$2"
-  local default_name="$3"
-  local override="${4:-}"
-  local candidate=""
+	local theme_id="$1"
+	local wallpaper_dir="$2"
+	local default_name="$3"
+	local override="${4:-}"
+	local candidate=""
 
-  if [[ -n $override ]]; then
-    candidate="$(readlink -f "$override" 2>/dev/null || true)"
-    [[ -n ${candidate:-} && -f $candidate ]] && {
-      printf '%s\n' "$candidate"
-      return 0
-    }
-  fi
+	if [[ -n $override ]]; then
+		candidate="$(readlink -f "$override" 2> /dev/null || true)"
+		[[ -n ${candidate:-} && -f $candidate ]] && {
+			printf '%s\n' "$candidate"
+			return 0
+		}
+	fi
 
-  for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
-    if [[ -n $default_name && -f $base/$default_name ]]; then
-      readlink -f "$base/$default_name"
-      return 0
-    fi
-  done
+	for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
+		if [[ -n $default_name && -f $base/$default_name ]]; then
+			readlink -f "$base/$default_name"
+			return 0
+		fi
+	done
 
-  for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
-    [[ -d $base ]] || continue
-    candidate="$(
-      find -L "$base" -maxdepth 1 \( -type f -o -type l \) \
-        \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" \
-        -o -iname "*.gif" -o -iname "*.bmp" \) 2>/dev/null | sort | head -n 1 || true
-    )"
-    [[ -n ${candidate:-} && -f $candidate ]] && {
-      printf '%s\n' "$candidate"
-      return 0
-    }
-  done
-  return 1
+	for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
+		[[ -d $base ]] || continue
+		candidate="$(
+			find -L "$base" -maxdepth 1 \( -type f -o -type l \) \
+				\( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" \
+				-o -iname "*.gif" -o -iname "*.bmp" \) 2> /dev/null | sort | head -n 1 || true
+		)"
+		[[ -n ${candidate:-} && -f $candidate ]] && {
+			printf '%s\n' "$candidate"
+			return 0
+		}
+	done
+	return 1
 }
 
 _dots_aa_sync_gtk_color_scheme() {
-  local mode="${1:-dark}"
-  if [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
-    # shellcheck source=/dev/null
-    source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
-    if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
-      apply_gtk_color_scheme "$mode" >/dev/null 2>&1 || true
-    fi
-  fi
+	local mode="${1:-dark}"
+	if [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
+		# shellcheck source=/dev/null
+		source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2> /dev/null || true
+		if declare -f apply_gtk_color_scheme > /dev/null 2>&1; then
+			apply_gtk_color_scheme "$mode" > /dev/null 2>&1 || true
+		fi
+	fi
 }
 
 _dots_aa_run_palette() {
-  local wallpaper="$1"
-  local scheme_type="$2"
-  local dark_mode="$3"
+	local wallpaper="$1"
+	local scheme_type="$2"
+	local dark_mode="$3"
 
-  if ! command -v wal >/dev/null 2>&1; then
-    echo "apply-appearance: wal not found" >&2
-    return 1
-  fi
-  # Drop any prior wal→image symlink before wal runs; echoing a path through
-  # that symlink would truncate the wallpaper file itself.
-  mkdir -p "$HOME/.cache/wal"
-  rm -f "$HOME/.cache/wal/wal"
-  if [[ $dark_mode == "light" ]]; then
-    wal -i "$wallpaper" -q -l || return 1
-  else
-    wal -i "$wallpaper" -q || return 1
-  fi
+	if ! command -v wal > /dev/null 2>&1; then
+		echo "apply-appearance: wal not found" >&2
+		return 1
+	fi
+	# Drop any prior wal→image symlink before wal runs; echoing a path through
+	# that symlink would truncate the wallpaper file itself.
+	mkdir -p "$HOME/.cache/wal"
+	rm -f "$HOME/.cache/wal/wal"
+	if [[ $dark_mode == "light" ]]; then
+		wal -i "$wallpaper" -q -l || return 1
+	else
+		wal -i "$wallpaper" -q || return 1
+	fi
 
-  _dots_aa_write_pointer "$wallpaper"
-  rm -f "$HOME/.cache/wal/wal"
-  printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
+	_dots_aa_write_pointer "$wallpaper"
+	rm -f "$HOME/.cache/wal/wal"
+	printf '%s\n' "$wallpaper" > "$HOME/.cache/wal/wal"
 
-  [[ -f $DOTS_M3_SCRIPT ]] || {
-    echo "apply-appearance: missing generate-m3-colors.py" >&2
-    return 1
-  }
-  mkdir -p "$(dirname "$DOTS_SCHEME_FILE")"
-  python3 "$DOTS_M3_SCRIPT" \
-    --image "$wallpaper" \
-    --scheme-type "$scheme_type" \
-    --mode "$dark_mode" \
-    --output "$DOTS_SCHEME_FILE" || return 1
+	[[ -f $DOTS_M3_SCRIPT ]] || {
+		echo "apply-appearance: missing generate-m3-colors.py" >&2
+		return 1
+	}
+	mkdir -p "$(dirname "$DOTS_SCHEME_FILE")"
+	python3 "$DOTS_M3_SCRIPT" \
+		--image "$wallpaper" \
+		--scheme-type "$scheme_type" \
+		--mode "$dark_mode" \
+		--output "$DOTS_SCHEME_FILE" || return 1
 
-  if command -v dots-color-scheme >/dev/null 2>&1; then
-    dots-color-scheme sync-state >/dev/null 2>&1 || return 1
-  fi
-  _dots_aa_sync_gtk_color_scheme "$dark_mode"
-  if command -v dots-hyprlock-theme >/dev/null 2>&1; then
-    dots-hyprlock-theme >/dev/null 2>&1 || true
-  fi
-  if command -v hyprctl >/dev/null 2>&1; then
-    hyprctl reload >/dev/null 2>&1 || true
-  fi
-  return 0
+	if command -v dots-color-scheme > /dev/null 2>&1; then
+		dots-color-scheme sync-state > /dev/null 2>&1 || return 1
+	fi
+	_dots_aa_sync_gtk_color_scheme "$dark_mode"
+	if command -v dots-hyprlock-theme > /dev/null 2>&1; then
+		dots-hyprlock-theme > /dev/null 2>&1 || true
+	fi
+	if command -v hyprctl > /dev/null 2>&1; then
+		hyprctl reload > /dev/null 2>&1 || true
+	fi
+	return 0
 }
 
 # Apply a theme pack once (no persistent current-theme state).
 dots_apply_theme() {
-  local theme_id="${1:-}"
-  local wallpaper_override="${2:-}"
+	local theme_id="${1:-}"
+	local wallpaper_override="${2:-}"
 
-  [[ -n $theme_id ]] || {
-    echo "dots_apply_theme: theme id required" >&2
-    return 1
-  }
-  local config_json="$DOTS_THEMES_DIR/$theme_id/theme.json"
-  [[ -f $config_json ]] || {
-    echo "dots_apply_theme: theme not found: $theme_id" >&2
-    return 1
-  }
+	[[ -n $theme_id ]] || {
+		echo "dots_apply_theme: theme id required" >&2
+		return 1
+	}
+	local config_json="$DOTS_THEMES_DIR/$theme_id/theme.json"
+	[[ -f $config_json ]] || {
+		echo "dots_apply_theme: theme not found: $theme_id" >&2
+		return 1
+	}
 
-  local scheme_type dark_mode_raw dark_mode gtk_theme icon_theme theme_name wallpaper_dir default_wp wallpaper
-  scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$config_json" schemeType tonal-spot)")"
-  dark_mode_raw="$(_dots_aa_json_get "$config_json" darkMode true)"
-  if [[ $dark_mode_raw == "false" ]]; then
-    dark_mode="light"
-  else
-    dark_mode="dark"
-  fi
-  gtk_theme="$(_dots_aa_json_get "$config_json" gtkTheme Orchis-Dark)"
-  icon_theme="$(_dots_aa_json_get "$config_json" iconTheme Numix-Circle)"
-  theme_name="$(_dots_aa_json_get "$config_json" name "$theme_id")"
-  wallpaper_dir="$(_dots_aa_json_get "$config_json" wallpaperDir "$theme_id")"
-  default_wp="$(_dots_aa_json_get "$config_json" defaultWallpaper "")"
+	local scheme_type dark_mode_raw dark_mode gtk_theme icon_theme theme_name wallpaper_dir default_wp wallpaper
+	scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$config_json" schemeType tonal-spot)")"
+	dark_mode_raw="$(_dots_aa_json_get "$config_json" darkMode true)"
+	if [[ $dark_mode_raw == "false" ]]; then
+		dark_mode="light"
+	else
+		dark_mode="dark"
+	fi
+	gtk_theme="$(_dots_aa_json_get "$config_json" gtkTheme Orchis-Dark)"
+	icon_theme="$(_dots_aa_json_get "$config_json" iconTheme Numix-Circle)"
+	theme_name="$(_dots_aa_json_get "$config_json" name "$theme_id")"
+	wallpaper_dir="$(_dots_aa_json_get "$config_json" wallpaperDir "$theme_id")"
+	default_wp="$(_dots_aa_json_get "$config_json" defaultWallpaper "")"
 
-  wallpaper="$(_dots_aa_resolve_theme_wallpaper "$theme_id" "$wallpaper_dir" "$default_wp" "$wallpaper_override" || true)"
-  [[ -n ${wallpaper:-} && -f $wallpaper ]] || {
-    echo "dots_apply_theme: no wallpaper for theme $theme_id" >&2
-    return 1
-  }
+	wallpaper="$(_dots_aa_resolve_theme_wallpaper "$theme_id" "$wallpaper_dir" "$default_wp" "$wallpaper_override" || true)"
+	[[ -n ${wallpaper:-} && -f $wallpaper ]] || {
+		echo "dots_apply_theme: no wallpaper for theme $theme_id" >&2
+		return 1
+	}
 
-  _dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode" || return 1
+	_dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode" || return 1
 
-  if command -v dots-gtk-theme >/dev/null 2>&1; then
-    if [[ -n $gtk_theme && $gtk_theme != "auto" ]]; then
-      local prefer
-      prefer=$([[ $dark_mode == "light" ]] && echo false || echo true)
-      dots-gtk-theme -q apply "$gtk_theme" "${icon_theme:-Numix-Circle}" "$prefer" >/dev/null 2>&1 || true
-    elif [[ $gtk_theme == "auto" ]]; then
-      dots-gtk-theme -q theme "$theme_id" >/dev/null 2>&1 || true
-      dots-gtk-theme -q color-scheme "$dark_mode" >/dev/null 2>&1 || true
-    elif [[ -n $icon_theme ]]; then
-      dots-gtk-theme -q set-icons "$icon_theme" >/dev/null 2>&1 || true
-      dots-gtk-theme -q color-scheme "$dark_mode" >/dev/null 2>&1 || true
-    else
-      dots-gtk-theme -q color-scheme "$dark_mode" >/dev/null 2>&1 || true
-    fi
-  elif [[ -n $icon_theme ]] && command -v gsettings >/dev/null 2>&1; then
-    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" >/dev/null 2>&1 || true
-    _dots_aa_sync_gtk_color_scheme "$dark_mode"
-  else
-    _dots_aa_sync_gtk_color_scheme "$dark_mode"
-  fi
+	if command -v dots-gtk-theme > /dev/null 2>&1; then
+		if [[ -n $gtk_theme && $gtk_theme != "auto" ]]; then
+			local prefer
+			prefer=$([[ $dark_mode == "light" ]] && echo false || echo true)
+			dots-gtk-theme -q apply "$gtk_theme" "${icon_theme:-Numix-Circle}" "$prefer" > /dev/null 2>&1 || true
+		elif [[ $gtk_theme == "auto" ]]; then
+			dots-gtk-theme -q theme "$theme_id" > /dev/null 2>&1 || true
+			dots-gtk-theme -q color-scheme "$dark_mode" > /dev/null 2>&1 || true
+		elif [[ -n $icon_theme ]]; then
+			dots-gtk-theme -q set-icons "$icon_theme" > /dev/null 2>&1 || true
+			dots-gtk-theme -q color-scheme "$dark_mode" > /dev/null 2>&1 || true
+		else
+			dots-gtk-theme -q color-scheme "$dark_mode" > /dev/null 2>&1 || true
+		fi
+	elif [[ -n $icon_theme ]] && command -v gsettings > /dev/null 2>&1; then
+		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" > /dev/null 2>&1 || true
+		_dots_aa_sync_gtk_color_scheme "$dark_mode"
+	else
+		_dots_aa_sync_gtk_color_scheme "$dark_mode"
+	fi
 
-  if [[ -f $HOME/.local/lib/dots/snappy-switcher-manager.sh ]]; then
-    # shellcheck source=/dev/null
-    source "$HOME/.local/lib/dots/snappy-switcher-manager.sh" 2>/dev/null || true
-    if declare -f apply_theme_snappy_switcher_theme >/dev/null 2>&1; then
-      apply_theme_snappy_switcher_theme "$theme_id" >/dev/null 2>&1 || true
-    fi
-  fi
+	if [[ -f $HOME/.local/lib/dots/snappy-switcher-manager.sh ]]; then
+		# shellcheck source=/dev/null
+		source "$HOME/.local/lib/dots/snappy-switcher-manager.sh" 2> /dev/null || true
+		if declare -f apply_theme_snappy_switcher_theme > /dev/null 2>&1; then
+			apply_theme_snappy_switcher_theme "$theme_id" > /dev/null 2>&1 || true
+		fi
+	fi
 
-  if command -v notify-send >/dev/null 2>&1; then
-    notify-send "HorneroConfig" "${theme_name} theme applied" >/dev/null 2>&1 || true
-  fi
-  return 0
+	if command -v notify-send > /dev/null 2>&1; then
+		notify-send "HorneroConfig" "${theme_name} theme applied" > /dev/null 2>&1 || true
+	fi
+	return 0
 }
 
 # Back-compat name used by older callers during transition.
 dots_apply_appearance() {
-  dots_apply_theme "$@"
+	dots_apply_theme "$@"
 }
 
 # Wallpaper-only: live mode/flavour from scheme state.
 dots_apply_wallpaper_only() {
-  local wallpaper="${1:-}"
-  wallpaper="$(readlink -f "$wallpaper" 2>/dev/null || true)"
-  [[ -n ${wallpaper:-} && -f $wallpaper ]] || {
-    echo "dots_apply_wallpaper_only: wallpaper not found" >&2
-    return 1
-  }
+	local wallpaper="${1:-}"
+	wallpaper="$(readlink -f "$wallpaper" 2> /dev/null || true)"
+	[[ -n ${wallpaper:-} && -f $wallpaper ]] || {
+		echo "dots_apply_wallpaper_only: wallpaper not found" >&2
+		return 1
+	}
 
-  local scheme_type="tonal-spot" dark_mode="dark"
-  local state_file="$DOTS_STATE_DIR/scheme/state.json"
-  if [[ -f $state_file ]]; then
-    scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$state_file" flavour tonal-spot)")"
-    dark_mode="$(_dots_aa_json_get "$state_file" mode dark)"
-    [[ $dark_mode == "light" || $dark_mode == "dark" ]] || dark_mode="dark"
-  fi
+	local scheme_type="tonal-spot" dark_mode="dark"
+	local state_file="$DOTS_STATE_DIR/scheme/state.json"
+	if [[ -f $state_file ]]; then
+		scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$state_file" flavour tonal-spot)")"
+		dark_mode="$(_dots_aa_json_get "$state_file" mode dark)"
+		[[ $dark_mode == "light" || $dark_mode == "dark" ]] || dark_mode="dark"
+	fi
 
-  _dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode"
+	_dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode"
 }

--- a/home/dot_local/lib/dots/gtk-theme-manager.sh
+++ b/home/dot_local/lib/dots/gtk-theme-manager.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 # Source smart colors for theme detection
 if [[ -f "$HOME/.local/lib/dots/smart-colors.sh" ]]; then
-  source "$HOME/.local/lib/dots/smart-colors.sh"
+	source "$HOME/.local/lib/dots/smart-colors.sh"
 fi
 
 # GTK configuration paths
@@ -28,120 +28,120 @@ readonly GTK3_CONFIG="$HOME/.config/gtk-3.0/settings.ini"
 
 # Function to log messages
 log() {
-  local level="$1"
-  shift
-  local message="$*"
-  local timestamp
-  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+	local level="$1"
+	shift
+	local message="$*"
+	local timestamp
+	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-  echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
+	echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
 }
 
 # Function to check if a GTK theme is installed
 is_gtk_theme_installed() {
-  local theme_name="$1"
+	local theme_name="$1"
 
-  # Check in common theme directories
-  local theme_dirs=(
-    "/usr/share/themes"
-    "/usr/local/share/themes"
-    "$HOME/.themes"
-    "$HOME/.local/share/themes"
-  )
+	# Check in common theme directories
+	local theme_dirs=(
+		"/usr/share/themes"
+		"/usr/local/share/themes"
+		"$HOME/.themes"
+		"$HOME/.local/share/themes"
+	)
 
-  for theme_dir in "${theme_dirs[@]}"; do
-    if [[ -d "$theme_dir/$theme_name" ]]; then
-      return 0
-    fi
-  done
+	for theme_dir in "${theme_dirs[@]}"; do
+		if [[ -d "$theme_dir/$theme_name" ]]; then
+			return 0
+		fi
+	done
 
-  return 1
+	return 1
 }
 
 # Function to check if an icon theme is installed
 is_icon_theme_installed() {
-  local icon_theme="$1"
+	local icon_theme="$1"
 
-  # Check in common icon directories
-  local icon_dirs=(
-    "/usr/share/icons"
-    "/usr/local/share/icons"
-    "$HOME/.icons"
-    "$HOME/.local/share/icons"
-  )
+	# Check in common icon directories
+	local icon_dirs=(
+		"/usr/share/icons"
+		"/usr/local/share/icons"
+		"$HOME/.icons"
+		"$HOME/.local/share/icons"
+	)
 
-  for icon_dir in "${icon_dirs[@]}"; do
-    if [[ -d "$icon_dir/$icon_theme" ]]; then
-      return 0
-    fi
-  done
+	for icon_dir in "${icon_dirs[@]}"; do
+		if [[ -d "$icon_dir/$icon_theme" ]]; then
+			return 0
+		fi
+	done
 
-  return 1
+	return 1
 }
 
 # Function to apply GTK theme with fallbacks
 apply_gtk_theme() {
-  local gtk_theme="$1"
-  local icon_theme="${2:-elementary}"
-  local prefer_dark="${3:-false}"
+	local gtk_theme="$1"
+	local icon_theme="${2:-elementary}"
+	local prefer_dark="${3:-false}"
 
-  log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
+	log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
 
-  # Validate theme availability with fallbacks
-  if ! is_gtk_theme_installed "$gtk_theme"; then
-    log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
+	# Validate theme availability with fallbacks
+	if ! is_gtk_theme_installed "$gtk_theme"; then
+		log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
 
-    # Common fallback themes in order of preference
-    local fallback_themes=(
-      "Orchis-Light"
-      "elementary"
-      "Arc-Dark"
-      "Arc"
-      "Breeze"
-      "oxygen-gtk"
-    )
+		# Common fallback themes in order of preference
+		local fallback_themes=(
+			"Orchis-Light"
+			"elementary"
+			"Arc-Dark"
+			"Arc"
+			"Breeze"
+			"oxygen-gtk"
+		)
 
-    for fallback in "${fallback_themes[@]}"; do
-      if is_gtk_theme_installed "$fallback"; then
-        gtk_theme="$fallback"
-        log "INFO" "Using fallback theme: $gtk_theme"
-        break
-      fi
-    done
+		for fallback in "${fallback_themes[@]}"; do
+			if is_gtk_theme_installed "$fallback"; then
+				gtk_theme="$fallback"
+				log "INFO" "Using fallback theme: $gtk_theme"
+				break
+			fi
+		done
 
-    if ! is_gtk_theme_installed "$gtk_theme"; then
-      log "ERROR" "No suitable GTK theme found, keeping current theme"
-      return 1
-    fi
-  fi
+		if ! is_gtk_theme_installed "$gtk_theme"; then
+			log "ERROR" "No suitable GTK theme found, keeping current theme"
+			return 1
+		fi
+	fi
 
-  # Validate icon theme with fallbacks
-  if ! is_icon_theme_installed "$icon_theme"; then
-    log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
+	# Validate icon theme with fallbacks
+	if ! is_icon_theme_installed "$icon_theme"; then
+		log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
 
-    local fallback_icons=(
-      "Numix-Circle"
-      "elementary"
-      "hicolor"
-    )
+		local fallback_icons=(
+			"Numix-Circle"
+			"elementary"
+			"hicolor"
+		)
 
-    for fallback in "${fallback_icons[@]}"; do
-      if is_icon_theme_installed "$fallback"; then
-        icon_theme="$fallback"
-        log "INFO" "Using fallback icon theme: $icon_theme"
-        break
-      fi
-    done
-  fi
+		for fallback in "${fallback_icons[@]}"; do
+			if is_icon_theme_installed "$fallback"; then
+				icon_theme="$fallback"
+				log "INFO" "Using fallback icon theme: $icon_theme"
+				break
+			fi
+		done
+	fi
 
-  # Update GTK2 configuration
-  if [[ -f $GTK2_CONFIG ]]; then
-    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
-    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
-    log "INFO" "Updated GTK2 configuration"
-  else
-    log "WARN" "GTK2 config not found, creating basic configuration"
-    cat >"$GTK2_CONFIG" <<EOF
+	# Update GTK2 configuration
+	if [[ -f $GTK2_CONFIG ]]; then
+		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
+		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
+		log "INFO" "Updated GTK2 configuration"
+	else
+		log "WARN" "GTK2 config not found, creating basic configuration"
+		cat > "$GTK2_CONFIG" << EOF
 # DO NOT EDIT! This file will be overwritten by LXAppearance.
 # Any customization should be done in ~/.gtkrc-2.0.mine instead.
 
@@ -162,18 +162,18 @@ gtk-xft-hinting=1
 gtk-xft-hintstyle="hintslight"
 gtk-xft-rgba="rgb"
 EOF
-  fi
+	fi
 
-  # Update GTK3 configuration
-  if [[ -f $GTK3_CONFIG ]]; then
-    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
-    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
-    sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-    log "INFO" "Updated GTK3 configuration"
-  else
-    log "WARN" "GTK3 config not found, creating configuration"
-    mkdir -p "$(dirname "$GTK3_CONFIG")"
-    cat >"$GTK3_CONFIG" <<EOF
+	# Update GTK3 configuration
+	if [[ -f $GTK3_CONFIG ]]; then
+		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
+		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
+		sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+		log "INFO" "Updated GTK3 configuration"
+	else
+		log "WARN" "GTK3 config not found, creating configuration"
+		mkdir -p "$(dirname "$GTK3_CONFIG")"
+		cat > "$GTK3_CONFIG" << EOF
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 gtk-theme-name=$gtk_theme
@@ -193,317 +193,317 @@ gtk-xft-hintstyle=hintslight
 gtk-xft-rgba=rgb
 gtk-modules=colorreload-gtk-module
 EOF
-  fi
+	fi
 
-  # Notify running GTK applications to reload themes
-  if command -v gsettings >/dev/null 2>&1; then
-    gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2>/dev/null || true
-    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2>/dev/null || true
-    # Older schemas expose this key; portals/libadwaita use color-scheme instead.
-    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
-    log "INFO" "Updated gsettings"
-  fi
+	# Notify running GTK applications to reload themes
+	if command -v gsettings > /dev/null 2>&1; then
+		gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2> /dev/null || true
+		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2> /dev/null || true
+		# Older schemas expose this key; portals/libadwaita use color-scheme instead.
+		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
+		log "INFO" "Updated gsettings"
+	fi
 
-  # Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
-  if [[ $prefer_dark == "true" ]]; then
-    apply_gtk_color_scheme dark
-  else
-    apply_gtk_color_scheme light
-  fi
+	# Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
+	if [[ $prefer_dark == "true" ]]; then
+		apply_gtk_color_scheme dark
+	else
+		apply_gtk_color_scheme light
+	fi
 
-  # XFCE4 settings support removed - using gsettings only
-  # If running XFCE4 session, gsettings should be sufficient
-  # Legacy xfconf-query support can be re-enabled if needed
+	# XFCE4 settings support removed - using gsettings only
+	# If running XFCE4 session, gsettings should be sufficient
+	# Legacy xfconf-query support can be re-enabled if needed
 
-  log "INFO" "GTK theme applied successfully: $gtk_theme"
-  return 0
+	log "INFO" "GTK theme applied successfully: $gtk_theme"
+	return 0
 }
 
 # Sync GTK/libadwaita light-dark preference without changing the theme name.
 # mode: "dark" | "light"
 apply_gtk_color_scheme() {
-  local mode="${1:-dark}"
-  local prefer_dark="true"
-  local color_scheme="prefer-dark"
-  if [[ $mode == "light" ]]; then
-    prefer_dark="false"
-    color_scheme="prefer-light"
-  elif [[ $mode != "dark" ]]; then
-    log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
-    return 1
-  fi
+	local mode="${1:-dark}"
+	local prefer_dark="true"
+	local color_scheme="prefer-dark"
+	if [[ $mode == "light" ]]; then
+		prefer_dark="false"
+		color_scheme="prefer-light"
+	elif [[ $mode != "dark" ]]; then
+		log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
+		return 1
+	fi
 
-  if [[ -f $GTK3_CONFIG ]]; then
-    if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2>/dev/null; then
-      sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-    else
-      printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >>"$GTK3_CONFIG"
-    fi
-  else
-    mkdir -p "$(dirname "$GTK3_CONFIG")" || {
-      log "ERROR" "Failed to create directory for $GTK3_CONFIG"
-      return 1
-    }
-    if ! cat >"$GTK3_CONFIG" <<EOF; then
+	if [[ -f $GTK3_CONFIG ]]; then
+		if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2> /dev/null; then
+			sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+		else
+			printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >> "$GTK3_CONFIG"
+		fi
+	else
+		mkdir -p "$(dirname "$GTK3_CONFIG")" || {
+			log "ERROR" "Failed to create directory for $GTK3_CONFIG"
+			return 1
+		}
+		if ! cat > "$GTK3_CONFIG" << EOF; then
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 EOF
-      log "ERROR" "Failed to write $GTK3_CONFIG"
-      return 1
-    fi
-    log "INFO" "Created GTK3 config for color-scheme sync"
-  fi
+			log "ERROR" "Failed to write $GTK3_CONFIG"
+			return 1
+		fi
+		log "INFO" "Created GTK3 config for color-scheme sync"
+	fi
 
-  if command -v gsettings >/dev/null 2>&1; then
-    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
-    gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" >/dev/null 2>&1 || true
-  fi
-  log "INFO" "GTK color-scheme set to $color_scheme"
-  return 0
+	if command -v gsettings > /dev/null 2>&1; then
+		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
+		gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" > /dev/null 2>&1 || true
+	fi
+	log "INFO" "GTK color-scheme set to $color_scheme"
+	return 0
 }
 
 # Function to detect optimal GTK theme based on wallpaper colors
 detect_optimal_gtk_theme() {
-  local wallpaper_path="$1"
-  local detected_theme="Orchis-Light" # Default
-  local prefer_dark="false"
+	local wallpaper_path="$1"
+	local detected_theme="Orchis-Light" # Default
+	local prefer_dark="false"
 
-  # First, try to use pywal's background color to determine if theme should be dark or light
-  if [[ -f "$HOME/.cache/wal/colors" ]]; then
-    log "INFO" "Analyzing pywal colors for optimal theme selection"
+	# First, try to use pywal's background color to determine if theme should be dark or light
+	if [[ -f "$HOME/.cache/wal/colors" ]]; then
+		log "INFO" "Analyzing pywal colors for optimal theme selection"
 
-    # Read background color from pywal
-    local bg_color
-    bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
+		# Read background color from pywal
+		local bg_color
+		bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
 
-    if [[ -n $bg_color ]]; then
-      # Convert hex to RGB and calculate brightness
-      local r=$((16#${bg_color:0:2}))
-      local g=$((16#${bg_color:2:2}))
-      local b=$((16#${bg_color:4:2}))
-      local brightness=$((r + g + b))
+		if [[ -n $bg_color ]]; then
+			# Convert hex to RGB and calculate brightness
+			local r=$((16#${bg_color:0:2}))
+			local g=$((16#${bg_color:2:2}))
+			local b=$((16#${bg_color:4:2}))
+			local brightness=$((r + g + b))
 
-      # If background is dark (low brightness), suggest dark theme
-      if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
-        log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
-        local dark_themes=(
-          "Orchis-Dark-Compact"
-          "Arc-Dark"
-          "elementary-dark"
-          "Breeze-Dark"
-        )
+			# If background is dark (low brightness), suggest dark theme
+			if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
+				log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
+				local dark_themes=(
+					"Orchis-Dark-Compact"
+					"Arc-Dark"
+					"elementary-dark"
+					"Breeze-Dark"
+				)
 
-        for theme in "${dark_themes[@]}"; do
-          if is_gtk_theme_installed "$theme"; then
-            detected_theme="$theme"
-            prefer_dark="true"
-            break
-          fi
-        done
-      else
-        log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
-        local light_themes=(
-          "Orchis-Light"
-          "Arc"
-          "elementary"
-          "Breeze"
-        )
+				for theme in "${dark_themes[@]}"; do
+					if is_gtk_theme_installed "$theme"; then
+						detected_theme="$theme"
+						prefer_dark="true"
+						break
+					fi
+				done
+			else
+				log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
+				local light_themes=(
+					"Orchis-Light"
+					"Arc"
+					"elementary"
+					"Breeze"
+				)
 
-        for theme in "${light_themes[@]}"; do
-          if is_gtk_theme_installed "$theme"; then
-            detected_theme="$theme"
-            prefer_dark="false"
-            break
-          fi
-        done
-      fi
-    fi
-  elif command -v dots-smart-colors >/dev/null 2>&1; then
-    # Fallback: use smart-colors to analyze current theme
-    log "INFO" "Using smart-colors to analyze current theme"
+				for theme in "${light_themes[@]}"; do
+					if is_gtk_theme_installed "$theme"; then
+						detected_theme="$theme"
+						prefer_dark="false"
+						break
+					fi
+				done
+			fi
+		fi
+	elif command -v dots-smart-colors > /dev/null 2>&1; then
+		# Fallback: use smart-colors to analyze current theme
+		log "INFO" "Using smart-colors to analyze current theme"
 
-    # Check if current theme is light or dark using smart-colors logic
-    if dots-smart-colors --analyze 2>/dev/null | grep -q "light theme\|bright"; then
-      log "INFO" "Light theme detected, suggesting light GTK theme"
-      local light_themes=(
-        "Orchis-Light"
-        "Arc"
-        "elementary"
-        "Breeze"
-      )
+		# Check if current theme is light or dark using smart-colors logic
+		if dots-smart-colors --analyze 2> /dev/null | grep -q "light theme\|bright"; then
+			log "INFO" "Light theme detected, suggesting light GTK theme"
+			local light_themes=(
+				"Orchis-Light"
+				"Arc"
+				"elementary"
+				"Breeze"
+			)
 
-      for theme in "${light_themes[@]}"; do
-        if is_gtk_theme_installed "$theme"; then
-          detected_theme="$theme"
-          prefer_dark="false"
-          break
-        fi
-      done
-    else
-      log "INFO" "Dark theme detected, suggesting dark GTK theme"
-      local dark_themes=(
-        "Orchis-Dark-Compact"
-        "Arc-Dark"
-        "elementary-dark"
-        "Breeze-Dark"
-      )
+			for theme in "${light_themes[@]}"; do
+				if is_gtk_theme_installed "$theme"; then
+					detected_theme="$theme"
+					prefer_dark="false"
+					break
+				fi
+			done
+		else
+			log "INFO" "Dark theme detected, suggesting dark GTK theme"
+			local dark_themes=(
+				"Orchis-Dark-Compact"
+				"Arc-Dark"
+				"elementary-dark"
+				"Breeze-Dark"
+			)
 
-      for theme in "${dark_themes[@]}"; do
-        if is_gtk_theme_installed "$theme"; then
-          detected_theme="$theme"
-          prefer_dark="true"
-          break
-        fi
-      done
-    fi
-  else
-    log "WARN" "No color analysis available, using default light theme"
-  fi
+			for theme in "${dark_themes[@]}"; do
+				if is_gtk_theme_installed "$theme"; then
+					detected_theme="$theme"
+					prefer_dark="true"
+					break
+				fi
+			done
+		fi
+	else
+		log "WARN" "No color analysis available, using default light theme"
+	fi
 
-  log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
-  echo "$detected_theme:$prefer_dark"
+	log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
+	echo "$detected_theme:$prefer_dark"
 }
 
 # Normalize prefer-dark to a real GTK boolean string (true/false).
 normalize_prefer_dark() {
-  case "${1:-auto}" in
-    true | 1 | yes | dark) echo "true" ;;
-    false | 0 | no | light) echo "false" ;;
-    *) echo "auto" ;;
-  esac
+	case "${1:-auto}" in
+		true | 1 | yes | dark) echo "true" ;;
+		false | 0 | no | light) echo "false" ;;
+		*) echo "auto" ;;
+	esac
 }
 
 # Apply GTK/icons from an appearance theme pack (one-shot recipe).
 apply_theme_gtk_theme() {
-  local theme_id="${1:-}"
+	local theme_id="${1:-}"
 
-  if [[ -z $theme_id ]]; then
-    log "WARN" "No theme specified, using wallpaper-based detection"
-    local wallpaper=""
-    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-      # shellcheck source=/dev/null
-      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-      wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
-    fi
-    if [[ -z ${wallpaper:-} ]]; then
-      wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)
-    fi
-    if [[ -n $wallpaper && -f $wallpaper ]]; then
-      local theme_info
-      theme_info=$(detect_optimal_gtk_theme "$wallpaper")
-      local gtk_theme="${theme_info%:*}"
-      local prefer_dark
-      prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-      apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
-    else
-      apply_gtk_theme "Orchis-Dark" "Numix-Circle" "true"
-    fi
-    return
-  fi
+	if [[ -z $theme_id ]]; then
+		log "WARN" "No theme specified, using wallpaper-based detection"
+		local wallpaper=""
+		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+			# shellcheck source=/dev/null
+			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+			wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
+		fi
+		if [[ -z ${wallpaper:-} ]]; then
+			wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2> /dev/null || true)
+		fi
+		if [[ -n $wallpaper && -f $wallpaper ]]; then
+			local theme_info
+			theme_info=$(detect_optimal_gtk_theme "$wallpaper")
+			local gtk_theme="${theme_info%:*}"
+			local prefer_dark
+			prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+			apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
+		else
+			apply_gtk_theme "Orchis-Dark" "Numix-Circle" "true"
+		fi
+		return
+	fi
 
-  log "INFO" "Applying GTK theme from appearance pack: $theme_id"
+	log "INFO" "Applying GTK theme from appearance pack: $theme_id"
 
-  local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
-  local theme_json="$HOME/.local/share/dots/themes/$theme_id/theme.json"
+	local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
+	local theme_json="$HOME/.local/share/dots/themes/$theme_id/theme.json"
 
-  if [[ ! -f $theme_json ]]; then
-    log "ERROR" "Theme pack not found: $theme_id ($theme_json)"
-    return 1
-  fi
+	if [[ ! -f $theme_json ]]; then
+		log "ERROR" "Theme pack not found: $theme_id ($theme_json)"
+		return 1
+	fi
 
-  local meta
-  meta="$(
-    python3 - "$theme_json" <<'PY'
+	local meta
+	meta="$(
+		python3 - "$theme_json" << 'PY'
 import json, sys
 data = json.load(open(sys.argv[1], encoding="utf-8"))
 print(data.get("gtkTheme") or "auto")
 print(data.get("iconTheme") or "Numix-Circle")
 print("true" if data.get("darkMode", True) else "false")
 PY
-  )"
-  gtk_theme="$(sed -n '1p' <<<"$meta")"
-  icon_theme="$(sed -n '2p' <<<"$meta")"
-  prefer_dark="$(sed -n '3p' <<<"$meta")"
-  prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
+	)"
+	gtk_theme="$(sed -n '1p' <<< "$meta")"
+	icon_theme="$(sed -n '2p' <<< "$meta")"
+	prefer_dark="$(sed -n '3p' <<< "$meta")"
+	prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
 
-  if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
-    local wal_wallpaper=""
-    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-      # shellcheck source=/dev/null
-      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-      wal_wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
-    fi
-    if [[ -z ${wal_wallpaper:-} ]]; then
-      wal_wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)
-    fi
-    if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
-      local theme_info
-      theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
-      gtk_theme="${theme_info%:*}"
-      if [[ $prefer_dark == "auto" ]]; then
-        prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-      fi
-    else
-      if [[ $prefer_dark == "true" ]]; then
-        gtk_theme="Orchis-Dark"
-      else
-        gtk_theme="Orchis-Light"
-      fi
-    fi
-  fi
+	if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
+		local wal_wallpaper=""
+		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+			# shellcheck source=/dev/null
+			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+			wal_wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
+		fi
+		if [[ -z ${wal_wallpaper:-} ]]; then
+			wal_wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2> /dev/null || true)
+		fi
+		if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
+			local theme_info
+			theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
+			gtk_theme="${theme_info%:*}"
+			if [[ $prefer_dark == "auto" ]]; then
+				prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+			fi
+		else
+			if [[ $prefer_dark == "true" ]]; then
+				gtk_theme="Orchis-Dark"
+			else
+				gtk_theme="Orchis-Light"
+			fi
+		fi
+	fi
 
-  if [[ $prefer_dark == "auto" ]]; then
-    prefer_dark="true"
-  fi
+	if [[ $prefer_dark == "auto" ]]; then
+		prefer_dark="true"
+	fi
 
-  apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
+	apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
 }
 
 # Function to get current GTK theme
 get_current_gtk_theme() {
-  if [[ -f $GTK3_CONFIG ]]; then
-    grep "^gtk-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
-  elif [[ -f $GTK2_CONFIG ]]; then
-    grep "^gtk-theme-name=" "$GTK2_CONFIG" | cut -d'"' -f2
-  else
-    echo "Unknown"
-  fi
+	if [[ -f $GTK3_CONFIG ]]; then
+		grep "^gtk-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
+	elif [[ -f $GTK2_CONFIG ]]; then
+		grep "^gtk-theme-name=" "$GTK2_CONFIG" | cut -d'"' -f2
+	else
+		echo "Unknown"
+	fi
 }
 
 # Function to get current icon theme
 get_current_icon_theme() {
-  if [[ -f $GTK3_CONFIG ]]; then
-    grep "^gtk-icon-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
-  elif command -v gsettings >/dev/null 2>&1; then
-    gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'"
-  else
-    echo ""
-  fi
+	if [[ -f $GTK3_CONFIG ]]; then
+		grep "^gtk-icon-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
+	elif command -v gsettings > /dev/null 2>&1; then
+		gsettings get org.gnome.desktop.interface icon-theme 2> /dev/null | tr -d "'"
+	else
+		echo ""
+	fi
 }
 
 # Function to list installed GTK themes
 list_installed_gtk_themes() {
-  local themes=()
+	local themes=()
 
-  local theme_dirs=(
-    "/usr/share/themes"
-    "/usr/local/share/themes"
-    "$HOME/.themes"
-    "$HOME/.local/share/themes"
-  )
+	local theme_dirs=(
+		"/usr/share/themes"
+		"/usr/local/share/themes"
+		"$HOME/.themes"
+		"$HOME/.local/share/themes"
+	)
 
-  for theme_dir in "${theme_dirs[@]}"; do
-    if [[ -d $theme_dir ]]; then
-      while IFS= read -r -d '' theme_path; do
-        local theme_name
-        theme_name=$(basename "$theme_path")
-        if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
-          themes+=("$theme_name")
-        fi
-      done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
-    fi
-  done
+	for theme_dir in "${theme_dirs[@]}"; do
+		if [[ -d $theme_dir ]]; then
+			while IFS= read -r -d '' theme_path; do
+				local theme_name
+				theme_name=$(basename "$theme_path")
+				if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
+					themes+=("$theme_name")
+				fi
+			done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
+		fi
+	done
 
-  # Remove duplicates and sort
-  printf '%s\n' "${themes[@]}" | sort -u
+	# Remove duplicates and sort
+	printf '%s\n' "${themes[@]}" | sort -u
 }

--- a/home/dot_local/lib/dots/gtk-theme-manager.sh
+++ b/home/dot_local/lib/dots/gtk-theme-manager.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 # Source smart colors for theme detection
 if [[ -f "$HOME/.local/lib/dots/smart-colors.sh" ]]; then
-	source "$HOME/.local/lib/dots/smart-colors.sh"
+  source "$HOME/.local/lib/dots/smart-colors.sh"
 fi
 
 # GTK configuration paths
@@ -28,120 +28,120 @@ readonly GTK3_CONFIG="$HOME/.config/gtk-3.0/settings.ini"
 
 # Function to log messages
 log() {
-	local level="$1"
-	shift
-	local message="$*"
-	local timestamp
-	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+  local level="$1"
+  shift
+  local message="$*"
+  local timestamp
+  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-	echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
+  echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
 }
 
 # Function to check if a GTK theme is installed
 is_gtk_theme_installed() {
-	local theme_name="$1"
+  local theme_name="$1"
 
-	# Check in common theme directories
-	local theme_dirs=(
-		"/usr/share/themes"
-		"/usr/local/share/themes"
-		"$HOME/.themes"
-		"$HOME/.local/share/themes"
-	)
+  # Check in common theme directories
+  local theme_dirs=(
+    "/usr/share/themes"
+    "/usr/local/share/themes"
+    "$HOME/.themes"
+    "$HOME/.local/share/themes"
+  )
 
-	for theme_dir in "${theme_dirs[@]}"; do
-		if [[ -d "$theme_dir/$theme_name" ]]; then
-			return 0
-		fi
-	done
+  for theme_dir in "${theme_dirs[@]}"; do
+    if [[ -d "$theme_dir/$theme_name" ]]; then
+      return 0
+    fi
+  done
 
-	return 1
+  return 1
 }
 
 # Function to check if an icon theme is installed
 is_icon_theme_installed() {
-	local icon_theme="$1"
+  local icon_theme="$1"
 
-	# Check in common icon directories
-	local icon_dirs=(
-		"/usr/share/icons"
-		"/usr/local/share/icons"
-		"$HOME/.icons"
-		"$HOME/.local/share/icons"
-	)
+  # Check in common icon directories
+  local icon_dirs=(
+    "/usr/share/icons"
+    "/usr/local/share/icons"
+    "$HOME/.icons"
+    "$HOME/.local/share/icons"
+  )
 
-	for icon_dir in "${icon_dirs[@]}"; do
-		if [[ -d "$icon_dir/$icon_theme" ]]; then
-			return 0
-		fi
-	done
+  for icon_dir in "${icon_dirs[@]}"; do
+    if [[ -d "$icon_dir/$icon_theme" ]]; then
+      return 0
+    fi
+  done
 
-	return 1
+  return 1
 }
 
 # Function to apply GTK theme with fallbacks
 apply_gtk_theme() {
-	local gtk_theme="$1"
-	local icon_theme="${2:-elementary}"
-	local prefer_dark="${3:-false}"
+  local gtk_theme="$1"
+  local icon_theme="${2:-elementary}"
+  local prefer_dark="${3:-false}"
 
-	log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
+  log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
 
-	# Validate theme availability with fallbacks
-	if ! is_gtk_theme_installed "$gtk_theme"; then
-		log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
+  # Validate theme availability with fallbacks
+  if ! is_gtk_theme_installed "$gtk_theme"; then
+    log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
 
-		# Common fallback themes in order of preference
-		local fallback_themes=(
-			"Orchis-Light"
-			"elementary"
-			"Arc-Dark"
-			"Arc"
-			"Breeze"
-			"oxygen-gtk"
-		)
+    # Common fallback themes in order of preference
+    local fallback_themes=(
+      "Orchis-Light"
+      "elementary"
+      "Arc-Dark"
+      "Arc"
+      "Breeze"
+      "oxygen-gtk"
+    )
 
-		for fallback in "${fallback_themes[@]}"; do
-			if is_gtk_theme_installed "$fallback"; then
-				gtk_theme="$fallback"
-				log "INFO" "Using fallback theme: $gtk_theme"
-				break
-			fi
-		done
+    for fallback in "${fallback_themes[@]}"; do
+      if is_gtk_theme_installed "$fallback"; then
+        gtk_theme="$fallback"
+        log "INFO" "Using fallback theme: $gtk_theme"
+        break
+      fi
+    done
 
-		if ! is_gtk_theme_installed "$gtk_theme"; then
-			log "ERROR" "No suitable GTK theme found, keeping current theme"
-			return 1
-		fi
-	fi
+    if ! is_gtk_theme_installed "$gtk_theme"; then
+      log "ERROR" "No suitable GTK theme found, keeping current theme"
+      return 1
+    fi
+  fi
 
-	# Validate icon theme with fallbacks
-	if ! is_icon_theme_installed "$icon_theme"; then
-		log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
+  # Validate icon theme with fallbacks
+  if ! is_icon_theme_installed "$icon_theme"; then
+    log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
 
-		local fallback_icons=(
-			"Numix-Circle"
-			"elementary"
-			"hicolor"
-		)
+    local fallback_icons=(
+      "Numix-Circle"
+      "elementary"
+      "hicolor"
+    )
 
-		for fallback in "${fallback_icons[@]}"; do
-			if is_icon_theme_installed "$fallback"; then
-				icon_theme="$fallback"
-				log "INFO" "Using fallback icon theme: $icon_theme"
-				break
-			fi
-		done
-	fi
+    for fallback in "${fallback_icons[@]}"; do
+      if is_icon_theme_installed "$fallback"; then
+        icon_theme="$fallback"
+        log "INFO" "Using fallback icon theme: $icon_theme"
+        break
+      fi
+    done
+  fi
 
-	# Update GTK2 configuration
-	if [[ -f $GTK2_CONFIG ]]; then
-		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
-		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
-		log "INFO" "Updated GTK2 configuration"
-	else
-		log "WARN" "GTK2 config not found, creating basic configuration"
-		cat > "$GTK2_CONFIG" << EOF
+  # Update GTK2 configuration
+  if [[ -f $GTK2_CONFIG ]]; then
+    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
+    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
+    log "INFO" "Updated GTK2 configuration"
+  else
+    log "WARN" "GTK2 config not found, creating basic configuration"
+    cat >"$GTK2_CONFIG" <<EOF
 # DO NOT EDIT! This file will be overwritten by LXAppearance.
 # Any customization should be done in ~/.gtkrc-2.0.mine instead.
 
@@ -162,18 +162,18 @@ gtk-xft-hinting=1
 gtk-xft-hintstyle="hintslight"
 gtk-xft-rgba="rgb"
 EOF
-	fi
+  fi
 
-	# Update GTK3 configuration
-	if [[ -f $GTK3_CONFIG ]]; then
-		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
-		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
-		sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-		log "INFO" "Updated GTK3 configuration"
-	else
-		log "WARN" "GTK3 config not found, creating configuration"
-		mkdir -p "$(dirname "$GTK3_CONFIG")"
-		cat > "$GTK3_CONFIG" << EOF
+  # Update GTK3 configuration
+  if [[ -f $GTK3_CONFIG ]]; then
+    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
+    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
+    sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+    log "INFO" "Updated GTK3 configuration"
+  else
+    log "WARN" "GTK3 config not found, creating configuration"
+    mkdir -p "$(dirname "$GTK3_CONFIG")"
+    cat >"$GTK3_CONFIG" <<EOF
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 gtk-theme-name=$gtk_theme
@@ -193,317 +193,313 @@ gtk-xft-hintstyle=hintslight
 gtk-xft-rgba=rgb
 gtk-modules=colorreload-gtk-module
 EOF
-	fi
+  fi
 
-	# Notify running GTK applications to reload themes
-	if command -v gsettings > /dev/null 2>&1; then
-		gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2> /dev/null || true
-		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2> /dev/null || true
-		# Older schemas expose this key; portals/libadwaita use color-scheme instead.
-		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
-		log "INFO" "Updated gsettings"
-	fi
+  # Notify running GTK applications to reload themes
+  if command -v gsettings >/dev/null 2>&1; then
+    gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2>/dev/null || true
+    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2>/dev/null || true
+    # Older schemas expose this key; portals/libadwaita use color-scheme instead.
+    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
+    log "INFO" "Updated gsettings"
+  fi
 
-	# Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
-	if [[ $prefer_dark == "true" ]]; then
-		apply_gtk_color_scheme dark
-	else
-		apply_gtk_color_scheme light
-	fi
+  # Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
+  if [[ $prefer_dark == "true" ]]; then
+    apply_gtk_color_scheme dark
+  else
+    apply_gtk_color_scheme light
+  fi
 
-	# XFCE4 settings support removed - using gsettings only
-	# If running XFCE4 session, gsettings should be sufficient
-	# Legacy xfconf-query support can be re-enabled if needed
+  # XFCE4 settings support removed - using gsettings only
+  # If running XFCE4 session, gsettings should be sufficient
+  # Legacy xfconf-query support can be re-enabled if needed
 
-	log "INFO" "GTK theme applied successfully: $gtk_theme"
-	return 0
+  log "INFO" "GTK theme applied successfully: $gtk_theme"
+  return 0
 }
 
 # Sync GTK/libadwaita light-dark preference without changing the theme name.
 # mode: "dark" | "light"
 apply_gtk_color_scheme() {
-	local mode="${1:-dark}"
-	local prefer_dark="true"
-	local color_scheme="prefer-dark"
-	if [[ $mode == "light" ]]; then
-		prefer_dark="false"
-		color_scheme="prefer-light"
-	elif [[ $mode != "dark" ]]; then
-		log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
-		return 1
-	fi
+  local mode="${1:-dark}"
+  local prefer_dark="true"
+  local color_scheme="prefer-dark"
+  if [[ $mode == "light" ]]; then
+    prefer_dark="false"
+    color_scheme="prefer-light"
+  elif [[ $mode != "dark" ]]; then
+    log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
+    return 1
+  fi
 
-	if [[ -f $GTK3_CONFIG ]]; then
-		if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2> /dev/null; then
-			sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-		else
-			printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >> "$GTK3_CONFIG"
-		fi
-	else
-		mkdir -p "$(dirname "$GTK3_CONFIG")" || {
-			log "ERROR" "Failed to create directory for $GTK3_CONFIG"
-			return 1
-		}
-		if ! cat > "$GTK3_CONFIG" << EOF; then
+  if [[ -f $GTK3_CONFIG ]]; then
+    if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2>/dev/null; then
+      sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+    else
+      printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >>"$GTK3_CONFIG"
+    fi
+  else
+    mkdir -p "$(dirname "$GTK3_CONFIG")" || {
+      log "ERROR" "Failed to create directory for $GTK3_CONFIG"
+      return 1
+    }
+    if ! cat >"$GTK3_CONFIG" <<EOF; then
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 EOF
-			log "ERROR" "Failed to write $GTK3_CONFIG"
-			return 1
-		fi
-		log "INFO" "Created GTK3 config for color-scheme sync"
-	fi
+      log "ERROR" "Failed to write $GTK3_CONFIG"
+      return 1
+    fi
+    log "INFO" "Created GTK3 config for color-scheme sync"
+  fi
 
-	if command -v gsettings > /dev/null 2>&1; then
-		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
-		gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" > /dev/null 2>&1 || true
-	fi
-	log "INFO" "GTK color-scheme set to $color_scheme"
-	return 0
+  if command -v gsettings >/dev/null 2>&1; then
+    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
+    gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" >/dev/null 2>&1 || true
+  fi
+  log "INFO" "GTK color-scheme set to $color_scheme"
+  return 0
 }
 
 # Function to detect optimal GTK theme based on wallpaper colors
 detect_optimal_gtk_theme() {
-	local wallpaper_path="$1"
-	local detected_theme="Orchis-Light" # Default
-	local prefer_dark="false"
+  local wallpaper_path="$1"
+  local detected_theme="Orchis-Light" # Default
+  local prefer_dark="false"
 
-	# First, try to use pywal's background color to determine if theme should be dark or light
-	if [[ -f "$HOME/.cache/wal/colors" ]]; then
-		log "INFO" "Analyzing pywal colors for optimal theme selection"
+  # First, try to use pywal's background color to determine if theme should be dark or light
+  if [[ -f "$HOME/.cache/wal/colors" ]]; then
+    log "INFO" "Analyzing pywal colors for optimal theme selection"
 
-		# Read background color from pywal
-		local bg_color
-		bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
+    # Read background color from pywal
+    local bg_color
+    bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
 
-		if [[ -n $bg_color ]]; then
-			# Convert hex to RGB and calculate brightness
-			local r=$((16#${bg_color:0:2}))
-			local g=$((16#${bg_color:2:2}))
-			local b=$((16#${bg_color:4:2}))
-			local brightness=$((r + g + b))
+    if [[ -n $bg_color ]]; then
+      # Convert hex to RGB and calculate brightness
+      local r=$((16#${bg_color:0:2}))
+      local g=$((16#${bg_color:2:2}))
+      local b=$((16#${bg_color:4:2}))
+      local brightness=$((r + g + b))
 
-			# If background is dark (low brightness), suggest dark theme
-			if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
-				log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
-				local dark_themes=(
-					"Orchis-Dark-Compact"
-					"Arc-Dark"
-					"elementary-dark"
-					"Breeze-Dark"
-				)
+      # If background is dark (low brightness), suggest dark theme
+      if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
+        log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
+        local dark_themes=(
+          "Orchis-Dark-Compact"
+          "Arc-Dark"
+          "elementary-dark"
+          "Breeze-Dark"
+        )
 
-				for theme in "${dark_themes[@]}"; do
-					if is_gtk_theme_installed "$theme"; then
-						detected_theme="$theme"
-						prefer_dark="true"
-						break
-					fi
-				done
-			else
-				log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
-				local light_themes=(
-					"Orchis-Light"
-					"Arc"
-					"elementary"
-					"Breeze"
-				)
+        for theme in "${dark_themes[@]}"; do
+          if is_gtk_theme_installed "$theme"; then
+            detected_theme="$theme"
+            prefer_dark="true"
+            break
+          fi
+        done
+      else
+        log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
+        local light_themes=(
+          "Orchis-Light"
+          "Arc"
+          "elementary"
+          "Breeze"
+        )
 
-				for theme in "${light_themes[@]}"; do
-					if is_gtk_theme_installed "$theme"; then
-						detected_theme="$theme"
-						prefer_dark="false"
-						break
-					fi
-				done
-			fi
-		fi
-	elif command -v dots-smart-colors > /dev/null 2>&1; then
-		# Fallback: use smart-colors to analyze current theme
-		log "INFO" "Using smart-colors to analyze current theme"
+        for theme in "${light_themes[@]}"; do
+          if is_gtk_theme_installed "$theme"; then
+            detected_theme="$theme"
+            prefer_dark="false"
+            break
+          fi
+        done
+      fi
+    fi
+  elif command -v dots-smart-colors >/dev/null 2>&1; then
+    # Fallback: use smart-colors to analyze current theme
+    log "INFO" "Using smart-colors to analyze current theme"
 
-		# Check if current theme is light or dark using smart-colors logic
-		if dots-smart-colors --analyze 2> /dev/null | grep -q "light theme\|bright"; then
-			log "INFO" "Light theme detected, suggesting light GTK theme"
-			local light_themes=(
-				"Orchis-Light"
-				"Arc"
-				"elementary"
-				"Breeze"
-			)
+    # Check if current theme is light or dark using smart-colors logic
+    if dots-smart-colors --analyze 2>/dev/null | grep -q "light theme\|bright"; then
+      log "INFO" "Light theme detected, suggesting light GTK theme"
+      local light_themes=(
+        "Orchis-Light"
+        "Arc"
+        "elementary"
+        "Breeze"
+      )
 
-			for theme in "${light_themes[@]}"; do
-				if is_gtk_theme_installed "$theme"; then
-					detected_theme="$theme"
-					prefer_dark="false"
-					break
-				fi
-			done
-		else
-			log "INFO" "Dark theme detected, suggesting dark GTK theme"
-			local dark_themes=(
-				"Orchis-Dark-Compact"
-				"Arc-Dark"
-				"elementary-dark"
-				"Breeze-Dark"
-			)
+      for theme in "${light_themes[@]}"; do
+        if is_gtk_theme_installed "$theme"; then
+          detected_theme="$theme"
+          prefer_dark="false"
+          break
+        fi
+      done
+    else
+      log "INFO" "Dark theme detected, suggesting dark GTK theme"
+      local dark_themes=(
+        "Orchis-Dark-Compact"
+        "Arc-Dark"
+        "elementary-dark"
+        "Breeze-Dark"
+      )
 
-			for theme in "${dark_themes[@]}"; do
-				if is_gtk_theme_installed "$theme"; then
-					detected_theme="$theme"
-					prefer_dark="true"
-					break
-				fi
-			done
-		fi
-	else
-		log "WARN" "No color analysis available, using default light theme"
-	fi
+      for theme in "${dark_themes[@]}"; do
+        if is_gtk_theme_installed "$theme"; then
+          detected_theme="$theme"
+          prefer_dark="true"
+          break
+        fi
+      done
+    fi
+  else
+    log "WARN" "No color analysis available, using default light theme"
+  fi
 
-	log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
-	echo "$detected_theme:$prefer_dark"
+  log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
+  echo "$detected_theme:$prefer_dark"
 }
 
 # Normalize prefer-dark to a real GTK boolean string (true/false).
 normalize_prefer_dark() {
-	case "${1:-auto}" in
-		true | 1 | yes | dark) echo "true" ;;
-		false | 0 | no | light) echo "false" ;;
-		*) echo "auto" ;;
-	esac
+  case "${1:-auto}" in
+    true | 1 | yes | dark) echo "true" ;;
+    false | 0 | no | light) echo "false" ;;
+    *) echo "auto" ;;
+  esac
 }
 
 # Apply GTK/icons from an appearance theme pack (one-shot recipe).
 apply_theme_gtk_theme() {
-	local theme_id="${1:-}"
+  local theme_id="${1:-}"
 
-	if [[ -z $theme_id ]]; then
-		log "WARN" "No theme specified, using wallpaper-based detection"
-		local wallpaper=""
-		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-			# shellcheck source=/dev/null
-			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-			wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
-		fi
-		if [[ -z ${wallpaper:-} ]]; then
-			wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2> /dev/null || true)
-		fi
-		if [[ -n $wallpaper && -f $wallpaper ]]; then
-			local theme_info
-			theme_info=$(detect_optimal_gtk_theme "$wallpaper")
-			local gtk_theme="${theme_info%:*}"
-			local prefer_dark
-			prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-			apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
-		else
-			apply_gtk_theme "Orchis-Dark" "Numix-Circle" "true"
-		fi
-		return
-	fi
+  if [[ -z $theme_id ]]; then
+    log "WARN" "No theme specified, using wallpaper-based detection"
+    local wallpaper=""
+    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+      # shellcheck source=/dev/null
+      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+      wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
+    fi
+    # Never readlink ~/.cache/wal/wal — it is a text path file, not an image symlink.
+    if [[ -n $wallpaper && -f $wallpaper ]]; then
+      local theme_info
+      theme_info=$(detect_optimal_gtk_theme "$wallpaper")
+      local gtk_theme="${theme_info%:*}"
+      local prefer_dark
+      prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+      apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
+    else
+      apply_gtk_theme "Orchis-Dark" "Numix-Circle" "true"
+    fi
+    return
+  fi
 
-	log "INFO" "Applying GTK theme from appearance pack: $theme_id"
+  log "INFO" "Applying GTK theme from appearance pack: $theme_id"
 
-	local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
-	local theme_json="$HOME/.local/share/dots/themes/$theme_id/theme.json"
+  local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
+  local theme_json="$HOME/.local/share/dots/themes/$theme_id/theme.json"
 
-	if [[ ! -f $theme_json ]]; then
-		log "ERROR" "Theme pack not found: $theme_id ($theme_json)"
-		return 1
-	fi
+  if [[ ! -f $theme_json ]]; then
+    log "ERROR" "Theme pack not found: $theme_id ($theme_json)"
+    return 1
+  fi
 
-	local meta
-	meta="$(
-		python3 - "$theme_json" << 'PY'
+  local meta
+  meta="$(
+    python3 - "$theme_json" <<'PY'
 import json, sys
 data = json.load(open(sys.argv[1], encoding="utf-8"))
 print(data.get("gtkTheme") or "auto")
 print(data.get("iconTheme") or "Numix-Circle")
 print("true" if data.get("darkMode", True) else "false")
 PY
-	)"
-	gtk_theme="$(sed -n '1p' <<< "$meta")"
-	icon_theme="$(sed -n '2p' <<< "$meta")"
-	prefer_dark="$(sed -n '3p' <<< "$meta")"
-	prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
+  )"
+  gtk_theme="$(sed -n '1p' <<<"$meta")"
+  icon_theme="$(sed -n '2p' <<<"$meta")"
+  prefer_dark="$(sed -n '3p' <<<"$meta")"
+  prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
 
-	if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
-		local wal_wallpaper=""
-		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-			# shellcheck source=/dev/null
-			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-			wal_wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
-		fi
-		if [[ -z ${wal_wallpaper:-} ]]; then
-			wal_wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2> /dev/null || true)
-		fi
-		if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
-			local theme_info
-			theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
-			gtk_theme="${theme_info%:*}"
-			if [[ $prefer_dark == "auto" ]]; then
-				prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-			fi
-		else
-			if [[ $prefer_dark == "true" ]]; then
-				gtk_theme="Orchis-Dark"
-			else
-				gtk_theme="Orchis-Light"
-			fi
-		fi
-	fi
+  if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
+    local wal_wallpaper=""
+    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+      # shellcheck source=/dev/null
+      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+      wal_wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
+    fi
+    # Prefer wallpaper-resolver (handles text wal pointer + state pointer).
+    if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
+      local theme_info
+      theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
+      gtk_theme="${theme_info%:*}"
+      if [[ $prefer_dark == "auto" ]]; then
+        prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+      fi
+    else
+      if [[ $prefer_dark == "true" ]]; then
+        gtk_theme="Orchis-Dark"
+      else
+        gtk_theme="Orchis-Light"
+      fi
+    fi
+  fi
 
-	if [[ $prefer_dark == "auto" ]]; then
-		prefer_dark="true"
-	fi
+  if [[ $prefer_dark == "auto" ]]; then
+    prefer_dark="true"
+  fi
 
-	apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
+  apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
 }
 
 # Function to get current GTK theme
 get_current_gtk_theme() {
-	if [[ -f $GTK3_CONFIG ]]; then
-		grep "^gtk-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
-	elif [[ -f $GTK2_CONFIG ]]; then
-		grep "^gtk-theme-name=" "$GTK2_CONFIG" | cut -d'"' -f2
-	else
-		echo "Unknown"
-	fi
+  if [[ -f $GTK3_CONFIG ]]; then
+    grep "^gtk-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
+  elif [[ -f $GTK2_CONFIG ]]; then
+    grep "^gtk-theme-name=" "$GTK2_CONFIG" | cut -d'"' -f2
+  else
+    echo "Unknown"
+  fi
 }
 
 # Function to get current icon theme
 get_current_icon_theme() {
-	if [[ -f $GTK3_CONFIG ]]; then
-		grep "^gtk-icon-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
-	elif command -v gsettings > /dev/null 2>&1; then
-		gsettings get org.gnome.desktop.interface icon-theme 2> /dev/null | tr -d "'"
-	else
-		echo ""
-	fi
+  if [[ -f $GTK3_CONFIG ]]; then
+    grep "^gtk-icon-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
+  elif command -v gsettings >/dev/null 2>&1; then
+    gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'"
+  else
+    echo ""
+  fi
 }
 
 # Function to list installed GTK themes
 list_installed_gtk_themes() {
-	local themes=()
+  local themes=()
 
-	local theme_dirs=(
-		"/usr/share/themes"
-		"/usr/local/share/themes"
-		"$HOME/.themes"
-		"$HOME/.local/share/themes"
-	)
+  local theme_dirs=(
+    "/usr/share/themes"
+    "/usr/local/share/themes"
+    "$HOME/.themes"
+    "$HOME/.local/share/themes"
+  )
 
-	for theme_dir in "${theme_dirs[@]}"; do
-		if [[ -d $theme_dir ]]; then
-			while IFS= read -r -d '' theme_path; do
-				local theme_name
-				theme_name=$(basename "$theme_path")
-				if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
-					themes+=("$theme_name")
-				fi
-			done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
-		fi
-	done
+  for theme_dir in "${theme_dirs[@]}"; do
+    if [[ -d $theme_dir ]]; then
+      while IFS= read -r -d '' theme_path; do
+        local theme_name
+        theme_name=$(basename "$theme_path")
+        if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
+          themes+=("$theme_name")
+        fi
+      done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
+    fi
+  done
 
-	# Remove duplicates and sort
-	printf '%s\n' "${themes[@]}" | sort -u
+  # Remove duplicates and sort
+  printf '%s\n' "${themes[@]}" | sort -u
 }

--- a/home/dot_local/lib/dots/gtk-theme-manager.sh
+++ b/home/dot_local/lib/dots/gtk-theme-manager.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 # Source smart colors for theme detection
 if [[ -f "$HOME/.local/lib/dots/smart-colors.sh" ]]; then
-	source "$HOME/.local/lib/dots/smart-colors.sh"
+  source "$HOME/.local/lib/dots/smart-colors.sh"
 fi
 
 # GTK configuration paths
@@ -28,120 +28,120 @@ readonly GTK3_CONFIG="$HOME/.config/gtk-3.0/settings.ini"
 
 # Function to log messages
 log() {
-	local level="$1"
-	shift
-	local message="$*"
-	local timestamp
-	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+  local level="$1"
+  shift
+  local message="$*"
+  local timestamp
+  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-	echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
+  echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
 }
 
 # Function to check if a GTK theme is installed
 is_gtk_theme_installed() {
-	local theme_name="$1"
+  local theme_name="$1"
 
-	# Check in common theme directories
-	local theme_dirs=(
-		"/usr/share/themes"
-		"/usr/local/share/themes"
-		"$HOME/.themes"
-		"$HOME/.local/share/themes"
-	)
+  # Check in common theme directories
+  local theme_dirs=(
+    "/usr/share/themes"
+    "/usr/local/share/themes"
+    "$HOME/.themes"
+    "$HOME/.local/share/themes"
+  )
 
-	for theme_dir in "${theme_dirs[@]}"; do
-		if [[ -d "$theme_dir/$theme_name" ]]; then
-			return 0
-		fi
-	done
+  for theme_dir in "${theme_dirs[@]}"; do
+    if [[ -d "$theme_dir/$theme_name" ]]; then
+      return 0
+    fi
+  done
 
-	return 1
+  return 1
 }
 
 # Function to check if an icon theme is installed
 is_icon_theme_installed() {
-	local icon_theme="$1"
+  local icon_theme="$1"
 
-	# Check in common icon directories
-	local icon_dirs=(
-		"/usr/share/icons"
-		"/usr/local/share/icons"
-		"$HOME/.icons"
-		"$HOME/.local/share/icons"
-	)
+  # Check in common icon directories
+  local icon_dirs=(
+    "/usr/share/icons"
+    "/usr/local/share/icons"
+    "$HOME/.icons"
+    "$HOME/.local/share/icons"
+  )
 
-	for icon_dir in "${icon_dirs[@]}"; do
-		if [[ -d "$icon_dir/$icon_theme" ]]; then
-			return 0
-		fi
-	done
+  for icon_dir in "${icon_dirs[@]}"; do
+    if [[ -d "$icon_dir/$icon_theme" ]]; then
+      return 0
+    fi
+  done
 
-	return 1
+  return 1
 }
 
 # Function to apply GTK theme with fallbacks
 apply_gtk_theme() {
-	local gtk_theme="$1"
-	local icon_theme="${2:-elementary}"
-	local prefer_dark="${3:-false}"
+  local gtk_theme="$1"
+  local icon_theme="${2:-elementary}"
+  local prefer_dark="${3:-false}"
 
-	log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
+  log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
 
-	# Validate theme availability with fallbacks
-	if ! is_gtk_theme_installed "$gtk_theme"; then
-		log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
+  # Validate theme availability with fallbacks
+  if ! is_gtk_theme_installed "$gtk_theme"; then
+    log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
 
-		# Common fallback themes in order of preference
-		local fallback_themes=(
-			"Orchis-Light"
-			"elementary"
-			"Arc-Dark"
-			"Arc"
-			"Breeze"
-			"oxygen-gtk"
-		)
+    # Common fallback themes in order of preference
+    local fallback_themes=(
+      "Orchis-Light"
+      "elementary"
+      "Arc-Dark"
+      "Arc"
+      "Breeze"
+      "oxygen-gtk"
+    )
 
-		for fallback in "${fallback_themes[@]}"; do
-			if is_gtk_theme_installed "$fallback"; then
-				gtk_theme="$fallback"
-				log "INFO" "Using fallback theme: $gtk_theme"
-				break
-			fi
-		done
+    for fallback in "${fallback_themes[@]}"; do
+      if is_gtk_theme_installed "$fallback"; then
+        gtk_theme="$fallback"
+        log "INFO" "Using fallback theme: $gtk_theme"
+        break
+      fi
+    done
 
-		if ! is_gtk_theme_installed "$gtk_theme"; then
-			log "ERROR" "No suitable GTK theme found, keeping current theme"
-			return 1
-		fi
-	fi
+    if ! is_gtk_theme_installed "$gtk_theme"; then
+      log "ERROR" "No suitable GTK theme found, keeping current theme"
+      return 1
+    fi
+  fi
 
-	# Validate icon theme with fallbacks
-	if ! is_icon_theme_installed "$icon_theme"; then
-		log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
+  # Validate icon theme with fallbacks
+  if ! is_icon_theme_installed "$icon_theme"; then
+    log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
 
-		local fallback_icons=(
-			"Numix-Circle"
-			"elementary"
-			"hicolor"
-		)
+    local fallback_icons=(
+      "Numix-Circle"
+      "elementary"
+      "hicolor"
+    )
 
-		for fallback in "${fallback_icons[@]}"; do
-			if is_icon_theme_installed "$fallback"; then
-				icon_theme="$fallback"
-				log "INFO" "Using fallback icon theme: $icon_theme"
-				break
-			fi
-		done
-	fi
+    for fallback in "${fallback_icons[@]}"; do
+      if is_icon_theme_installed "$fallback"; then
+        icon_theme="$fallback"
+        log "INFO" "Using fallback icon theme: $icon_theme"
+        break
+      fi
+    done
+  fi
 
-	# Update GTK2 configuration
-	if [[ -f $GTK2_CONFIG ]]; then
-		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
-		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
-		log "INFO" "Updated GTK2 configuration"
-	else
-		log "WARN" "GTK2 config not found, creating basic configuration"
-		cat > "$GTK2_CONFIG" << EOF
+  # Update GTK2 configuration
+  if [[ -f $GTK2_CONFIG ]]; then
+    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
+    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
+    log "INFO" "Updated GTK2 configuration"
+  else
+    log "WARN" "GTK2 config not found, creating basic configuration"
+    cat >"$GTK2_CONFIG" <<EOF
 # DO NOT EDIT! This file will be overwritten by LXAppearance.
 # Any customization should be done in ~/.gtkrc-2.0.mine instead.
 
@@ -162,18 +162,18 @@ gtk-xft-hinting=1
 gtk-xft-hintstyle="hintslight"
 gtk-xft-rgba="rgb"
 EOF
-	fi
+  fi
 
-	# Update GTK3 configuration
-	if [[ -f $GTK3_CONFIG ]]; then
-		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
-		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
-		sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-		log "INFO" "Updated GTK3 configuration"
-	else
-		log "WARN" "GTK3 config not found, creating configuration"
-		mkdir -p "$(dirname "$GTK3_CONFIG")"
-		cat > "$GTK3_CONFIG" << EOF
+  # Update GTK3 configuration
+  if [[ -f $GTK3_CONFIG ]]; then
+    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
+    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
+    sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+    log "INFO" "Updated GTK3 configuration"
+  else
+    log "WARN" "GTK3 config not found, creating configuration"
+    mkdir -p "$(dirname "$GTK3_CONFIG")"
+    cat >"$GTK3_CONFIG" <<EOF
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 gtk-theme-name=$gtk_theme
@@ -193,306 +193,317 @@ gtk-xft-hintstyle=hintslight
 gtk-xft-rgba=rgb
 gtk-modules=colorreload-gtk-module
 EOF
-	fi
+  fi
 
-	# Notify running GTK applications to reload themes
-	if command -v gsettings > /dev/null 2>&1; then
-		gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2> /dev/null || true
-		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2> /dev/null || true
-		# Older schemas expose this key; portals/libadwaita use color-scheme instead.
-		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
-		log "INFO" "Updated gsettings"
-	fi
+  # Notify running GTK applications to reload themes
+  if command -v gsettings >/dev/null 2>&1; then
+    gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2>/dev/null || true
+    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2>/dev/null || true
+    # Older schemas expose this key; portals/libadwaita use color-scheme instead.
+    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
+    log "INFO" "Updated gsettings"
+  fi
 
-	# Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
-	if [[ $prefer_dark == "true" ]]; then
-		apply_gtk_color_scheme dark
-	else
-		apply_gtk_color_scheme light
-	fi
+  # Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
+  if [[ $prefer_dark == "true" ]]; then
+    apply_gtk_color_scheme dark
+  else
+    apply_gtk_color_scheme light
+  fi
 
-	# XFCE4 settings support removed - using gsettings only
-	# If running XFCE4 session, gsettings should be sufficient
-	# Legacy xfconf-query support can be re-enabled if needed
+  # XFCE4 settings support removed - using gsettings only
+  # If running XFCE4 session, gsettings should be sufficient
+  # Legacy xfconf-query support can be re-enabled if needed
 
-	log "INFO" "GTK theme applied successfully: $gtk_theme"
-	return 0
+  log "INFO" "GTK theme applied successfully: $gtk_theme"
+  return 0
 }
 
 # Sync GTK/libadwaita light-dark preference without changing the theme name.
 # mode: "dark" | "light"
 apply_gtk_color_scheme() {
-	local mode="${1:-dark}"
-	local prefer_dark="true"
-	local color_scheme="prefer-dark"
-	if [[ $mode == "light" ]]; then
-		prefer_dark="false"
-		color_scheme="prefer-light"
-	elif [[ $mode != "dark" ]]; then
-		log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
-		return 1
-	fi
+  local mode="${1:-dark}"
+  local prefer_dark="true"
+  local color_scheme="prefer-dark"
+  if [[ $mode == "light" ]]; then
+    prefer_dark="false"
+    color_scheme="prefer-light"
+  elif [[ $mode != "dark" ]]; then
+    log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
+    return 1
+  fi
 
-	if [[ -f $GTK3_CONFIG ]]; then
-		if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2> /dev/null; then
-			sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-		else
-			printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >> "$GTK3_CONFIG"
-		fi
-	else
-		mkdir -p "$(dirname "$GTK3_CONFIG")" || {
-			log "ERROR" "Failed to create directory for $GTK3_CONFIG"
-			return 1
-		}
-		if ! cat > "$GTK3_CONFIG" << EOF; then
+  if [[ -f $GTK3_CONFIG ]]; then
+    if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2>/dev/null; then
+      sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+    else
+      printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >>"$GTK3_CONFIG"
+    fi
+  else
+    mkdir -p "$(dirname "$GTK3_CONFIG")" || {
+      log "ERROR" "Failed to create directory for $GTK3_CONFIG"
+      return 1
+    }
+    if ! cat >"$GTK3_CONFIG" <<EOF; then
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 EOF
-			log "ERROR" "Failed to write $GTK3_CONFIG"
-			return 1
-		fi
-		log "INFO" "Created GTK3 config for color-scheme sync"
-	fi
+      log "ERROR" "Failed to write $GTK3_CONFIG"
+      return 1
+    fi
+    log "INFO" "Created GTK3 config for color-scheme sync"
+  fi
 
-	if command -v gsettings > /dev/null 2>&1; then
-		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
-		gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" > /dev/null 2>&1 || true
-	fi
-	log "INFO" "GTK color-scheme set to $color_scheme"
-	return 0
+  if command -v gsettings >/dev/null 2>&1; then
+    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
+    gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" >/dev/null 2>&1 || true
+  fi
+  log "INFO" "GTK color-scheme set to $color_scheme"
+  return 0
 }
 
 # Function to detect optimal GTK theme based on wallpaper colors
 detect_optimal_gtk_theme() {
-	local wallpaper_path="$1"
-	local detected_theme="Orchis-Light" # Default
-	local prefer_dark="false"
+  local wallpaper_path="$1"
+  local detected_theme="Orchis-Light" # Default
+  local prefer_dark="false"
 
-	# First, try to use pywal's background color to determine if theme should be dark or light
-	if [[ -f "$HOME/.cache/wal/colors" ]]; then
-		log "INFO" "Analyzing pywal colors for optimal theme selection"
+  # First, try to use pywal's background color to determine if theme should be dark or light
+  if [[ -f "$HOME/.cache/wal/colors" ]]; then
+    log "INFO" "Analyzing pywal colors for optimal theme selection"
 
-		# Read background color from pywal
-		local bg_color
-		bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
+    # Read background color from pywal
+    local bg_color
+    bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
 
-		if [[ -n $bg_color ]]; then
-			# Convert hex to RGB and calculate brightness
-			local r=$((16#${bg_color:0:2}))
-			local g=$((16#${bg_color:2:2}))
-			local b=$((16#${bg_color:4:2}))
-			local brightness=$((r + g + b))
+    if [[ -n $bg_color ]]; then
+      # Convert hex to RGB and calculate brightness
+      local r=$((16#${bg_color:0:2}))
+      local g=$((16#${bg_color:2:2}))
+      local b=$((16#${bg_color:4:2}))
+      local brightness=$((r + g + b))
 
-			# If background is dark (low brightness), suggest dark theme
-			if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
-				log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
-				local dark_themes=(
-					"Orchis-Dark-Compact"
-					"Arc-Dark"
-					"elementary-dark"
-					"Breeze-Dark"
-				)
+      # If background is dark (low brightness), suggest dark theme
+      if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
+        log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
+        local dark_themes=(
+          "Orchis-Dark-Compact"
+          "Arc-Dark"
+          "elementary-dark"
+          "Breeze-Dark"
+        )
 
-				for theme in "${dark_themes[@]}"; do
-					if is_gtk_theme_installed "$theme"; then
-						detected_theme="$theme"
-						prefer_dark="true"
-						break
-					fi
-				done
-			else
-				log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
-				local light_themes=(
-					"Orchis-Light"
-					"Arc"
-					"elementary"
-					"Breeze"
-				)
+        for theme in "${dark_themes[@]}"; do
+          if is_gtk_theme_installed "$theme"; then
+            detected_theme="$theme"
+            prefer_dark="true"
+            break
+          fi
+        done
+      else
+        log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
+        local light_themes=(
+          "Orchis-Light"
+          "Arc"
+          "elementary"
+          "Breeze"
+        )
 
-				for theme in "${light_themes[@]}"; do
-					if is_gtk_theme_installed "$theme"; then
-						detected_theme="$theme"
-						prefer_dark="false"
-						break
-					fi
-				done
-			fi
-		fi
-	elif command -v dots-smart-colors > /dev/null 2>&1; then
-		# Fallback: use smart-colors to analyze current theme
-		log "INFO" "Using smart-colors to analyze current theme"
+        for theme in "${light_themes[@]}"; do
+          if is_gtk_theme_installed "$theme"; then
+            detected_theme="$theme"
+            prefer_dark="false"
+            break
+          fi
+        done
+      fi
+    fi
+  elif command -v dots-smart-colors >/dev/null 2>&1; then
+    # Fallback: use smart-colors to analyze current theme
+    log "INFO" "Using smart-colors to analyze current theme"
 
-		# Check if current theme is light or dark using smart-colors logic
-		if dots-smart-colors --analyze 2> /dev/null | grep -q "light theme\|bright"; then
-			log "INFO" "Light theme detected, suggesting light GTK theme"
-			local light_themes=(
-				"Orchis-Light"
-				"Arc"
-				"elementary"
-				"Breeze"
-			)
+    # Check if current theme is light or dark using smart-colors logic
+    if dots-smart-colors --analyze 2>/dev/null | grep -q "light theme\|bright"; then
+      log "INFO" "Light theme detected, suggesting light GTK theme"
+      local light_themes=(
+        "Orchis-Light"
+        "Arc"
+        "elementary"
+        "Breeze"
+      )
 
-			for theme in "${light_themes[@]}"; do
-				if is_gtk_theme_installed "$theme"; then
-					detected_theme="$theme"
-					prefer_dark="false"
-					break
-				fi
-			done
-		else
-			log "INFO" "Dark theme detected, suggesting dark GTK theme"
-			local dark_themes=(
-				"Orchis-Dark-Compact"
-				"Arc-Dark"
-				"elementary-dark"
-				"Breeze-Dark"
-			)
+      for theme in "${light_themes[@]}"; do
+        if is_gtk_theme_installed "$theme"; then
+          detected_theme="$theme"
+          prefer_dark="false"
+          break
+        fi
+      done
+    else
+      log "INFO" "Dark theme detected, suggesting dark GTK theme"
+      local dark_themes=(
+        "Orchis-Dark-Compact"
+        "Arc-Dark"
+        "elementary-dark"
+        "Breeze-Dark"
+      )
 
-			for theme in "${dark_themes[@]}"; do
-				if is_gtk_theme_installed "$theme"; then
-					detected_theme="$theme"
-					prefer_dark="true"
-					break
-				fi
-			done
-		fi
-	else
-		log "WARN" "No color analysis available, using default light theme"
-	fi
+      for theme in "${dark_themes[@]}"; do
+        if is_gtk_theme_installed "$theme"; then
+          detected_theme="$theme"
+          prefer_dark="true"
+          break
+        fi
+      done
+    fi
+  else
+    log "WARN" "No color analysis available, using default light theme"
+  fi
 
-	log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
-	echo "$detected_theme:$prefer_dark"
+  log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
+  echo "$detected_theme:$prefer_dark"
 }
 
 # Normalize prefer-dark to a real GTK boolean string (true/false).
 normalize_prefer_dark() {
-	case "${1:-auto}" in
-		true | 1 | yes | dark) echo "true" ;;
-		false | 0 | no | light) echo "false" ;;
-		*) echo "auto" ;;
-	esac
+  case "${1:-auto}" in
+    true | 1 | yes | dark) echo "true" ;;
+    false | 0 | no | light) echo "false" ;;
+    *) echo "auto" ;;
+  esac
 }
 
 # Apply GTK/icons from an appearance theme pack (one-shot recipe).
 apply_theme_gtk_theme() {
-	local theme_id="${1:-}"
+  local theme_id="${1:-}"
 
-	if [[ -z $theme_id ]]; then
-		log "WARN" "No theme specified, using wallpaper-based detection"
-		local wallpaper=""
-		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-			# shellcheck source=/dev/null
-			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-			wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
-		fi
-		if [[ -z ${wallpaper:-} ]]; then
-			wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2> /dev/null || true)
-		fi
-		if [[ -n $wallpaper && -f $wallpaper ]]; then
-			local theme_info
-			theme_info=$(detect_optimal_gtk_theme "$wallpaper")
-			local gtk_theme="${theme_info%:*}"
-			local prefer_dark
-			prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-			apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
-		else
-			apply_gtk_theme "Orchis-Dark" "Numix-Circle" "true"
-		fi
-		return
-	fi
+  if [[ -z $theme_id ]]; then
+    log "WARN" "No theme specified, using wallpaper-based detection"
+    local wallpaper=""
+    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+      # shellcheck source=/dev/null
+      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+      wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
+    fi
+    if [[ -z ${wallpaper:-} ]]; then
+      wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)
+    fi
+    if [[ -n $wallpaper && -f $wallpaper ]]; then
+      local theme_info
+      theme_info=$(detect_optimal_gtk_theme "$wallpaper")
+      local gtk_theme="${theme_info%:*}"
+      local prefer_dark
+      prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+      apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
+    else
+      apply_gtk_theme "Orchis-Dark" "Numix-Circle" "true"
+    fi
+    return
+  fi
 
-	log "INFO" "Applying GTK theme from appearance pack: $theme_id"
+  log "INFO" "Applying GTK theme from appearance pack: $theme_id"
 
-	local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
-	local theme_json="$HOME/.local/share/dots/themes/$theme_id/theme.json"
+  local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
+  local theme_json="$HOME/.local/share/dots/themes/$theme_id/theme.json"
 
-	if [[ ! -f $theme_json ]]; then
-		log "ERROR" "Theme pack not found: $theme_id ($theme_json)"
-		return 1
-	fi
+  if [[ ! -f $theme_json ]]; then
+    log "ERROR" "Theme pack not found: $theme_id ($theme_json)"
+    return 1
+  fi
 
-	local meta
-	meta="$(
-		python3 - "$theme_json" << 'PY'
+  local meta
+  meta="$(
+    python3 - "$theme_json" <<'PY'
 import json, sys
 data = json.load(open(sys.argv[1], encoding="utf-8"))
 print(data.get("gtkTheme") or "auto")
 print(data.get("iconTheme") or "Numix-Circle")
 print("true" if data.get("darkMode", True) else "false")
 PY
-	)"
-	gtk_theme="$(sed -n '1p' <<< "$meta")"
-	icon_theme="$(sed -n '2p' <<< "$meta")"
-	prefer_dark="$(sed -n '3p' <<< "$meta")"
-	prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
+  )"
+  gtk_theme="$(sed -n '1p' <<<"$meta")"
+  icon_theme="$(sed -n '2p' <<<"$meta")"
+  prefer_dark="$(sed -n '3p' <<<"$meta")"
+  prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
 
-	if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
-		local wal_wallpaper=""
-		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-			# shellcheck source=/dev/null
-			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-			wal_wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
-		fi
-		if [[ -z ${wal_wallpaper:-} ]]; then
-			wal_wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2> /dev/null || true)
-		fi
-		if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
-			local theme_info
-			theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
-			gtk_theme="${theme_info%:*}"
-			if [[ $prefer_dark == "auto" ]]; then
-				prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-			fi
-		else
-			if [[ $prefer_dark == "true" ]]; then
-				gtk_theme="Orchis-Dark"
-			else
-				gtk_theme="Orchis-Light"
-			fi
-		fi
-	fi
+  if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
+    local wal_wallpaper=""
+    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+      # shellcheck source=/dev/null
+      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+      wal_wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
+    fi
+    if [[ -z ${wal_wallpaper:-} ]]; then
+      wal_wallpaper=$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)
+    fi
+    if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
+      local theme_info
+      theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
+      gtk_theme="${theme_info%:*}"
+      if [[ $prefer_dark == "auto" ]]; then
+        prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+      fi
+    else
+      if [[ $prefer_dark == "true" ]]; then
+        gtk_theme="Orchis-Dark"
+      else
+        gtk_theme="Orchis-Light"
+      fi
+    fi
+  fi
 
-	if [[ $prefer_dark == "auto" ]]; then
-		prefer_dark="true"
-	fi
+  if [[ $prefer_dark == "auto" ]]; then
+    prefer_dark="true"
+  fi
 
-	apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
+  apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
 }
 
 # Function to get current GTK theme
 get_current_gtk_theme() {
-	if [[ -f $GTK3_CONFIG ]]; then
-		grep "^gtk-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
-	elif [[ -f $GTK2_CONFIG ]]; then
-		grep "^gtk-theme-name=" "$GTK2_CONFIG" | cut -d'"' -f2
-	else
-		echo "Unknown"
-	fi
+  if [[ -f $GTK3_CONFIG ]]; then
+    grep "^gtk-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
+  elif [[ -f $GTK2_CONFIG ]]; then
+    grep "^gtk-theme-name=" "$GTK2_CONFIG" | cut -d'"' -f2
+  else
+    echo "Unknown"
+  fi
+}
+
+# Function to get current icon theme
+get_current_icon_theme() {
+  if [[ -f $GTK3_CONFIG ]]; then
+    grep "^gtk-icon-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
+  elif command -v gsettings >/dev/null 2>&1; then
+    gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'"
+  else
+    echo ""
+  fi
 }
 
 # Function to list installed GTK themes
 list_installed_gtk_themes() {
-	local themes=()
+  local themes=()
 
-	local theme_dirs=(
-		"/usr/share/themes"
-		"/usr/local/share/themes"
-		"$HOME/.themes"
-		"$HOME/.local/share/themes"
-	)
+  local theme_dirs=(
+    "/usr/share/themes"
+    "/usr/local/share/themes"
+    "$HOME/.themes"
+    "$HOME/.local/share/themes"
+  )
 
-	for theme_dir in "${theme_dirs[@]}"; do
-		if [[ -d $theme_dir ]]; then
-			while IFS= read -r -d '' theme_path; do
-				local theme_name
-				theme_name=$(basename "$theme_path")
-				if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
-					themes+=("$theme_name")
-				fi
-			done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
-		fi
-	done
+  for theme_dir in "${theme_dirs[@]}"; do
+    if [[ -d $theme_dir ]]; then
+      while IFS= read -r -d '' theme_path; do
+        local theme_name
+        theme_name=$(basename "$theme_path")
+        if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
+          themes+=("$theme_name")
+        fi
+      done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
+    fi
+  done
 
-	# Remove duplicates and sort
-	printf '%s\n' "${themes[@]}" | sort -u
+  # Remove duplicates and sort
+  printf '%s\n' "${themes[@]}" | sort -u
 }

--- a/home/dot_local/lib/dots/gtk-theme-manager.sh
+++ b/home/dot_local/lib/dots/gtk-theme-manager.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 # Source smart colors for theme detection
 if [[ -f "$HOME/.local/lib/dots/smart-colors.sh" ]]; then
-  source "$HOME/.local/lib/dots/smart-colors.sh"
+	source "$HOME/.local/lib/dots/smart-colors.sh"
 fi
 
 # GTK configuration paths
@@ -28,120 +28,120 @@ readonly GTK3_CONFIG="$HOME/.config/gtk-3.0/settings.ini"
 
 # Function to log messages
 log() {
-  local level="$1"
-  shift
-  local message="$*"
-  local timestamp
-  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+	local level="$1"
+	shift
+	local message="$*"
+	local timestamp
+	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-  echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
+	echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
 }
 
 # Function to check if a GTK theme is installed
 is_gtk_theme_installed() {
-  local theme_name="$1"
+	local theme_name="$1"
 
-  # Check in common theme directories
-  local theme_dirs=(
-    "/usr/share/themes"
-    "/usr/local/share/themes"
-    "$HOME/.themes"
-    "$HOME/.local/share/themes"
-  )
+	# Check in common theme directories
+	local theme_dirs=(
+		"/usr/share/themes"
+		"/usr/local/share/themes"
+		"$HOME/.themes"
+		"$HOME/.local/share/themes"
+	)
 
-  for theme_dir in "${theme_dirs[@]}"; do
-    if [[ -d "$theme_dir/$theme_name" ]]; then
-      return 0
-    fi
-  done
+	for theme_dir in "${theme_dirs[@]}"; do
+		if [[ -d "$theme_dir/$theme_name" ]]; then
+			return 0
+		fi
+	done
 
-  return 1
+	return 1
 }
 
 # Function to check if an icon theme is installed
 is_icon_theme_installed() {
-  local icon_theme="$1"
+	local icon_theme="$1"
 
-  # Check in common icon directories
-  local icon_dirs=(
-    "/usr/share/icons"
-    "/usr/local/share/icons"
-    "$HOME/.icons"
-    "$HOME/.local/share/icons"
-  )
+	# Check in common icon directories
+	local icon_dirs=(
+		"/usr/share/icons"
+		"/usr/local/share/icons"
+		"$HOME/.icons"
+		"$HOME/.local/share/icons"
+	)
 
-  for icon_dir in "${icon_dirs[@]}"; do
-    if [[ -d "$icon_dir/$icon_theme" ]]; then
-      return 0
-    fi
-  done
+	for icon_dir in "${icon_dirs[@]}"; do
+		if [[ -d "$icon_dir/$icon_theme" ]]; then
+			return 0
+		fi
+	done
 
-  return 1
+	return 1
 }
 
 # Function to apply GTK theme with fallbacks
 apply_gtk_theme() {
-  local gtk_theme="$1"
-  local icon_theme="${2:-elementary}"
-  local prefer_dark="${3:-false}"
+	local gtk_theme="$1"
+	local icon_theme="${2:-elementary}"
+	local prefer_dark="${3:-false}"
 
-  log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
+	log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
 
-  # Validate theme availability with fallbacks
-  if ! is_gtk_theme_installed "$gtk_theme"; then
-    log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
+	# Validate theme availability with fallbacks
+	if ! is_gtk_theme_installed "$gtk_theme"; then
+		log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
 
-    # Common fallback themes in order of preference
-    local fallback_themes=(
-      "Orchis-Light"
-      "elementary"
-      "Arc-Dark"
-      "Arc"
-      "Breeze"
-      "oxygen-gtk"
-    )
+		# Common fallback themes in order of preference
+		local fallback_themes=(
+			"Orchis-Light"
+			"elementary"
+			"Arc-Dark"
+			"Arc"
+			"Breeze"
+			"oxygen-gtk"
+		)
 
-    for fallback in "${fallback_themes[@]}"; do
-      if is_gtk_theme_installed "$fallback"; then
-        gtk_theme="$fallback"
-        log "INFO" "Using fallback theme: $gtk_theme"
-        break
-      fi
-    done
+		for fallback in "${fallback_themes[@]}"; do
+			if is_gtk_theme_installed "$fallback"; then
+				gtk_theme="$fallback"
+				log "INFO" "Using fallback theme: $gtk_theme"
+				break
+			fi
+		done
 
-    if ! is_gtk_theme_installed "$gtk_theme"; then
-      log "ERROR" "No suitable GTK theme found, keeping current theme"
-      return 1
-    fi
-  fi
+		if ! is_gtk_theme_installed "$gtk_theme"; then
+			log "ERROR" "No suitable GTK theme found, keeping current theme"
+			return 1
+		fi
+	fi
 
-  # Validate icon theme with fallbacks
-  if ! is_icon_theme_installed "$icon_theme"; then
-    log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
+	# Validate icon theme with fallbacks
+	if ! is_icon_theme_installed "$icon_theme"; then
+		log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
 
-    local fallback_icons=(
-      "Numix-Circle"
-      "elementary"
-      "hicolor"
-    )
+		local fallback_icons=(
+			"Numix-Circle"
+			"elementary"
+			"hicolor"
+		)
 
-    for fallback in "${fallback_icons[@]}"; do
-      if is_icon_theme_installed "$fallback"; then
-        icon_theme="$fallback"
-        log "INFO" "Using fallback icon theme: $icon_theme"
-        break
-      fi
-    done
-  fi
+		for fallback in "${fallback_icons[@]}"; do
+			if is_icon_theme_installed "$fallback"; then
+				icon_theme="$fallback"
+				log "INFO" "Using fallback icon theme: $icon_theme"
+				break
+			fi
+		done
+	fi
 
-  # Update GTK2 configuration
-  if [[ -f $GTK2_CONFIG ]]; then
-    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
-    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
-    log "INFO" "Updated GTK2 configuration"
-  else
-    log "WARN" "GTK2 config not found, creating basic configuration"
-    cat >"$GTK2_CONFIG" <<EOF
+	# Update GTK2 configuration
+	if [[ -f $GTK2_CONFIG ]]; then
+		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
+		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
+		log "INFO" "Updated GTK2 configuration"
+	else
+		log "WARN" "GTK2 config not found, creating basic configuration"
+		cat > "$GTK2_CONFIG" << EOF
 # DO NOT EDIT! This file will be overwritten by LXAppearance.
 # Any customization should be done in ~/.gtkrc-2.0.mine instead.
 
@@ -162,18 +162,18 @@ gtk-xft-hinting=1
 gtk-xft-hintstyle="hintslight"
 gtk-xft-rgba="rgb"
 EOF
-  fi
+	fi
 
-  # Update GTK3 configuration
-  if [[ -f $GTK3_CONFIG ]]; then
-    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
-    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
-    sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-    log "INFO" "Updated GTK3 configuration"
-  else
-    log "WARN" "GTK3 config not found, creating configuration"
-    mkdir -p "$(dirname "$GTK3_CONFIG")"
-    cat >"$GTK3_CONFIG" <<EOF
+	# Update GTK3 configuration
+	if [[ -f $GTK3_CONFIG ]]; then
+		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
+		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
+		sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+		log "INFO" "Updated GTK3 configuration"
+	else
+		log "WARN" "GTK3 config not found, creating configuration"
+		mkdir -p "$(dirname "$GTK3_CONFIG")"
+		cat > "$GTK3_CONFIG" << EOF
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 gtk-theme-name=$gtk_theme
@@ -193,313 +193,313 @@ gtk-xft-hintstyle=hintslight
 gtk-xft-rgba=rgb
 gtk-modules=colorreload-gtk-module
 EOF
-  fi
+	fi
 
-  # Notify running GTK applications to reload themes
-  if command -v gsettings >/dev/null 2>&1; then
-    gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2>/dev/null || true
-    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2>/dev/null || true
-    # Older schemas expose this key; portals/libadwaita use color-scheme instead.
-    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
-    log "INFO" "Updated gsettings"
-  fi
+	# Notify running GTK applications to reload themes
+	if command -v gsettings > /dev/null 2>&1; then
+		gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2> /dev/null || true
+		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2> /dev/null || true
+		# Older schemas expose this key; portals/libadwaita use color-scheme instead.
+		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
+		log "INFO" "Updated gsettings"
+	fi
 
-  # Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
-  if [[ $prefer_dark == "true" ]]; then
-    apply_gtk_color_scheme dark
-  else
-    apply_gtk_color_scheme light
-  fi
+	# Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
+	if [[ $prefer_dark == "true" ]]; then
+		apply_gtk_color_scheme dark
+	else
+		apply_gtk_color_scheme light
+	fi
 
-  # XFCE4 settings support removed - using gsettings only
-  # If running XFCE4 session, gsettings should be sufficient
-  # Legacy xfconf-query support can be re-enabled if needed
+	# XFCE4 settings support removed - using gsettings only
+	# If running XFCE4 session, gsettings should be sufficient
+	# Legacy xfconf-query support can be re-enabled if needed
 
-  log "INFO" "GTK theme applied successfully: $gtk_theme"
-  return 0
+	log "INFO" "GTK theme applied successfully: $gtk_theme"
+	return 0
 }
 
 # Sync GTK/libadwaita light-dark preference without changing the theme name.
 # mode: "dark" | "light"
 apply_gtk_color_scheme() {
-  local mode="${1:-dark}"
-  local prefer_dark="true"
-  local color_scheme="prefer-dark"
-  if [[ $mode == "light" ]]; then
-    prefer_dark="false"
-    color_scheme="prefer-light"
-  elif [[ $mode != "dark" ]]; then
-    log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
-    return 1
-  fi
+	local mode="${1:-dark}"
+	local prefer_dark="true"
+	local color_scheme="prefer-dark"
+	if [[ $mode == "light" ]]; then
+		prefer_dark="false"
+		color_scheme="prefer-light"
+	elif [[ $mode != "dark" ]]; then
+		log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
+		return 1
+	fi
 
-  if [[ -f $GTK3_CONFIG ]]; then
-    if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2>/dev/null; then
-      sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-    else
-      printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >>"$GTK3_CONFIG"
-    fi
-  else
-    mkdir -p "$(dirname "$GTK3_CONFIG")" || {
-      log "ERROR" "Failed to create directory for $GTK3_CONFIG"
-      return 1
-    }
-    if ! cat >"$GTK3_CONFIG" <<EOF; then
+	if [[ -f $GTK3_CONFIG ]]; then
+		if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2> /dev/null; then
+			sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+		else
+			printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >> "$GTK3_CONFIG"
+		fi
+	else
+		mkdir -p "$(dirname "$GTK3_CONFIG")" || {
+			log "ERROR" "Failed to create directory for $GTK3_CONFIG"
+			return 1
+		}
+		if ! cat > "$GTK3_CONFIG" << EOF; then
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 EOF
-      log "ERROR" "Failed to write $GTK3_CONFIG"
-      return 1
-    fi
-    log "INFO" "Created GTK3 config for color-scheme sync"
-  fi
+			log "ERROR" "Failed to write $GTK3_CONFIG"
+			return 1
+		fi
+		log "INFO" "Created GTK3 config for color-scheme sync"
+	fi
 
-  if command -v gsettings >/dev/null 2>&1; then
-    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
-    gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" >/dev/null 2>&1 || true
-  fi
-  log "INFO" "GTK color-scheme set to $color_scheme"
-  return 0
+	if command -v gsettings > /dev/null 2>&1; then
+		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
+		gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" > /dev/null 2>&1 || true
+	fi
+	log "INFO" "GTK color-scheme set to $color_scheme"
+	return 0
 }
 
 # Function to detect optimal GTK theme based on wallpaper colors
 detect_optimal_gtk_theme() {
-  local wallpaper_path="$1"
-  local detected_theme="Orchis-Light" # Default
-  local prefer_dark="false"
+	local wallpaper_path="$1"
+	local detected_theme="Orchis-Light" # Default
+	local prefer_dark="false"
 
-  # First, try to use pywal's background color to determine if theme should be dark or light
-  if [[ -f "$HOME/.cache/wal/colors" ]]; then
-    log "INFO" "Analyzing pywal colors for optimal theme selection"
+	# First, try to use pywal's background color to determine if theme should be dark or light
+	if [[ -f "$HOME/.cache/wal/colors" ]]; then
+		log "INFO" "Analyzing pywal colors for optimal theme selection"
 
-    # Read background color from pywal
-    local bg_color
-    bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
+		# Read background color from pywal
+		local bg_color
+		bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
 
-    if [[ -n $bg_color ]]; then
-      # Convert hex to RGB and calculate brightness
-      local r=$((16#${bg_color:0:2}))
-      local g=$((16#${bg_color:2:2}))
-      local b=$((16#${bg_color:4:2}))
-      local brightness=$((r + g + b))
+		if [[ -n $bg_color ]]; then
+			# Convert hex to RGB and calculate brightness
+			local r=$((16#${bg_color:0:2}))
+			local g=$((16#${bg_color:2:2}))
+			local b=$((16#${bg_color:4:2}))
+			local brightness=$((r + g + b))
 
-      # If background is dark (low brightness), suggest dark theme
-      if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
-        log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
-        local dark_themes=(
-          "Orchis-Dark-Compact"
-          "Arc-Dark"
-          "elementary-dark"
-          "Breeze-Dark"
-        )
+			# If background is dark (low brightness), suggest dark theme
+			if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
+				log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
+				local dark_themes=(
+					"Orchis-Dark-Compact"
+					"Arc-Dark"
+					"elementary-dark"
+					"Breeze-Dark"
+				)
 
-        for theme in "${dark_themes[@]}"; do
-          if is_gtk_theme_installed "$theme"; then
-            detected_theme="$theme"
-            prefer_dark="true"
-            break
-          fi
-        done
-      else
-        log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
-        local light_themes=(
-          "Orchis-Light"
-          "Arc"
-          "elementary"
-          "Breeze"
-        )
+				for theme in "${dark_themes[@]}"; do
+					if is_gtk_theme_installed "$theme"; then
+						detected_theme="$theme"
+						prefer_dark="true"
+						break
+					fi
+				done
+			else
+				log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
+				local light_themes=(
+					"Orchis-Light"
+					"Arc"
+					"elementary"
+					"Breeze"
+				)
 
-        for theme in "${light_themes[@]}"; do
-          if is_gtk_theme_installed "$theme"; then
-            detected_theme="$theme"
-            prefer_dark="false"
-            break
-          fi
-        done
-      fi
-    fi
-  elif command -v dots-smart-colors >/dev/null 2>&1; then
-    # Fallback: use smart-colors to analyze current theme
-    log "INFO" "Using smart-colors to analyze current theme"
+				for theme in "${light_themes[@]}"; do
+					if is_gtk_theme_installed "$theme"; then
+						detected_theme="$theme"
+						prefer_dark="false"
+						break
+					fi
+				done
+			fi
+		fi
+	elif command -v dots-smart-colors > /dev/null 2>&1; then
+		# Fallback: use smart-colors to analyze current theme
+		log "INFO" "Using smart-colors to analyze current theme"
 
-    # Check if current theme is light or dark using smart-colors logic
-    if dots-smart-colors --analyze 2>/dev/null | grep -q "light theme\|bright"; then
-      log "INFO" "Light theme detected, suggesting light GTK theme"
-      local light_themes=(
-        "Orchis-Light"
-        "Arc"
-        "elementary"
-        "Breeze"
-      )
+		# Check if current theme is light or dark using smart-colors logic
+		if dots-smart-colors --analyze 2> /dev/null | grep -q "light theme\|bright"; then
+			log "INFO" "Light theme detected, suggesting light GTK theme"
+			local light_themes=(
+				"Orchis-Light"
+				"Arc"
+				"elementary"
+				"Breeze"
+			)
 
-      for theme in "${light_themes[@]}"; do
-        if is_gtk_theme_installed "$theme"; then
-          detected_theme="$theme"
-          prefer_dark="false"
-          break
-        fi
-      done
-    else
-      log "INFO" "Dark theme detected, suggesting dark GTK theme"
-      local dark_themes=(
-        "Orchis-Dark-Compact"
-        "Arc-Dark"
-        "elementary-dark"
-        "Breeze-Dark"
-      )
+			for theme in "${light_themes[@]}"; do
+				if is_gtk_theme_installed "$theme"; then
+					detected_theme="$theme"
+					prefer_dark="false"
+					break
+				fi
+			done
+		else
+			log "INFO" "Dark theme detected, suggesting dark GTK theme"
+			local dark_themes=(
+				"Orchis-Dark-Compact"
+				"Arc-Dark"
+				"elementary-dark"
+				"Breeze-Dark"
+			)
 
-      for theme in "${dark_themes[@]}"; do
-        if is_gtk_theme_installed "$theme"; then
-          detected_theme="$theme"
-          prefer_dark="true"
-          break
-        fi
-      done
-    fi
-  else
-    log "WARN" "No color analysis available, using default light theme"
-  fi
+			for theme in "${dark_themes[@]}"; do
+				if is_gtk_theme_installed "$theme"; then
+					detected_theme="$theme"
+					prefer_dark="true"
+					break
+				fi
+			done
+		fi
+	else
+		log "WARN" "No color analysis available, using default light theme"
+	fi
 
-  log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
-  echo "$detected_theme:$prefer_dark"
+	log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
+	echo "$detected_theme:$prefer_dark"
 }
 
 # Normalize prefer-dark to a real GTK boolean string (true/false).
 normalize_prefer_dark() {
-  case "${1:-auto}" in
-    true | 1 | yes | dark) echo "true" ;;
-    false | 0 | no | light) echo "false" ;;
-    *) echo "auto" ;;
-  esac
+	case "${1:-auto}" in
+		true | 1 | yes | dark) echo "true" ;;
+		false | 0 | no | light) echo "false" ;;
+		*) echo "auto" ;;
+	esac
 }
 
 # Apply GTK/icons from an appearance theme pack (one-shot recipe).
 apply_theme_gtk_theme() {
-  local theme_id="${1:-}"
+	local theme_id="${1:-}"
 
-  if [[ -z $theme_id ]]; then
-    log "WARN" "No theme specified, using wallpaper-based detection"
-    local wallpaper=""
-    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-      # shellcheck source=/dev/null
-      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-      wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
-    fi
-    # Never readlink ~/.cache/wal/wal — it is a text path file, not an image symlink.
-    if [[ -n $wallpaper && -f $wallpaper ]]; then
-      local theme_info
-      theme_info=$(detect_optimal_gtk_theme "$wallpaper")
-      local gtk_theme="${theme_info%:*}"
-      local prefer_dark
-      prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-      apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
-    else
-      apply_gtk_theme "Orchis-Dark" "Numix-Circle" "true"
-    fi
-    return
-  fi
+	if [[ -z $theme_id ]]; then
+		log "WARN" "No theme specified, using wallpaper-based detection"
+		local wallpaper=""
+		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+			# shellcheck source=/dev/null
+			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+			wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
+		fi
+		# Never readlink ~/.cache/wal/wal — it is a text path file, not an image symlink.
+		if [[ -n $wallpaper && -f $wallpaper ]]; then
+			local theme_info
+			theme_info=$(detect_optimal_gtk_theme "$wallpaper")
+			local gtk_theme="${theme_info%:*}"
+			local prefer_dark
+			prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+			apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
+		else
+			apply_gtk_theme "Orchis-Dark" "Numix-Circle" "true"
+		fi
+		return
+	fi
 
-  log "INFO" "Applying GTK theme from appearance pack: $theme_id"
+	log "INFO" "Applying GTK theme from appearance pack: $theme_id"
 
-  local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
-  local theme_json="$HOME/.local/share/dots/themes/$theme_id/theme.json"
+	local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
+	local theme_json="$HOME/.local/share/dots/themes/$theme_id/theme.json"
 
-  if [[ ! -f $theme_json ]]; then
-    log "ERROR" "Theme pack not found: $theme_id ($theme_json)"
-    return 1
-  fi
+	if [[ ! -f $theme_json ]]; then
+		log "ERROR" "Theme pack not found: $theme_id ($theme_json)"
+		return 1
+	fi
 
-  local meta
-  meta="$(
-    python3 - "$theme_json" <<'PY'
+	local meta
+	meta="$(
+		python3 - "$theme_json" << 'PY'
 import json, sys
 data = json.load(open(sys.argv[1], encoding="utf-8"))
 print(data.get("gtkTheme") or "auto")
 print(data.get("iconTheme") or "Numix-Circle")
 print("true" if data.get("darkMode", True) else "false")
 PY
-  )"
-  gtk_theme="$(sed -n '1p' <<<"$meta")"
-  icon_theme="$(sed -n '2p' <<<"$meta")"
-  prefer_dark="$(sed -n '3p' <<<"$meta")"
-  prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
+	)"
+	gtk_theme="$(sed -n '1p' <<< "$meta")"
+	icon_theme="$(sed -n '2p' <<< "$meta")"
+	prefer_dark="$(sed -n '3p' <<< "$meta")"
+	prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
 
-  if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
-    local wal_wallpaper=""
-    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-      # shellcheck source=/dev/null
-      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-      wal_wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
-    fi
-    # Prefer wallpaper-resolver (handles text wal pointer + state pointer).
-    if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
-      local theme_info
-      theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
-      gtk_theme="${theme_info%:*}"
-      if [[ $prefer_dark == "auto" ]]; then
-        prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-      fi
-    else
-      if [[ $prefer_dark == "true" ]]; then
-        gtk_theme="Orchis-Dark"
-      else
-        gtk_theme="Orchis-Light"
-      fi
-    fi
-  fi
+	if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
+		local wal_wallpaper=""
+		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+			# shellcheck source=/dev/null
+			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+			wal_wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
+		fi
+		# Prefer wallpaper-resolver (handles text wal pointer + state pointer).
+		if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
+			local theme_info
+			theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
+			gtk_theme="${theme_info%:*}"
+			if [[ $prefer_dark == "auto" ]]; then
+				prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+			fi
+		else
+			if [[ $prefer_dark == "true" ]]; then
+				gtk_theme="Orchis-Dark"
+			else
+				gtk_theme="Orchis-Light"
+			fi
+		fi
+	fi
 
-  if [[ $prefer_dark == "auto" ]]; then
-    prefer_dark="true"
-  fi
+	if [[ $prefer_dark == "auto" ]]; then
+		prefer_dark="true"
+	fi
 
-  apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
+	apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
 }
 
 # Function to get current GTK theme
 get_current_gtk_theme() {
-  if [[ -f $GTK3_CONFIG ]]; then
-    grep "^gtk-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
-  elif [[ -f $GTK2_CONFIG ]]; then
-    grep "^gtk-theme-name=" "$GTK2_CONFIG" | cut -d'"' -f2
-  else
-    echo "Unknown"
-  fi
+	if [[ -f $GTK3_CONFIG ]]; then
+		grep "^gtk-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
+	elif [[ -f $GTK2_CONFIG ]]; then
+		grep "^gtk-theme-name=" "$GTK2_CONFIG" | cut -d'"' -f2
+	else
+		echo "Unknown"
+	fi
 }
 
 # Function to get current icon theme
 get_current_icon_theme() {
-  if [[ -f $GTK3_CONFIG ]]; then
-    grep "^gtk-icon-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
-  elif command -v gsettings >/dev/null 2>&1; then
-    gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'"
-  else
-    echo ""
-  fi
+	if [[ -f $GTK3_CONFIG ]]; then
+		grep "^gtk-icon-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
+	elif command -v gsettings > /dev/null 2>&1; then
+		gsettings get org.gnome.desktop.interface icon-theme 2> /dev/null | tr -d "'"
+	else
+		echo ""
+	fi
 }
 
 # Function to list installed GTK themes
 list_installed_gtk_themes() {
-  local themes=()
+	local themes=()
 
-  local theme_dirs=(
-    "/usr/share/themes"
-    "/usr/local/share/themes"
-    "$HOME/.themes"
-    "$HOME/.local/share/themes"
-  )
+	local theme_dirs=(
+		"/usr/share/themes"
+		"/usr/local/share/themes"
+		"$HOME/.themes"
+		"$HOME/.local/share/themes"
+	)
 
-  for theme_dir in "${theme_dirs[@]}"; do
-    if [[ -d $theme_dir ]]; then
-      while IFS= read -r -d '' theme_path; do
-        local theme_name
-        theme_name=$(basename "$theme_path")
-        if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
-          themes+=("$theme_name")
-        fi
-      done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
-    fi
-  done
+	for theme_dir in "${theme_dirs[@]}"; do
+		if [[ -d $theme_dir ]]; then
+			while IFS= read -r -d '' theme_path; do
+				local theme_name
+				theme_name=$(basename "$theme_path")
+				if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
+					themes+=("$theme_name")
+				fi
+			done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
+		fi
+	done
 
-  # Remove duplicates and sort
-  printf '%s\n' "${themes[@]}" | sort -u
+	# Remove duplicates and sort
+	printf '%s\n' "${themes[@]}" | sort -u
 }

--- a/home/dot_local/lib/dots/gtk-theme-manager.sh
+++ b/home/dot_local/lib/dots/gtk-theme-manager.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 # Source smart colors for theme detection
 if [[ -f "$HOME/.local/lib/dots/smart-colors.sh" ]]; then
-	source "$HOME/.local/lib/dots/smart-colors.sh"
+  source "$HOME/.local/lib/dots/smart-colors.sh"
 fi
 
 # GTK configuration paths
@@ -28,120 +28,120 @@ readonly GTK3_CONFIG="$HOME/.config/gtk-3.0/settings.ini"
 
 # Function to log messages
 log() {
-	local level="$1"
-	shift
-	local message="$*"
-	local timestamp
-	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+  local level="$1"
+  shift
+  local message="$*"
+  local timestamp
+  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-	echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
+  echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
 }
 
 # Function to check if a GTK theme is installed
 is_gtk_theme_installed() {
-	local theme_name="$1"
+  local theme_name="$1"
 
-	# Check in common theme directories
-	local theme_dirs=(
-		"/usr/share/themes"
-		"/usr/local/share/themes"
-		"$HOME/.themes"
-		"$HOME/.local/share/themes"
-	)
+  # Check in common theme directories
+  local theme_dirs=(
+    "/usr/share/themes"
+    "/usr/local/share/themes"
+    "$HOME/.themes"
+    "$HOME/.local/share/themes"
+  )
 
-	for theme_dir in "${theme_dirs[@]}"; do
-		if [[ -d "$theme_dir/$theme_name" ]]; then
-			return 0
-		fi
-	done
+  for theme_dir in "${theme_dirs[@]}"; do
+    if [[ -d "$theme_dir/$theme_name" ]]; then
+      return 0
+    fi
+  done
 
-	return 1
+  return 1
 }
 
 # Function to check if an icon theme is installed
 is_icon_theme_installed() {
-	local icon_theme="$1"
+  local icon_theme="$1"
 
-	# Check in common icon directories
-	local icon_dirs=(
-		"/usr/share/icons"
-		"/usr/local/share/icons"
-		"$HOME/.icons"
-		"$HOME/.local/share/icons"
-	)
+  # Check in common icon directories
+  local icon_dirs=(
+    "/usr/share/icons"
+    "/usr/local/share/icons"
+    "$HOME/.icons"
+    "$HOME/.local/share/icons"
+  )
 
-	for icon_dir in "${icon_dirs[@]}"; do
-		if [[ -d "$icon_dir/$icon_theme" ]]; then
-			return 0
-		fi
-	done
+  for icon_dir in "${icon_dirs[@]}"; do
+    if [[ -d "$icon_dir/$icon_theme" ]]; then
+      return 0
+    fi
+  done
 
-	return 1
+  return 1
 }
 
 # Function to apply GTK theme with fallbacks
 apply_gtk_theme() {
-	local gtk_theme="$1"
-	local icon_theme="${2:-elementary}"
-	local prefer_dark="${3:-false}"
+  local gtk_theme="$1"
+  local icon_theme="${2:-elementary}"
+  local prefer_dark="${3:-false}"
 
-	log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
+  log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
 
-	# Validate theme availability with fallbacks
-	if ! is_gtk_theme_installed "$gtk_theme"; then
-		log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
+  # Validate theme availability with fallbacks
+  if ! is_gtk_theme_installed "$gtk_theme"; then
+    log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
 
-		# Common fallback themes in order of preference
-		local fallback_themes=(
-			"Orchis-Light"
-			"elementary"
-			"Arc-Dark"
-			"Arc"
-			"Breeze"
-			"oxygen-gtk"
-		)
+    # Common fallback themes in order of preference
+    local fallback_themes=(
+      "Orchis-Light"
+      "elementary"
+      "Arc-Dark"
+      "Arc"
+      "Breeze"
+      "oxygen-gtk"
+    )
 
-		for fallback in "${fallback_themes[@]}"; do
-			if is_gtk_theme_installed "$fallback"; then
-				gtk_theme="$fallback"
-				log "INFO" "Using fallback theme: $gtk_theme"
-				break
-			fi
-		done
+    for fallback in "${fallback_themes[@]}"; do
+      if is_gtk_theme_installed "$fallback"; then
+        gtk_theme="$fallback"
+        log "INFO" "Using fallback theme: $gtk_theme"
+        break
+      fi
+    done
 
-		if ! is_gtk_theme_installed "$gtk_theme"; then
-			log "ERROR" "No suitable GTK theme found, keeping current theme"
-			return 1
-		fi
-	fi
+    if ! is_gtk_theme_installed "$gtk_theme"; then
+      log "ERROR" "No suitable GTK theme found, keeping current theme"
+      return 1
+    fi
+  fi
 
-	# Validate icon theme with fallbacks
-	if ! is_icon_theme_installed "$icon_theme"; then
-		log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
+  # Validate icon theme with fallbacks
+  if ! is_icon_theme_installed "$icon_theme"; then
+    log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
 
-		local fallback_icons=(
-			"Numix-Circle"
-			"elementary"
-			"hicolor"
-		)
+    local fallback_icons=(
+      "Numix-Circle"
+      "elementary"
+      "hicolor"
+    )
 
-		for fallback in "${fallback_icons[@]}"; do
-			if is_icon_theme_installed "$fallback"; then
-				icon_theme="$fallback"
-				log "INFO" "Using fallback icon theme: $icon_theme"
-				break
-			fi
-		done
-	fi
+    for fallback in "${fallback_icons[@]}"; do
+      if is_icon_theme_installed "$fallback"; then
+        icon_theme="$fallback"
+        log "INFO" "Using fallback icon theme: $icon_theme"
+        break
+      fi
+    done
+  fi
 
-	# Update GTK2 configuration
-	if [[ -f $GTK2_CONFIG ]]; then
-		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
-		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
-		log "INFO" "Updated GTK2 configuration"
-	else
-		log "WARN" "GTK2 config not found, creating basic configuration"
-		cat > "$GTK2_CONFIG" << EOF
+  # Update GTK2 configuration
+  if [[ -f $GTK2_CONFIG ]]; then
+    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
+    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
+    log "INFO" "Updated GTK2 configuration"
+  else
+    log "WARN" "GTK2 config not found, creating basic configuration"
+    cat >"$GTK2_CONFIG" <<EOF
 # DO NOT EDIT! This file will be overwritten by LXAppearance.
 # Any customization should be done in ~/.gtkrc-2.0.mine instead.
 
@@ -162,18 +162,18 @@ gtk-xft-hinting=1
 gtk-xft-hintstyle="hintslight"
 gtk-xft-rgba="rgb"
 EOF
-	fi
+  fi
 
-	# Update GTK3 configuration
-	if [[ -f $GTK3_CONFIG ]]; then
-		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
-		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
-		sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-		log "INFO" "Updated GTK3 configuration"
-	else
-		log "WARN" "GTK3 config not found, creating configuration"
-		mkdir -p "$(dirname "$GTK3_CONFIG")"
-		cat > "$GTK3_CONFIG" << EOF
+  # Update GTK3 configuration
+  if [[ -f $GTK3_CONFIG ]]; then
+    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
+    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
+    sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+    log "INFO" "Updated GTK3 configuration"
+  else
+    log "WARN" "GTK3 config not found, creating configuration"
+    mkdir -p "$(dirname "$GTK3_CONFIG")"
+    cat >"$GTK3_CONFIG" <<EOF
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 gtk-theme-name=$gtk_theme
@@ -193,323 +193,335 @@ gtk-xft-hintstyle=hintslight
 gtk-xft-rgba=rgb
 gtk-modules=colorreload-gtk-module
 EOF
-	fi
+  fi
 
-	# Notify running GTK applications to reload themes
-	if command -v gsettings > /dev/null 2>&1; then
-		gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2> /dev/null || true
-		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2> /dev/null || true
-		# Older schemas expose this key; portals/libadwaita use color-scheme instead.
-		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
-		log "INFO" "Updated gsettings"
-	fi
+  # Notify running GTK applications to reload themes
+  if command -v gsettings >/dev/null 2>&1; then
+    gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2>/dev/null || true
+    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2>/dev/null || true
+    # Older schemas expose this key; portals/libadwaita use color-scheme instead.
+    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
+    log "INFO" "Updated gsettings"
+  fi
 
-	# Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
-	if [[ $prefer_dark == "true" ]]; then
-		apply_gtk_color_scheme dark
-	else
-		apply_gtk_color_scheme light
-	fi
+  # Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
+  if [[ $prefer_dark == "true" ]]; then
+    apply_gtk_color_scheme dark
+  else
+    apply_gtk_color_scheme light
+  fi
 
-	# XFCE4 settings support removed - using gsettings only
-	# If running XFCE4 session, gsettings should be sufficient
-	# Legacy xfconf-query support can be re-enabled if needed
+  # XFCE4 settings support removed - using gsettings only
+  # If running XFCE4 session, gsettings should be sufficient
+  # Legacy xfconf-query support can be re-enabled if needed
 
-	log "INFO" "GTK theme applied successfully: $gtk_theme"
-	return 0
+  log "INFO" "GTK theme applied successfully: $gtk_theme"
+  return 0
 }
 
 # Sync GTK/libadwaita light-dark preference without changing the theme name.
 # mode: "dark" | "light"
 apply_gtk_color_scheme() {
-	local mode="${1:-dark}"
-	local prefer_dark="true"
-	local color_scheme="prefer-dark"
-	if [[ $mode == "light" ]]; then
-		prefer_dark="false"
-		color_scheme="prefer-light"
-	elif [[ $mode != "dark" ]]; then
-		log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
-		return 1
-	fi
+  local mode="${1:-dark}"
+  local prefer_dark="true"
+  local color_scheme="prefer-dark"
+  if [[ $mode == "light" ]]; then
+    prefer_dark="false"
+    color_scheme="prefer-light"
+  elif [[ $mode != "dark" ]]; then
+    log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
+    return 1
+  fi
 
-	if [[ -f $GTK3_CONFIG ]]; then
-		if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2> /dev/null; then
-			sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-		else
-			printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >> "$GTK3_CONFIG"
-		fi
-	else
-		mkdir -p "$(dirname "$GTK3_CONFIG")" || {
-			log "ERROR" "Failed to create directory for $GTK3_CONFIG"
-			return 1
-		}
-		if ! cat > "$GTK3_CONFIG" << EOF; then
+  if [[ -f $GTK3_CONFIG ]]; then
+    if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2>/dev/null; then
+      sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+    else
+      printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >>"$GTK3_CONFIG"
+    fi
+  else
+    mkdir -p "$(dirname "$GTK3_CONFIG")" || {
+      log "ERROR" "Failed to create directory for $GTK3_CONFIG"
+      return 1
+    }
+    if ! cat >"$GTK3_CONFIG" <<EOF; then
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 EOF
-			log "ERROR" "Failed to write $GTK3_CONFIG"
-			return 1
-		fi
-		log "INFO" "Created GTK3 config for color-scheme sync"
-	fi
+      log "ERROR" "Failed to write $GTK3_CONFIG"
+      return 1
+    fi
+    log "INFO" "Created GTK3 config for color-scheme sync"
+  fi
 
-	if command -v gsettings > /dev/null 2>&1; then
-		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
-		gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" > /dev/null 2>&1 || true
-	fi
-	log "INFO" "GTK color-scheme set to $color_scheme"
-	return 0
+  if command -v gsettings >/dev/null 2>&1; then
+    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
+    gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" >/dev/null 2>&1 || true
+  fi
+  log "INFO" "GTK color-scheme set to $color_scheme"
+  return 0
 }
 
 # Function to detect optimal GTK theme based on wallpaper colors
 detect_optimal_gtk_theme() {
-	local wallpaper_path="$1"
-	local detected_theme="Orchis-Light" # Default
-	local prefer_dark="false"
+  local wallpaper_path="$1"
+  local detected_theme="Orchis-Light" # Default
+  local prefer_dark="false"
 
-	# First, try to use pywal's background color to determine if theme should be dark or light
-	if [[ -f "$HOME/.cache/wal/colors" ]]; then
-		log "INFO" "Analyzing pywal colors for optimal theme selection"
+  # First, try to use pywal's background color to determine if theme should be dark or light
+  if [[ -f "$HOME/.cache/wal/colors" ]]; then
+    log "INFO" "Analyzing pywal colors for optimal theme selection"
 
-		# Read background color from pywal
-		local bg_color
-		bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
+    # Read background color from pywal
+    local bg_color
+    bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
 
-		if [[ -n $bg_color ]]; then
-			# Convert hex to RGB and calculate brightness
-			local r=$((16#${bg_color:0:2}))
-			local g=$((16#${bg_color:2:2}))
-			local b=$((16#${bg_color:4:2}))
-			local brightness=$((r + g + b))
+    if [[ -n $bg_color ]]; then
+      # Convert hex to RGB and calculate brightness
+      local r=$((16#${bg_color:0:2}))
+      local g=$((16#${bg_color:2:2}))
+      local b=$((16#${bg_color:4:2}))
+      local brightness=$((r + g + b))
 
-			# If background is dark (low brightness), suggest dark theme
-			if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
-				log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
-				local dark_themes=(
-					"Orchis-Dark-Compact"
-					"Arc-Dark"
-					"elementary-dark"
-					"Breeze-Dark"
-				)
+      # If background is dark (low brightness), suggest dark theme
+      if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
+        log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
+        local dark_themes=(
+          "Orchis-Dark-Compact"
+          "Arc-Dark"
+          "elementary-dark"
+          "Breeze-Dark"
+        )
 
-				for theme in "${dark_themes[@]}"; do
-					if is_gtk_theme_installed "$theme"; then
-						detected_theme="$theme"
-						prefer_dark="true"
-						break
-					fi
-				done
-			else
-				log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
-				local light_themes=(
-					"Orchis-Light"
-					"Arc"
-					"elementary"
-					"Breeze"
-				)
+        for theme in "${dark_themes[@]}"; do
+          if is_gtk_theme_installed "$theme"; then
+            detected_theme="$theme"
+            prefer_dark="true"
+            break
+          fi
+        done
+      else
+        log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
+        local light_themes=(
+          "Orchis-Light"
+          "Arc"
+          "elementary"
+          "Breeze"
+        )
 
-				for theme in "${light_themes[@]}"; do
-					if is_gtk_theme_installed "$theme"; then
-						detected_theme="$theme"
-						prefer_dark="false"
-						break
-					fi
-				done
-			fi
-		fi
-	elif command -v dots-smart-colors > /dev/null 2>&1; then
-		# Fallback: use smart-colors to analyze current theme
-		log "INFO" "Using smart-colors to analyze current theme"
+        for theme in "${light_themes[@]}"; do
+          if is_gtk_theme_installed "$theme"; then
+            detected_theme="$theme"
+            prefer_dark="false"
+            break
+          fi
+        done
+      fi
+    fi
+  elif command -v dots-smart-colors >/dev/null 2>&1; then
+    # Fallback: use smart-colors to analyze current theme
+    log "INFO" "Using smart-colors to analyze current theme"
 
-		# Check if current theme is light or dark using smart-colors logic
-		if dots-smart-colors --analyze 2> /dev/null | grep -q "light theme\|bright"; then
-			log "INFO" "Light theme detected, suggesting light GTK theme"
-			local light_themes=(
-				"Orchis-Light"
-				"Arc"
-				"elementary"
-				"Breeze"
-			)
+    # Check if current theme is light or dark using smart-colors logic
+    if dots-smart-colors --analyze 2>/dev/null | grep -q "light theme\|bright"; then
+      log "INFO" "Light theme detected, suggesting light GTK theme"
+      local light_themes=(
+        "Orchis-Light"
+        "Arc"
+        "elementary"
+        "Breeze"
+      )
 
-			for theme in "${light_themes[@]}"; do
-				if is_gtk_theme_installed "$theme"; then
-					detected_theme="$theme"
-					prefer_dark="false"
-					break
-				fi
-			done
-		else
-			log "INFO" "Dark theme detected, suggesting dark GTK theme"
-			local dark_themes=(
-				"Orchis-Dark-Compact"
-				"Arc-Dark"
-				"elementary-dark"
-				"Breeze-Dark"
-			)
+      for theme in "${light_themes[@]}"; do
+        if is_gtk_theme_installed "$theme"; then
+          detected_theme="$theme"
+          prefer_dark="false"
+          break
+        fi
+      done
+    else
+      log "INFO" "Dark theme detected, suggesting dark GTK theme"
+      local dark_themes=(
+        "Orchis-Dark-Compact"
+        "Arc-Dark"
+        "elementary-dark"
+        "Breeze-Dark"
+      )
 
-			for theme in "${dark_themes[@]}"; do
-				if is_gtk_theme_installed "$theme"; then
-					detected_theme="$theme"
-					prefer_dark="true"
-					break
-				fi
-			done
-		fi
-	else
-		log "WARN" "No color analysis available, using default light theme"
-	fi
+      for theme in "${dark_themes[@]}"; do
+        if is_gtk_theme_installed "$theme"; then
+          detected_theme="$theme"
+          prefer_dark="true"
+          break
+        fi
+      done
+    fi
+  else
+    log "WARN" "No color analysis available, using default light theme"
+  fi
 
-	log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
-	echo "$detected_theme:$prefer_dark"
+  log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
+  echo "$detected_theme:$prefer_dark"
 }
 
 # Normalize prefer-dark to a real GTK boolean string (true/false).
 normalize_prefer_dark() {
-	case "${1:-auto}" in
-		true | 1 | yes | dark) echo "true" ;;
-		false | 0 | no | light) echo "false" ;;
-		*) echo "auto" ;;
-	esac
+  case "${1:-auto}" in
+    true | 1 | yes | dark) echo "true" ;;
+    false | 0 | no | light) echo "false" ;;
+    *) echo "auto" ;;
+  esac
 }
 
 # Apply GTK/icons from an appearance theme pack (one-shot recipe).
 apply_theme_gtk_theme() {
-	local theme_id="${1:-}"
+  local theme_id="${1:-}"
 
-	if [[ -z $theme_id ]]; then
-		log "WARN" "No theme specified, using wallpaper-based detection"
-		local wallpaper=""
-		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-			# shellcheck source=/dev/null
-			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-			wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
-		fi
-		# Never readlink ~/.cache/wal/wal — it is a text path file, not an image symlink.
-		if [[ -n $wallpaper && -f $wallpaper ]]; then
-			local theme_info
-			theme_info=$(detect_optimal_gtk_theme "$wallpaper")
-			local gtk_theme="${theme_info%:*}"
-			local prefer_dark
-			prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-			apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
-		else
-			apply_gtk_theme "Orchis-Dark" "Numix-Circle" "true"
-		fi
-		return
-	fi
+  if [[ -z $theme_id ]]; then
+    log "WARN" "No theme specified, using wallpaper-based detection"
+    local wallpaper=""
+    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+      # shellcheck source=/dev/null
+      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+      wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
+    fi
+    # Never readlink ~/.cache/wal/wal — it is a text path file, not an image symlink.
+    if [[ -n $wallpaper && -f $wallpaper ]]; then
+      local theme_info
+      theme_info=$(detect_optimal_gtk_theme "$wallpaper")
+      local gtk_theme="${theme_info%:*}"
+      local prefer_dark
+      prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+      apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
+    else
+      apply_gtk_theme "Orchis-Dark" "Numix-Circle" "true"
+    fi
+    return
+  fi
 
-	log "INFO" "Applying GTK theme from appearance pack: $theme_id"
+  log "INFO" "Applying GTK theme from appearance pack: $theme_id"
 
-	local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
-	local theme_json="$HOME/.local/share/dots/themes/$theme_id/theme.json"
+  local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
+  local theme_json="$HOME/.local/share/dots/themes/$theme_id/theme.json"
 
-	if [[ ! -f $theme_json ]]; then
-		log "ERROR" "Theme pack not found: $theme_id ($theme_json)"
-		return 1
-	fi
+  if [[ ! -f $theme_json ]]; then
+    log "ERROR" "Theme pack not found: $theme_id ($theme_json)"
+    return 1
+  fi
 
-	local meta
-	meta="$(
-		python3 - "$theme_json" << 'PY'
+  local meta
+  meta="$(
+    python3 - "$theme_json" <<'PY'
 import json, sys
 data = json.load(open(sys.argv[1], encoding="utf-8"))
-print(data.get("gtkTheme") or "auto")
-print(data.get("iconTheme") or "Numix-Circle")
-print("true" if data.get("darkMode", True) else "false")
+gtk = data.get("gtkTheme") or "auto"
+icon = data.get("iconTheme") or "Numix-Circle"
+if "gtkPreferDark" in data and data["gtkPreferDark"] is not None:
+    prefer = "true" if data["gtkPreferDark"] else "false"
+else:
+    gtk_lc = str(gtk).lower()
+    if "light" in gtk_lc:
+        prefer = "false"
+    elif "dark" in gtk_lc:
+        prefer = "true"
+    else:
+        prefer = "true" if data.get("darkMode", True) else "false"
+print(gtk)
+print(icon)
+print(prefer)
 PY
-	)"
-	gtk_theme="$(sed -n '1p' <<< "$meta")"
-	icon_theme="$(sed -n '2p' <<< "$meta")"
-	prefer_dark="$(sed -n '3p' <<< "$meta")"
-	prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
+  )"
+  gtk_theme="$(sed -n '1p' <<<"$meta")"
+  icon_theme="$(sed -n '2p' <<<"$meta")"
+  prefer_dark="$(sed -n '3p' <<<"$meta")"
+  prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
 
-	if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
-		local wal_wallpaper=""
-		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-			# shellcheck source=/dev/null
-			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-			wal_wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
-		fi
-		# Prefer wallpaper-resolver (handles text wal pointer + state pointer).
-		if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
-			local theme_info
-			theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
-			gtk_theme="${theme_info%:*}"
-			if [[ $prefer_dark == "auto" ]]; then
-				prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-			fi
-		else
-			if [[ $prefer_dark == "true" ]]; then
-				gtk_theme="Orchis-Dark"
-			else
-				gtk_theme="Orchis-Light"
-			fi
-		fi
-	fi
+  if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
+    local wal_wallpaper=""
+    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+      # shellcheck source=/dev/null
+      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+      wal_wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
+    fi
+    # Prefer wallpaper-resolver (handles text wal pointer + state pointer).
+    if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
+      local theme_info
+      theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
+      gtk_theme="${theme_info%:*}"
+      if [[ $prefer_dark == "auto" ]]; then
+        prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+      fi
+    else
+      if [[ $prefer_dark == "true" ]]; then
+        gtk_theme="Orchis-Dark-Compact"
+      else
+        gtk_theme="Orchis-Light-Compact"
+      fi
+    fi
+  fi
 
-	if [[ $prefer_dark == "auto" ]]; then
-		prefer_dark="true"
-	fi
+  if [[ $prefer_dark == "auto" ]]; then
+    prefer_dark="false"
+  fi
 
-	apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
+  apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
 }
 
 # Function to get current GTK theme
 get_current_gtk_theme() {
-	local value=""
-	if [[ -f $GTK3_CONFIG ]]; then
-		value="$(grep "^gtk-theme-name=" "$GTK3_CONFIG" 2> /dev/null | cut -d'=' -f2 || true)"
-	fi
-	if [[ -z $value && -f $GTK2_CONFIG ]]; then
-		value="$(grep "^gtk-theme-name=" "$GTK2_CONFIG" 2> /dev/null | cut -d'"' -f2 || true)"
-	fi
-	if [[ -z $value ]] && command -v gsettings > /dev/null 2>&1; then
-		value="$(gsettings get org.gnome.desktop.interface gtk-theme 2> /dev/null | tr -d "'" || true)"
-	fi
-	printf '%s\n' "${value:-Unknown}"
-	return 0
+  local value=""
+  if [[ -f $GTK3_CONFIG ]]; then
+    value="$(grep "^gtk-theme-name=" "$GTK3_CONFIG" 2>/dev/null | cut -d'=' -f2 || true)"
+  fi
+  if [[ -z $value && -f $GTK2_CONFIG ]]; then
+    value="$(grep "^gtk-theme-name=" "$GTK2_CONFIG" 2>/dev/null | cut -d'"' -f2 || true)"
+  fi
+  if [[ -z $value ]] && command -v gsettings >/dev/null 2>&1; then
+    value="$(gsettings get org.gnome.desktop.interface gtk-theme 2>/dev/null | tr -d "'" || true)"
+  fi
+  printf '%s\n' "${value:-Unknown}"
+  return 0
 }
 
 # Function to get current icon theme
 get_current_icon_theme() {
-	local value=""
-	if [[ -f $GTK3_CONFIG ]]; then
-		value="$(grep "^gtk-icon-theme-name=" "$GTK3_CONFIG" 2> /dev/null | cut -d'=' -f2 || true)"
-	fi
-	if [[ -z $value ]] && command -v gsettings > /dev/null 2>&1; then
-		value="$(gsettings get org.gnome.desktop.interface icon-theme 2> /dev/null | tr -d "'" || true)"
-	fi
-	if [[ -z $value && -f $GTK2_CONFIG ]]; then
-		value="$(grep "^gtk-icon-theme-name=" "$GTK2_CONFIG" 2> /dev/null | cut -d'"' -f2 || true)"
-	fi
-	printf '%s\n' "${value:-}"
-	return 0
+  local value=""
+  if [[ -f $GTK3_CONFIG ]]; then
+    value="$(grep "^gtk-icon-theme-name=" "$GTK3_CONFIG" 2>/dev/null | cut -d'=' -f2 || true)"
+  fi
+  if [[ -z $value ]] && command -v gsettings >/dev/null 2>&1; then
+    value="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'" || true)"
+  fi
+  if [[ -z $value && -f $GTK2_CONFIG ]]; then
+    value="$(grep "^gtk-icon-theme-name=" "$GTK2_CONFIG" 2>/dev/null | cut -d'"' -f2 || true)"
+  fi
+  printf '%s\n' "${value:-}"
+  return 0
 }
 
 # Function to list installed GTK themes
 list_installed_gtk_themes() {
-	local themes=()
+  local themes=()
 
-	local theme_dirs=(
-		"/usr/share/themes"
-		"/usr/local/share/themes"
-		"$HOME/.themes"
-		"$HOME/.local/share/themes"
-	)
+  local theme_dirs=(
+    "/usr/share/themes"
+    "/usr/local/share/themes"
+    "$HOME/.themes"
+    "$HOME/.local/share/themes"
+  )
 
-	for theme_dir in "${theme_dirs[@]}"; do
-		if [[ -d $theme_dir ]]; then
-			while IFS= read -r -d '' theme_path; do
-				local theme_name
-				theme_name=$(basename "$theme_path")
-				if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
-					themes+=("$theme_name")
-				fi
-			done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
-		fi
-	done
+  for theme_dir in "${theme_dirs[@]}"; do
+    if [[ -d $theme_dir ]]; then
+      while IFS= read -r -d '' theme_path; do
+        local theme_name
+        theme_name=$(basename "$theme_path")
+        if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
+          themes+=("$theme_name")
+        fi
+      done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
+    fi
+  done
 
-	# Remove duplicates and sort
-	printf '%s\n' "${themes[@]}" | sort -u
+  # Remove duplicates and sort
+  printf '%s\n' "${themes[@]}" | sort -u
 }

--- a/home/dot_local/lib/dots/gtk-theme-manager.sh
+++ b/home/dot_local/lib/dots/gtk-theme-manager.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 # Source smart colors for theme detection
 if [[ -f "$HOME/.local/lib/dots/smart-colors.sh" ]]; then
-  source "$HOME/.local/lib/dots/smart-colors.sh"
+	source "$HOME/.local/lib/dots/smart-colors.sh"
 fi
 
 # GTK configuration paths
@@ -28,120 +28,120 @@ readonly GTK3_CONFIG="$HOME/.config/gtk-3.0/settings.ini"
 
 # Function to log messages
 log() {
-  local level="$1"
-  shift
-  local message="$*"
-  local timestamp
-  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+	local level="$1"
+	shift
+	local message="$*"
+	local timestamp
+	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-  echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
+	echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
 }
 
 # Function to check if a GTK theme is installed
 is_gtk_theme_installed() {
-  local theme_name="$1"
+	local theme_name="$1"
 
-  # Check in common theme directories
-  local theme_dirs=(
-    "/usr/share/themes"
-    "/usr/local/share/themes"
-    "$HOME/.themes"
-    "$HOME/.local/share/themes"
-  )
+	# Check in common theme directories
+	local theme_dirs=(
+		"/usr/share/themes"
+		"/usr/local/share/themes"
+		"$HOME/.themes"
+		"$HOME/.local/share/themes"
+	)
 
-  for theme_dir in "${theme_dirs[@]}"; do
-    if [[ -d "$theme_dir/$theme_name" ]]; then
-      return 0
-    fi
-  done
+	for theme_dir in "${theme_dirs[@]}"; do
+		if [[ -d "$theme_dir/$theme_name" ]]; then
+			return 0
+		fi
+	done
 
-  return 1
+	return 1
 }
 
 # Function to check if an icon theme is installed
 is_icon_theme_installed() {
-  local icon_theme="$1"
+	local icon_theme="$1"
 
-  # Check in common icon directories
-  local icon_dirs=(
-    "/usr/share/icons"
-    "/usr/local/share/icons"
-    "$HOME/.icons"
-    "$HOME/.local/share/icons"
-  )
+	# Check in common icon directories
+	local icon_dirs=(
+		"/usr/share/icons"
+		"/usr/local/share/icons"
+		"$HOME/.icons"
+		"$HOME/.local/share/icons"
+	)
 
-  for icon_dir in "${icon_dirs[@]}"; do
-    if [[ -d "$icon_dir/$icon_theme" ]]; then
-      return 0
-    fi
-  done
+	for icon_dir in "${icon_dirs[@]}"; do
+		if [[ -d "$icon_dir/$icon_theme" ]]; then
+			return 0
+		fi
+	done
 
-  return 1
+	return 1
 }
 
 # Function to apply GTK theme with fallbacks
 apply_gtk_theme() {
-  local gtk_theme="$1"
-  local icon_theme="${2:-elementary}"
-  local prefer_dark="${3:-false}"
+	local gtk_theme="$1"
+	local icon_theme="${2:-elementary}"
+	local prefer_dark="${3:-false}"
 
-  log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
+	log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
 
-  # Validate theme availability with fallbacks
-  if ! is_gtk_theme_installed "$gtk_theme"; then
-    log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
+	# Validate theme availability with fallbacks
+	if ! is_gtk_theme_installed "$gtk_theme"; then
+		log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
 
-    # Common fallback themes in order of preference
-    local fallback_themes=(
-      "Orchis-Light"
-      "elementary"
-      "Arc-Dark"
-      "Arc"
-      "Breeze"
-      "oxygen-gtk"
-    )
+		# Common fallback themes in order of preference
+		local fallback_themes=(
+			"Orchis-Light"
+			"elementary"
+			"Arc-Dark"
+			"Arc"
+			"Breeze"
+			"oxygen-gtk"
+		)
 
-    for fallback in "${fallback_themes[@]}"; do
-      if is_gtk_theme_installed "$fallback"; then
-        gtk_theme="$fallback"
-        log "INFO" "Using fallback theme: $gtk_theme"
-        break
-      fi
-    done
+		for fallback in "${fallback_themes[@]}"; do
+			if is_gtk_theme_installed "$fallback"; then
+				gtk_theme="$fallback"
+				log "INFO" "Using fallback theme: $gtk_theme"
+				break
+			fi
+		done
 
-    if ! is_gtk_theme_installed "$gtk_theme"; then
-      log "ERROR" "No suitable GTK theme found, keeping current theme"
-      return 1
-    fi
-  fi
+		if ! is_gtk_theme_installed "$gtk_theme"; then
+			log "ERROR" "No suitable GTK theme found, keeping current theme"
+			return 1
+		fi
+	fi
 
-  # Validate icon theme with fallbacks
-  if ! is_icon_theme_installed "$icon_theme"; then
-    log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
+	# Validate icon theme with fallbacks
+	if ! is_icon_theme_installed "$icon_theme"; then
+		log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
 
-    local fallback_icons=(
-      "Numix-Circle"
-      "elementary"
-      "hicolor"
-    )
+		local fallback_icons=(
+			"Numix-Circle"
+			"elementary"
+			"hicolor"
+		)
 
-    for fallback in "${fallback_icons[@]}"; do
-      if is_icon_theme_installed "$fallback"; then
-        icon_theme="$fallback"
-        log "INFO" "Using fallback icon theme: $icon_theme"
-        break
-      fi
-    done
-  fi
+		for fallback in "${fallback_icons[@]}"; do
+			if is_icon_theme_installed "$fallback"; then
+				icon_theme="$fallback"
+				log "INFO" "Using fallback icon theme: $icon_theme"
+				break
+			fi
+		done
+	fi
 
-  # Update GTK2 configuration
-  if [[ -f $GTK2_CONFIG ]]; then
-    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
-    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
-    log "INFO" "Updated GTK2 configuration"
-  else
-    log "WARN" "GTK2 config not found, creating basic configuration"
-    cat >"$GTK2_CONFIG" <<EOF
+	# Update GTK2 configuration
+	if [[ -f $GTK2_CONFIG ]]; then
+		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
+		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
+		log "INFO" "Updated GTK2 configuration"
+	else
+		log "WARN" "GTK2 config not found, creating basic configuration"
+		cat > "$GTK2_CONFIG" << EOF
 # DO NOT EDIT! This file will be overwritten by LXAppearance.
 # Any customization should be done in ~/.gtkrc-2.0.mine instead.
 
@@ -162,18 +162,18 @@ gtk-xft-hinting=1
 gtk-xft-hintstyle="hintslight"
 gtk-xft-rgba="rgb"
 EOF
-  fi
+	fi
 
-  # Update GTK3 configuration
-  if [[ -f $GTK3_CONFIG ]]; then
-    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
-    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
-    sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-    log "INFO" "Updated GTK3 configuration"
-  else
-    log "WARN" "GTK3 config not found, creating configuration"
-    mkdir -p "$(dirname "$GTK3_CONFIG")"
-    cat >"$GTK3_CONFIG" <<EOF
+	# Update GTK3 configuration
+	if [[ -f $GTK3_CONFIG ]]; then
+		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
+		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
+		sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+		log "INFO" "Updated GTK3 configuration"
+	else
+		log "WARN" "GTK3 config not found, creating configuration"
+		mkdir -p "$(dirname "$GTK3_CONFIG")"
+		cat > "$GTK3_CONFIG" << EOF
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 gtk-theme-name=$gtk_theme
@@ -193,225 +193,225 @@ gtk-xft-hintstyle=hintslight
 gtk-xft-rgba=rgb
 gtk-modules=colorreload-gtk-module
 EOF
-  fi
+	fi
 
-  # Notify running GTK applications to reload themes
-  if command -v gsettings >/dev/null 2>&1; then
-    gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2>/dev/null || true
-    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2>/dev/null || true
-    # Older schemas expose this key; portals/libadwaita use color-scheme instead.
-    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
-    log "INFO" "Updated gsettings"
-  fi
+	# Notify running GTK applications to reload themes
+	if command -v gsettings > /dev/null 2>&1; then
+		gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2> /dev/null || true
+		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2> /dev/null || true
+		# Older schemas expose this key; portals/libadwaita use color-scheme instead.
+		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
+		log "INFO" "Updated gsettings"
+	fi
 
-  # Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
-  if [[ $prefer_dark == "true" ]]; then
-    apply_gtk_color_scheme dark
-  else
-    apply_gtk_color_scheme light
-  fi
+	# Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
+	if [[ $prefer_dark == "true" ]]; then
+		apply_gtk_color_scheme dark
+	else
+		apply_gtk_color_scheme light
+	fi
 
-  # XFCE4 settings support removed - using gsettings only
-  # If running XFCE4 session, gsettings should be sufficient
-  # Legacy xfconf-query support can be re-enabled if needed
+	# XFCE4 settings support removed - using gsettings only
+	# If running XFCE4 session, gsettings should be sufficient
+	# Legacy xfconf-query support can be re-enabled if needed
 
-  log "INFO" "GTK theme applied successfully: $gtk_theme"
-  return 0
+	log "INFO" "GTK theme applied successfully: $gtk_theme"
+	return 0
 }
 
 # Sync GTK/libadwaita light-dark preference without changing the theme name.
 # mode: "dark" | "light"
 apply_gtk_color_scheme() {
-  local mode="${1:-dark}"
-  local prefer_dark="true"
-  local color_scheme="prefer-dark"
-  if [[ $mode == "light" ]]; then
-    prefer_dark="false"
-    color_scheme="prefer-light"
-  elif [[ $mode != "dark" ]]; then
-    log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
-    return 1
-  fi
+	local mode="${1:-dark}"
+	local prefer_dark="true"
+	local color_scheme="prefer-dark"
+	if [[ $mode == "light" ]]; then
+		prefer_dark="false"
+		color_scheme="prefer-light"
+	elif [[ $mode != "dark" ]]; then
+		log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
+		return 1
+	fi
 
-  if [[ -f $GTK3_CONFIG ]]; then
-    if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2>/dev/null; then
-      sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-    else
-      printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >>"$GTK3_CONFIG"
-    fi
-  else
-    mkdir -p "$(dirname "$GTK3_CONFIG")" || {
-      log "ERROR" "Failed to create directory for $GTK3_CONFIG"
-      return 1
-    }
-    if ! cat >"$GTK3_CONFIG" <<EOF; then
+	if [[ -f $GTK3_CONFIG ]]; then
+		if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2> /dev/null; then
+			sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
+		else
+			printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >> "$GTK3_CONFIG"
+		fi
+	else
+		mkdir -p "$(dirname "$GTK3_CONFIG")" || {
+			log "ERROR" "Failed to create directory for $GTK3_CONFIG"
+			return 1
+		}
+		if ! cat > "$GTK3_CONFIG" << EOF; then
 [Settings]
 gtk-application-prefer-dark-theme=$prefer_dark
 EOF
-      log "ERROR" "Failed to write $GTK3_CONFIG"
-      return 1
-    fi
-    log "INFO" "Created GTK3 config for color-scheme sync"
-  fi
+			log "ERROR" "Failed to write $GTK3_CONFIG"
+			return 1
+		fi
+		log "INFO" "Created GTK3 config for color-scheme sync"
+	fi
 
-  if command -v gsettings >/dev/null 2>&1; then
-    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
-    gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" >/dev/null 2>&1 || true
-  fi
-  log "INFO" "GTK color-scheme set to $color_scheme"
-  return 0
+	if command -v gsettings > /dev/null 2>&1; then
+		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
+		gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" > /dev/null 2>&1 || true
+	fi
+	log "INFO" "GTK color-scheme set to $color_scheme"
+	return 0
 }
 
 # Function to detect optimal GTK theme based on wallpaper colors
 detect_optimal_gtk_theme() {
-  local wallpaper_path="$1"
-  local detected_theme="Orchis-Light" # Default
-  local prefer_dark="false"
+	local wallpaper_path="$1"
+	local detected_theme="Orchis-Light" # Default
+	local prefer_dark="false"
 
-  # First, try to use pywal's background color to determine if theme should be dark or light
-  if [[ -f "$HOME/.cache/wal/colors" ]]; then
-    log "INFO" "Analyzing pywal colors for optimal theme selection"
+	# First, try to use pywal's background color to determine if theme should be dark or light
+	if [[ -f "$HOME/.cache/wal/colors" ]]; then
+		log "INFO" "Analyzing pywal colors for optimal theme selection"
 
-    # Read background color from pywal
-    local bg_color
-    bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
+		# Read background color from pywal
+		local bg_color
+		bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
 
-    if [[ -n $bg_color ]]; then
-      # Convert hex to RGB and calculate brightness
-      local r=$((16#${bg_color:0:2}))
-      local g=$((16#${bg_color:2:2}))
-      local b=$((16#${bg_color:4:2}))
-      local brightness=$((r + g + b))
+		if [[ -n $bg_color ]]; then
+			# Convert hex to RGB and calculate brightness
+			local r=$((16#${bg_color:0:2}))
+			local g=$((16#${bg_color:2:2}))
+			local b=$((16#${bg_color:4:2}))
+			local brightness=$((r + g + b))
 
-      # If background is dark (low brightness), suggest dark theme
-      if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
-        log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
-        local dark_themes=(
-          "Orchis-Dark-Compact"
-          "Arc-Dark"
-          "elementary-dark"
-          "Breeze-Dark"
-        )
+			# If background is dark (low brightness), suggest dark theme
+			if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
+				log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
+				local dark_themes=(
+					"Orchis-Dark-Compact"
+					"Arc-Dark"
+					"elementary-dark"
+					"Breeze-Dark"
+				)
 
-        for theme in "${dark_themes[@]}"; do
-          if is_gtk_theme_installed "$theme"; then
-            detected_theme="$theme"
-            prefer_dark="true"
-            break
-          fi
-        done
-      else
-        log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
-        local light_themes=(
-          "Orchis-Light"
-          "Arc"
-          "elementary"
-          "Breeze"
-        )
+				for theme in "${dark_themes[@]}"; do
+					if is_gtk_theme_installed "$theme"; then
+						detected_theme="$theme"
+						prefer_dark="true"
+						break
+					fi
+				done
+			else
+				log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
+				local light_themes=(
+					"Orchis-Light"
+					"Arc"
+					"elementary"
+					"Breeze"
+				)
 
-        for theme in "${light_themes[@]}"; do
-          if is_gtk_theme_installed "$theme"; then
-            detected_theme="$theme"
-            prefer_dark="false"
-            break
-          fi
-        done
-      fi
-    fi
-  elif command -v dots-smart-colors >/dev/null 2>&1; then
-    # Fallback: use smart-colors to analyze current theme
-    log "INFO" "Using smart-colors to analyze current theme"
+				for theme in "${light_themes[@]}"; do
+					if is_gtk_theme_installed "$theme"; then
+						detected_theme="$theme"
+						prefer_dark="false"
+						break
+					fi
+				done
+			fi
+		fi
+	elif command -v dots-smart-colors > /dev/null 2>&1; then
+		# Fallback: use smart-colors to analyze current theme
+		log "INFO" "Using smart-colors to analyze current theme"
 
-    # Check if current theme is light or dark using smart-colors logic
-    if dots-smart-colors --analyze 2>/dev/null | grep -q "light theme\|bright"; then
-      log "INFO" "Light theme detected, suggesting light GTK theme"
-      local light_themes=(
-        "Orchis-Light"
-        "Arc"
-        "elementary"
-        "Breeze"
-      )
+		# Check if current theme is light or dark using smart-colors logic
+		if dots-smart-colors --analyze 2> /dev/null | grep -q "light theme\|bright"; then
+			log "INFO" "Light theme detected, suggesting light GTK theme"
+			local light_themes=(
+				"Orchis-Light"
+				"Arc"
+				"elementary"
+				"Breeze"
+			)
 
-      for theme in "${light_themes[@]}"; do
-        if is_gtk_theme_installed "$theme"; then
-          detected_theme="$theme"
-          prefer_dark="false"
-          break
-        fi
-      done
-    else
-      log "INFO" "Dark theme detected, suggesting dark GTK theme"
-      local dark_themes=(
-        "Orchis-Dark-Compact"
-        "Arc-Dark"
-        "elementary-dark"
-        "Breeze-Dark"
-      )
+			for theme in "${light_themes[@]}"; do
+				if is_gtk_theme_installed "$theme"; then
+					detected_theme="$theme"
+					prefer_dark="false"
+					break
+				fi
+			done
+		else
+			log "INFO" "Dark theme detected, suggesting dark GTK theme"
+			local dark_themes=(
+				"Orchis-Dark-Compact"
+				"Arc-Dark"
+				"elementary-dark"
+				"Breeze-Dark"
+			)
 
-      for theme in "${dark_themes[@]}"; do
-        if is_gtk_theme_installed "$theme"; then
-          detected_theme="$theme"
-          prefer_dark="true"
-          break
-        fi
-      done
-    fi
-  else
-    log "WARN" "No color analysis available, using default light theme"
-  fi
+			for theme in "${dark_themes[@]}"; do
+				if is_gtk_theme_installed "$theme"; then
+					detected_theme="$theme"
+					prefer_dark="true"
+					break
+				fi
+			done
+		fi
+	else
+		log "WARN" "No color analysis available, using default light theme"
+	fi
 
-  log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
-  echo "$detected_theme:$prefer_dark"
+	log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
+	echo "$detected_theme:$prefer_dark"
 }
 
 # Normalize prefer-dark to a real GTK boolean string (true/false).
 normalize_prefer_dark() {
-  case "${1:-auto}" in
-    true | 1 | yes | dark) echo "true" ;;
-    false | 0 | no | light) echo "false" ;;
-    *) echo "auto" ;;
-  esac
+	case "${1:-auto}" in
+		true | 1 | yes | dark) echo "true" ;;
+		false | 0 | no | light) echo "false" ;;
+		*) echo "auto" ;;
+	esac
 }
 
 # Apply GTK/icons from an appearance theme pack (one-shot recipe).
 apply_theme_gtk_theme() {
-  local theme_id="${1:-}"
+	local theme_id="${1:-}"
 
-  if [[ -z $theme_id ]]; then
-    log "WARN" "No theme specified, using wallpaper-based detection"
-    local wallpaper=""
-    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-      # shellcheck source=/dev/null
-      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-      wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
-    fi
-    # Never readlink ~/.cache/wal/wal — it is a text path file, not an image symlink.
-    if [[ -n $wallpaper && -f $wallpaper ]]; then
-      local theme_info
-      theme_info=$(detect_optimal_gtk_theme "$wallpaper")
-      local gtk_theme="${theme_info%:*}"
-      local prefer_dark
-      prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-      apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
-    else
-      apply_gtk_theme "Orchis-Dark" "Numix-Circle" "true"
-    fi
-    return
-  fi
+	if [[ -z $theme_id ]]; then
+		log "WARN" "No theme specified, using wallpaper-based detection"
+		local wallpaper=""
+		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+			# shellcheck source=/dev/null
+			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+			wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
+		fi
+		# Never readlink ~/.cache/wal/wal — it is a text path file, not an image symlink.
+		if [[ -n $wallpaper && -f $wallpaper ]]; then
+			local theme_info
+			theme_info=$(detect_optimal_gtk_theme "$wallpaper")
+			local gtk_theme="${theme_info%:*}"
+			local prefer_dark
+			prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+			apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
+		else
+			apply_gtk_theme "Orchis-Dark" "Numix-Circle" "true"
+		fi
+		return
+	fi
 
-  log "INFO" "Applying GTK theme from appearance pack: $theme_id"
+	log "INFO" "Applying GTK theme from appearance pack: $theme_id"
 
-  local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
-  local theme_json="$HOME/.local/share/dots/themes/$theme_id/theme.json"
+	local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
+	local theme_json="$HOME/.local/share/dots/themes/$theme_id/theme.json"
 
-  if [[ ! -f $theme_json ]]; then
-    log "ERROR" "Theme pack not found: $theme_id ($theme_json)"
-    return 1
-  fi
+	if [[ ! -f $theme_json ]]; then
+		log "ERROR" "Theme pack not found: $theme_id ($theme_json)"
+		return 1
+	fi
 
-  local meta
-  meta="$(
-    python3 - "$theme_json" <<'PY'
+	local meta
+	meta="$(
+		python3 - "$theme_json" << 'PY'
 import json, sys
 data = json.load(open(sys.argv[1], encoding="utf-8"))
 gtk = data.get("gtkTheme") or "auto"
@@ -430,98 +430,98 @@ print(gtk)
 print(icon)
 print(prefer)
 PY
-  )"
-  gtk_theme="$(sed -n '1p' <<<"$meta")"
-  icon_theme="$(sed -n '2p' <<<"$meta")"
-  prefer_dark="$(sed -n '3p' <<<"$meta")"
-  prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
+	)"
+	gtk_theme="$(sed -n '1p' <<< "$meta")"
+	icon_theme="$(sed -n '2p' <<< "$meta")"
+	prefer_dark="$(sed -n '3p' <<< "$meta")"
+	prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
 
-  if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
-    local wal_wallpaper=""
-    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-      # shellcheck source=/dev/null
-      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-      wal_wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
-    fi
-    # Prefer wallpaper-resolver (handles text wal pointer + state pointer).
-    if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
-      local theme_info
-      theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
-      gtk_theme="${theme_info%:*}"
-      if [[ $prefer_dark == "auto" ]]; then
-        prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-      fi
-    else
-      if [[ $prefer_dark == "true" ]]; then
-        gtk_theme="Orchis-Dark-Compact"
-      else
-        gtk_theme="Orchis-Light-Compact"
-      fi
-    fi
-  fi
+	if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
+		local wal_wallpaper=""
+		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+			# shellcheck source=/dev/null
+			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+			wal_wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
+		fi
+		# Prefer wallpaper-resolver (handles text wal pointer + state pointer).
+		if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
+			local theme_info
+			theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
+			gtk_theme="${theme_info%:*}"
+			if [[ $prefer_dark == "auto" ]]; then
+				prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+			fi
+		else
+			if [[ $prefer_dark == "true" ]]; then
+				gtk_theme="Orchis-Dark-Compact"
+			else
+				gtk_theme="Orchis-Light-Compact"
+			fi
+		fi
+	fi
 
-  if [[ $prefer_dark == "auto" ]]; then
-    prefer_dark="false"
-  fi
+	if [[ $prefer_dark == "auto" ]]; then
+		prefer_dark="false"
+	fi
 
-  apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
+	apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
 }
 
 # Function to get current GTK theme
 get_current_gtk_theme() {
-  local value=""
-  if [[ -f $GTK3_CONFIG ]]; then
-    value="$(grep "^gtk-theme-name=" "$GTK3_CONFIG" 2>/dev/null | cut -d'=' -f2 || true)"
-  fi
-  if [[ -z $value && -f $GTK2_CONFIG ]]; then
-    value="$(grep "^gtk-theme-name=" "$GTK2_CONFIG" 2>/dev/null | cut -d'"' -f2 || true)"
-  fi
-  if [[ -z $value ]] && command -v gsettings >/dev/null 2>&1; then
-    value="$(gsettings get org.gnome.desktop.interface gtk-theme 2>/dev/null | tr -d "'" || true)"
-  fi
-  printf '%s\n' "${value:-Unknown}"
-  return 0
+	local value=""
+	if [[ -f $GTK3_CONFIG ]]; then
+		value="$(grep "^gtk-theme-name=" "$GTK3_CONFIG" 2> /dev/null | cut -d'=' -f2 || true)"
+	fi
+	if [[ -z $value && -f $GTK2_CONFIG ]]; then
+		value="$(grep "^gtk-theme-name=" "$GTK2_CONFIG" 2> /dev/null | cut -d'"' -f2 || true)"
+	fi
+	if [[ -z $value ]] && command -v gsettings > /dev/null 2>&1; then
+		value="$(gsettings get org.gnome.desktop.interface gtk-theme 2> /dev/null | tr -d "'" || true)"
+	fi
+	printf '%s\n' "${value:-Unknown}"
+	return 0
 }
 
 # Function to get current icon theme
 get_current_icon_theme() {
-  local value=""
-  if [[ -f $GTK3_CONFIG ]]; then
-    value="$(grep "^gtk-icon-theme-name=" "$GTK3_CONFIG" 2>/dev/null | cut -d'=' -f2 || true)"
-  fi
-  if [[ -z $value ]] && command -v gsettings >/dev/null 2>&1; then
-    value="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'" || true)"
-  fi
-  if [[ -z $value && -f $GTK2_CONFIG ]]; then
-    value="$(grep "^gtk-icon-theme-name=" "$GTK2_CONFIG" 2>/dev/null | cut -d'"' -f2 || true)"
-  fi
-  printf '%s\n' "${value:-}"
-  return 0
+	local value=""
+	if [[ -f $GTK3_CONFIG ]]; then
+		value="$(grep "^gtk-icon-theme-name=" "$GTK3_CONFIG" 2> /dev/null | cut -d'=' -f2 || true)"
+	fi
+	if [[ -z $value ]] && command -v gsettings > /dev/null 2>&1; then
+		value="$(gsettings get org.gnome.desktop.interface icon-theme 2> /dev/null | tr -d "'" || true)"
+	fi
+	if [[ -z $value && -f $GTK2_CONFIG ]]; then
+		value="$(grep "^gtk-icon-theme-name=" "$GTK2_CONFIG" 2> /dev/null | cut -d'"' -f2 || true)"
+	fi
+	printf '%s\n' "${value:-}"
+	return 0
 }
 
 # Function to list installed GTK themes
 list_installed_gtk_themes() {
-  local themes=()
+	local themes=()
 
-  local theme_dirs=(
-    "/usr/share/themes"
-    "/usr/local/share/themes"
-    "$HOME/.themes"
-    "$HOME/.local/share/themes"
-  )
+	local theme_dirs=(
+		"/usr/share/themes"
+		"/usr/local/share/themes"
+		"$HOME/.themes"
+		"$HOME/.local/share/themes"
+	)
 
-  for theme_dir in "${theme_dirs[@]}"; do
-    if [[ -d $theme_dir ]]; then
-      while IFS= read -r -d '' theme_path; do
-        local theme_name
-        theme_name=$(basename "$theme_path")
-        if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
-          themes+=("$theme_name")
-        fi
-      done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
-    fi
-  done
+	for theme_dir in "${theme_dirs[@]}"; do
+		if [[ -d $theme_dir ]]; then
+			while IFS= read -r -d '' theme_path; do
+				local theme_name
+				theme_name=$(basename "$theme_path")
+				if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
+					themes+=("$theme_name")
+				fi
+			done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
+		fi
+	done
 
-  # Remove duplicates and sort
-  printf '%s\n' "${themes[@]}" | sort -u
+	# Remove duplicates and sort
+	printf '%s\n' "${themes[@]}" | sort -u
 }

--- a/home/dot_local/lib/dots/gtk-theme-manager.sh
+++ b/home/dot_local/lib/dots/gtk-theme-manager.sh
@@ -457,24 +457,34 @@ PY
 
 # Function to get current GTK theme
 get_current_gtk_theme() {
+	local value=""
 	if [[ -f $GTK3_CONFIG ]]; then
-		grep "^gtk-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
-	elif [[ -f $GTK2_CONFIG ]]; then
-		grep "^gtk-theme-name=" "$GTK2_CONFIG" | cut -d'"' -f2
-	else
-		echo "Unknown"
+		value="$(grep "^gtk-theme-name=" "$GTK3_CONFIG" 2> /dev/null | cut -d'=' -f2 || true)"
 	fi
+	if [[ -z $value && -f $GTK2_CONFIG ]]; then
+		value="$(grep "^gtk-theme-name=" "$GTK2_CONFIG" 2> /dev/null | cut -d'"' -f2 || true)"
+	fi
+	if [[ -z $value ]] && command -v gsettings > /dev/null 2>&1; then
+		value="$(gsettings get org.gnome.desktop.interface gtk-theme 2> /dev/null | tr -d "'" || true)"
+	fi
+	printf '%s\n' "${value:-Unknown}"
+	return 0
 }
 
 # Function to get current icon theme
 get_current_icon_theme() {
+	local value=""
 	if [[ -f $GTK3_CONFIG ]]; then
-		grep "^gtk-icon-theme-name=" "$GTK3_CONFIG" | cut -d'=' -f2
-	elif command -v gsettings > /dev/null 2>&1; then
-		gsettings get org.gnome.desktop.interface icon-theme 2> /dev/null | tr -d "'"
-	else
-		echo ""
+		value="$(grep "^gtk-icon-theme-name=" "$GTK3_CONFIG" 2> /dev/null | cut -d'=' -f2 || true)"
 	fi
+	if [[ -z $value ]] && command -v gsettings > /dev/null 2>&1; then
+		value="$(gsettings get org.gnome.desktop.interface icon-theme 2> /dev/null | tr -d "'" || true)"
+	fi
+	if [[ -z $value && -f $GTK2_CONFIG ]]; then
+		value="$(grep "^gtk-icon-theme-name=" "$GTK2_CONFIG" 2> /dev/null | cut -d'"' -f2 || true)"
+	fi
+	printf '%s\n' "${value:-}"
+	return 0
 }
 
 # Function to list installed GTK themes

--- a/home/dot_local/lib/dots/list-themes.py
+++ b/home/dot_local/lib/dots/list-themes.py
@@ -72,8 +72,19 @@ def load_theme(theme_dir: Path, walls_root: Path) -> dict | None:
         "tags": data.get("tags") or [],
         "darkMode": bool(data.get("darkMode", True)),
         "schemeType": data.get("schemeType") or "tonal-spot",
-        "gtkTheme": data.get("gtkTheme") or "Orchis-Dark",
+        "gtkTheme": data.get("gtkTheme") or "Orchis-Light-Compact",
         "iconTheme": data.get("iconTheme") or "Numix-Circle",
+        "gtkPreferDark": (
+            bool(data["gtkPreferDark"])
+            if "gtkPreferDark" in data and data["gtkPreferDark"] is not None
+            else (
+                False
+                if "light" in str(data.get("gtkTheme") or "").lower()
+                else True
+                if "dark" in str(data.get("gtkTheme") or "").lower()
+                else bool(data.get("darkMode", True))
+            )
+        ),
         "defaultWallpaper": default,
         "wallpaperDir": wallpaper_dir,
         "wallpapers": walls,

--- a/home/dot_local/lib/dots/list-themes.py
+++ b/home/dot_local/lib/dots/list-themes.py
@@ -10,17 +10,35 @@ from pathlib import Path
 EXTS = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp"}
 
 
-def wallpaper_names(theme_id: str, wallpaper_dir: str, walls_root: Path) -> list[str]:
-    names: set[str] = set()
+def resolve_wallpaper_file(wallpaper_dir: str, filename: str, walls_root: Path) -> str:
+    """Prefer Pictures (chezmoi link), then data dir."""
+    pics = Path.home() / "Pictures/Wallpapers" / wallpaper_dir / filename
+    data_path = walls_root / wallpaper_dir / filename
+    if pics.is_file():
+        return str(pics)
+    if data_path.is_file():
+        return str(data_path)
+    # Canonical post-chezmoi target even if not linked yet.
+    return str(pics)
+
+
+def wallpaper_index(theme_id: str, wallpaper_dir: str, walls_root: Path) -> dict[str, str]:
+    """Map wallpaper filename → absolute path across Pictures + data roots."""
+    paths: dict[str, str] = {}
     pics_root = Path.home() / "Pictures/Wallpapers"
+    dir_name = wallpaper_dir or theme_id
     for root in (pics_root, walls_root):
-        d = root / (wallpaper_dir or theme_id)
+        d = root / dir_name
         if not d.is_dir():
             continue
         for p in d.iterdir():
-            if p.is_file() and p.suffix.lower() in EXTS:
-                names.add(p.name)
-    return sorted(names)
+            if not p.is_file() or p.suffix.lower() not in EXTS:
+                continue
+            # Prefer Pictures when both roots expose the same name.
+            if p.name in paths and root == walls_root:
+                continue
+            paths[p.name] = str(p.resolve()) if p.exists() else str(p)
+    return dict(sorted(paths.items()))
 
 
 def load_theme(theme_dir: Path, walls_root: Path) -> dict | None:
@@ -33,7 +51,8 @@ def load_theme(theme_dir: Path, walls_root: Path) -> dict | None:
         return None
     theme_id = data.get("id") or theme_dir.name
     wallpaper_dir = data.get("wallpaperDir") or theme_id
-    walls = wallpaper_names(theme_id, wallpaper_dir, walls_root)
+    wallpaper_paths = wallpaper_index(theme_id, wallpaper_dir, walls_root)
+    walls = list(wallpaper_paths.keys())
     preview = ""
     for cand in ("preview.jpg", "preview.webp", "preview.png"):
         p = theme_dir / cand
@@ -43,15 +62,9 @@ def load_theme(theme_dir: Path, walls_root: Path) -> dict | None:
     default = data.get("defaultWallpaper") or (walls[0] if walls else "")
     wallpaper_path = ""
     if default:
-        pics = Path.home() / "Pictures/Wallpapers" / wallpaper_dir / default
-        data_path = walls_root / wallpaper_dir / default
-        if pics.exists():
-            wallpaper_path = str(pics)
-        elif data_path.exists():
-            wallpaper_path = str(data_path)
-        else:
-            # Canonical post-chezmoi target even if not linked yet.
-            wallpaper_path = str(pics)
+        wallpaper_path = wallpaper_paths.get(default) or resolve_wallpaper_file(
+            wallpaper_dir, default, walls_root
+        )
     return {
         "id": theme_id,
         "name": data.get("name") or theme_id,
@@ -64,6 +77,7 @@ def load_theme(theme_dir: Path, walls_root: Path) -> dict | None:
         "defaultWallpaper": default,
         "wallpaperDir": wallpaper_dir,
         "wallpapers": walls,
+        "wallpaperPaths": wallpaper_paths,
         "preview": preview,
         "wallpaperPath": wallpaper_path,
     }

--- a/home/dot_local/lib/dots/list-themes.py
+++ b/home/dot_local/lib/dots/list-themes.py
@@ -11,10 +11,16 @@ EXTS = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp"}
 
 
 def wallpaper_names(theme_id: str, wallpaper_dir: str, walls_root: Path) -> list[str]:
-    d = walls_root / (wallpaper_dir or theme_id)
-    if not d.is_dir():
-        return []
-    return sorted(p.name for p in d.iterdir() if p.is_file() and p.suffix.lower() in EXTS)
+    names: set[str] = set()
+    pics_root = Path.home() / "Pictures/Wallpapers"
+    for root in (pics_root, walls_root):
+        d = root / (wallpaper_dir or theme_id)
+        if not d.is_dir():
+            continue
+        for p in d.iterdir():
+            if p.is_file() and p.suffix.lower() in EXTS:
+                names.add(p.name)
+    return sorted(names)
 
 
 def load_theme(theme_dir: Path, walls_root: Path) -> dict | None:

--- a/home/dot_local/share/dots/themes/catppuccin-latte/theme.json
+++ b/home/dot_local/share/dots/themes/catppuccin-latte/theme.json
@@ -3,11 +3,16 @@
   "id": "catppuccin-latte",
   "name": "Catppuccin Latte",
   "description": "Light Catppuccin mauve for soft daytime sessions",
-  "tags": ["catppuccin", "pastel", "light"],
+  "tags": [
+    "catppuccin",
+    "pastel",
+    "light"
+  ],
   "darkMode": false,
   "schemeType": "tonal-spot",
-  "gtkTheme": "catppuccin-latte-mauve-compact",
+  "gtkTheme": "Orchis-Light-Compact",
   "iconTheme": "Papirus",
   "defaultWallpaper": "catppuccin-latte-01.png",
-  "wallpaperDir": "catppuccin-latte"
+  "wallpaperDir": "catppuccin-latte",
+  "gtkPreferDark": false
 }

--- a/home/dot_local/share/dots/themes/catppuccin-latte/theme.json
+++ b/home/dot_local/share/dots/themes/catppuccin-latte/theme.json
@@ -3,11 +3,7 @@
   "id": "catppuccin-latte",
   "name": "Catppuccin Latte",
   "description": "Light Catppuccin mauve for soft daytime sessions",
-  "tags": [
-    "catppuccin",
-    "pastel",
-    "light"
-  ],
+  "tags": ["catppuccin", "pastel", "light"],
   "darkMode": false,
   "schemeType": "tonal-spot",
   "gtkTheme": "Orchis-Light-Compact",

--- a/home/dot_local/share/dots/themes/catppuccin-mocha/theme.json
+++ b/home/dot_local/share/dots/themes/catppuccin-mocha/theme.json
@@ -3,11 +3,17 @@
   "id": "catppuccin-mocha",
   "name": "Catppuccin Mocha",
   "description": "Cozy dark Catppuccin with soft pastels",
-  "tags": ["catppuccin", "pastel", "cozy", "dark"],
+  "tags": [
+    "catppuccin",
+    "pastel",
+    "cozy",
+    "dark"
+  ],
   "darkMode": true,
   "schemeType": "tonal-spot",
-  "gtkTheme": "Orchis-Dark",
+  "gtkTheme": "Orchis-Light-Compact",
   "iconTheme": "Papirus-Dark",
   "defaultWallpaper": "catppuccin-mauve-02.png",
-  "wallpaperDir": "catppuccin-mocha"
+  "wallpaperDir": "catppuccin-mocha",
+  "gtkPreferDark": false
 }

--- a/home/dot_local/share/dots/themes/catppuccin-mocha/theme.json
+++ b/home/dot_local/share/dots/themes/catppuccin-mocha/theme.json
@@ -3,12 +3,7 @@
   "id": "catppuccin-mocha",
   "name": "Catppuccin Mocha",
   "description": "Cozy dark Catppuccin with soft pastels",
-  "tags": [
-    "catppuccin",
-    "pastel",
-    "cozy",
-    "dark"
-  ],
+  "tags": ["catppuccin", "pastel", "cozy", "dark"],
   "darkMode": true,
   "schemeType": "tonal-spot",
   "gtkTheme": "Orchis-Light-Compact",

--- a/home/dot_local/share/dots/themes/everforest/theme.json
+++ b/home/dot_local/share/dots/themes/everforest/theme.json
@@ -3,11 +3,17 @@
   "id": "everforest",
   "name": "Everforest",
   "description": "Soft green forest fidelity theme",
-  "tags": ["everforest", "nature", "green", "dark"],
+  "tags": [
+    "everforest",
+    "nature",
+    "green",
+    "dark"
+  ],
   "darkMode": true,
   "schemeType": "fidelity",
-  "gtkTheme": "Orchis-Dark",
+  "gtkTheme": "Orchis-Light-Compact",
   "iconTheme": "Numix-Circle",
   "defaultWallpaper": "everforest-deep-01.png",
-  "wallpaperDir": "everforest"
+  "wallpaperDir": "everforest",
+  "gtkPreferDark": false
 }

--- a/home/dot_local/share/dots/themes/everforest/theme.json
+++ b/home/dot_local/share/dots/themes/everforest/theme.json
@@ -3,12 +3,7 @@
   "id": "everforest",
   "name": "Everforest",
   "description": "Soft green forest fidelity theme",
-  "tags": [
-    "everforest",
-    "nature",
-    "green",
-    "dark"
-  ],
+  "tags": ["everforest", "nature", "green", "dark"],
   "darkMode": true,
   "schemeType": "fidelity",
   "gtkTheme": "Orchis-Light-Compact",

--- a/home/dot_local/share/dots/themes/gruvbox/theme.json
+++ b/home/dot_local/share/dots/themes/gruvbox/theme.json
@@ -3,13 +3,7 @@
   "id": "gruvbox",
   "name": "Gruvbox",
   "description": "Warm retro palette with anime and pixel art",
-  "tags": [
-    "gruvbox",
-    "warm",
-    "retro",
-    "anime",
-    "dark"
-  ],
+  "tags": ["gruvbox", "warm", "retro", "anime", "dark"],
   "darkMode": true,
   "schemeType": "expressive",
   "gtkTheme": "Orchis-Light-Compact",

--- a/home/dot_local/share/dots/themes/gruvbox/theme.json
+++ b/home/dot_local/share/dots/themes/gruvbox/theme.json
@@ -3,11 +3,18 @@
   "id": "gruvbox",
   "name": "Gruvbox",
   "description": "Warm retro palette with anime and pixel art",
-  "tags": ["gruvbox", "warm", "retro", "anime", "dark"],
+  "tags": [
+    "gruvbox",
+    "warm",
+    "retro",
+    "anime",
+    "dark"
+  ],
   "darkMode": true,
   "schemeType": "expressive",
-  "gtkTheme": "Orchis-Dark",
+  "gtkTheme": "Orchis-Light-Compact",
   "iconTheme": "Numix-Circle",
   "defaultWallpaper": "gruvbox-anime-01.jpg",
-  "wallpaperDir": "gruvbox"
+  "wallpaperDir": "gruvbox",
+  "gtkPreferDark": false
 }

--- a/home/dot_local/share/dots/themes/landscape/theme.json
+++ b/home/dot_local/share/dots/themes/landscape/theme.json
@@ -3,11 +3,17 @@
   "id": "landscape",
   "name": "Landscape",
   "description": "Cinematic nature vistas and fantasy scenery",
-  "tags": ["nature", "cinematic", "landscape", "dark"],
+  "tags": [
+    "nature",
+    "cinematic",
+    "landscape",
+    "dark"
+  ],
   "darkMode": true,
   "schemeType": "fidelity",
-  "gtkTheme": "Orchis-Dark",
+  "gtkTheme": "Orchis-Light-Compact",
   "iconTheme": "Numix-Circle",
   "defaultWallpaper": "landscape-01.jpg",
-  "wallpaperDir": "landscape"
+  "wallpaperDir": "landscape",
+  "gtkPreferDark": false
 }

--- a/home/dot_local/share/dots/themes/landscape/theme.json
+++ b/home/dot_local/share/dots/themes/landscape/theme.json
@@ -3,12 +3,7 @@
   "id": "landscape",
   "name": "Landscape",
   "description": "Cinematic nature vistas and fantasy scenery",
-  "tags": [
-    "nature",
-    "cinematic",
-    "landscape",
-    "dark"
-  ],
+  "tags": ["nature", "cinematic", "landscape", "dark"],
   "darkMode": true,
   "schemeType": "fidelity",
   "gtkTheme": "Orchis-Light-Compact",

--- a/home/dot_local/share/dots/themes/monochrome/theme.json
+++ b/home/dot_local/share/dots/themes/monochrome/theme.json
@@ -3,11 +3,17 @@
   "id": "monochrome",
   "name": "Monochrome",
   "description": "High-contrast black and white focus aesthetic",
-  "tags": ["monochrome", "minimal", "a11y", "dark"],
+  "tags": [
+    "monochrome",
+    "minimal",
+    "a11y",
+    "dark"
+  ],
   "darkMode": true,
   "schemeType": "monochrome",
   "gtkTheme": "Adwaita-dark",
   "iconTheme": "Papirus-Dark",
   "defaultWallpaper": "mono-curated-1.jpg",
-  "wallpaperDir": "monochrome"
+  "wallpaperDir": "monochrome",
+  "gtkPreferDark": true
 }

--- a/home/dot_local/share/dots/themes/monochrome/theme.json
+++ b/home/dot_local/share/dots/themes/monochrome/theme.json
@@ -3,12 +3,7 @@
   "id": "monochrome",
   "name": "Monochrome",
   "description": "High-contrast black and white focus aesthetic",
-  "tags": [
-    "monochrome",
-    "minimal",
-    "a11y",
-    "dark"
-  ],
+  "tags": ["monochrome", "minimal", "a11y", "dark"],
   "darkMode": true,
   "schemeType": "monochrome",
   "gtkTheme": "Adwaita-dark",

--- a/home/dot_local/share/dots/themes/neon-city/theme.json
+++ b/home/dot_local/share/dots/themes/neon-city/theme.json
@@ -3,11 +3,17 @@
   "id": "neon-city",
   "name": "Neon City",
   "description": "Cyberpunk neon nights and futuristic streets",
-  "tags": ["cyberpunk", "neon", "dark", "city"],
+  "tags": [
+    "cyberpunk",
+    "neon",
+    "dark",
+    "city"
+  ],
   "darkMode": true,
   "schemeType": "vibrant",
-  "gtkTheme": "Orchis-Dark-Compact",
+  "gtkTheme": "Orchis-Light-Compact",
   "iconTheme": "Numix-Circle",
   "defaultWallpaper": "neon-city-01.jpg",
-  "wallpaperDir": "neon-city"
+  "wallpaperDir": "neon-city",
+  "gtkPreferDark": false
 }

--- a/home/dot_local/share/dots/themes/neon-city/theme.json
+++ b/home/dot_local/share/dots/themes/neon-city/theme.json
@@ -3,12 +3,7 @@
   "id": "neon-city",
   "name": "Neon City",
   "description": "Cyberpunk neon nights and futuristic streets",
-  "tags": [
-    "cyberpunk",
-    "neon",
-    "dark",
-    "city"
-  ],
+  "tags": ["cyberpunk", "neon", "dark", "city"],
   "darkMode": true,
   "schemeType": "vibrant",
   "gtkTheme": "Orchis-Light-Compact",

--- a/home/dot_local/share/dots/themes/nord-dreams/theme.json
+++ b/home/dot_local/share/dots/themes/nord-dreams/theme.json
@@ -3,12 +3,7 @@
   "id": "nord-dreams",
   "name": "Nord Dreams",
   "description": "Cool arctic Nord tones and frosty calm",
-  "tags": [
-    "nord",
-    "cool",
-    "minimal",
-    "dark"
-  ],
+  "tags": ["nord", "cool", "minimal", "dark"],
   "darkMode": true,
   "schemeType": "tonal-spot",
   "gtkTheme": "Orchis-Light-Compact",

--- a/home/dot_local/share/dots/themes/nord-dreams/theme.json
+++ b/home/dot_local/share/dots/themes/nord-dreams/theme.json
@@ -3,11 +3,17 @@
   "id": "nord-dreams",
   "name": "Nord Dreams",
   "description": "Cool arctic Nord tones and frosty calm",
-  "tags": ["nord", "cool", "minimal", "dark"],
+  "tags": [
+    "nord",
+    "cool",
+    "minimal",
+    "dark"
+  ],
   "darkMode": true,
   "schemeType": "tonal-spot",
-  "gtkTheme": "Orchis-Dark-Compact",
+  "gtkTheme": "Orchis-Light-Compact",
   "iconTheme": "Numix-Circle",
   "defaultWallpaper": "nord-aurora-01.png",
-  "wallpaperDir": "nord-dreams"
+  "wallpaperDir": "nord-dreams",
+  "gtkPreferDark": false
 }

--- a/home/dot_local/share/dots/themes/rose-pine/theme.json
+++ b/home/dot_local/share/dots/themes/rose-pine/theme.json
@@ -3,11 +3,16 @@
   "id": "rose-pine",
   "name": "Ros\u00e9 Pine",
   "description": "Elegant muted rose and pine dark palette",
-  "tags": ["rose-pine", "muted", "dark"],
+  "tags": [
+    "rose-pine",
+    "muted",
+    "dark"
+  ],
   "darkMode": true,
   "schemeType": "expressive",
-  "gtkTheme": "Orchis-Dark",
+  "gtkTheme": "Orchis-Light-Compact",
   "iconTheme": "Numix-Circle",
   "defaultWallpaper": "rose-pine-dawn-01.png",
-  "wallpaperDir": "rose-pine"
+  "wallpaperDir": "rose-pine",
+  "gtkPreferDark": false
 }

--- a/home/dot_local/share/dots/themes/rose-pine/theme.json
+++ b/home/dot_local/share/dots/themes/rose-pine/theme.json
@@ -3,11 +3,7 @@
   "id": "rose-pine",
   "name": "Ros\u00e9 Pine",
   "description": "Elegant muted rose and pine dark palette",
-  "tags": [
-    "rose-pine",
-    "muted",
-    "dark"
-  ],
+  "tags": ["rose-pine", "muted", "dark"],
   "darkMode": true,
   "schemeType": "expressive",
   "gtkTheme": "Orchis-Light-Compact",

--- a/home/dot_local/share/dots/themes/soft-morning/theme.json
+++ b/home/dot_local/share/dots/themes/soft-morning/theme.json
@@ -3,12 +3,7 @@
   "id": "soft-morning",
   "name": "Soft Morning",
   "description": "Calm mist, florals, and soft natural light",
-  "tags": [
-    "morning",
-    "calm",
-    "pastel",
-    "light"
-  ],
+  "tags": ["morning", "calm", "pastel", "light"],
   "darkMode": false,
   "schemeType": "neutral",
   "gtkTheme": "Orchis-Light-Compact",

--- a/home/dot_local/share/dots/themes/soft-morning/theme.json
+++ b/home/dot_local/share/dots/themes/soft-morning/theme.json
@@ -3,11 +3,17 @@
   "id": "soft-morning",
   "name": "Soft Morning",
   "description": "Calm mist, florals, and soft natural light",
-  "tags": ["morning", "calm", "pastel", "light"],
+  "tags": [
+    "morning",
+    "calm",
+    "pastel",
+    "light"
+  ],
   "darkMode": false,
   "schemeType": "neutral",
-  "gtkTheme": "Orchis-Light",
+  "gtkTheme": "Orchis-Light-Compact",
   "iconTheme": "Numix-Circle",
   "defaultWallpaper": "morning-lake-2.jpg",
-  "wallpaperDir": "soft-morning"
+  "wallpaperDir": "soft-morning",
+  "gtkPreferDark": false
 }

--- a/home/dot_local/share/dots/themes/vapor-dreams/theme.json
+++ b/home/dot_local/share/dots/themes/vapor-dreams/theme.json
@@ -3,11 +3,17 @@
   "id": "vapor-dreams",
   "name": "Vapor Dreams",
   "description": "Nostalgic 80s/90s vaporwave with retro gradients",
-  "tags": ["vaporwave", "retro", "synthwave", "dark"],
+  "tags": [
+    "vaporwave",
+    "retro",
+    "synthwave",
+    "dark"
+  ],
   "darkMode": true,
   "schemeType": "expressive",
-  "gtkTheme": "Orchis-Dark",
+  "gtkTheme": "Orchis-Light-Compact",
   "iconTheme": "Numix-Circle",
   "defaultWallpaper": "vapor-dreams-01.jpg",
-  "wallpaperDir": "vapor-dreams"
+  "wallpaperDir": "vapor-dreams",
+  "gtkPreferDark": false
 }

--- a/home/dot_local/share/dots/themes/vapor-dreams/theme.json
+++ b/home/dot_local/share/dots/themes/vapor-dreams/theme.json
@@ -3,12 +3,7 @@
   "id": "vapor-dreams",
   "name": "Vapor Dreams",
   "description": "Nostalgic 80s/90s vaporwave with retro gradients",
-  "tags": [
-    "vaporwave",
-    "retro",
-    "synthwave",
-    "dark"
-  ],
+  "tags": ["vaporwave", "retro", "synthwave", "dark"],
   "darkMode": true,
   "schemeType": "expressive",
   "gtkTheme": "Orchis-Light-Compact",

--- a/home/dot_local/share/dots/themes/warm-sunset/theme.json
+++ b/home/dot_local/share/dots/themes/warm-sunset/theme.json
@@ -3,11 +3,17 @@
   "id": "warm-sunset",
   "name": "Warm Sunset",
   "description": "Golden-hour landscapes with warm cinematic tones",
-  "tags": ["sunset", "warm", "cinematic", "light"],
+  "tags": [
+    "sunset",
+    "warm",
+    "cinematic",
+    "light"
+  ],
   "darkMode": false,
   "schemeType": "vibrant",
-  "gtkTheme": "Orchis-Light",
+  "gtkTheme": "Orchis-Light-Compact",
   "iconTheme": "Numix-Circle",
   "defaultWallpaper": "warm-sunset-05.jpg",
-  "wallpaperDir": "warm-sunset"
+  "wallpaperDir": "warm-sunset",
+  "gtkPreferDark": false
 }

--- a/home/dot_local/share/dots/themes/warm-sunset/theme.json
+++ b/home/dot_local/share/dots/themes/warm-sunset/theme.json
@@ -3,12 +3,7 @@
   "id": "warm-sunset",
   "name": "Warm Sunset",
   "description": "Golden-hour landscapes with warm cinematic tones",
-  "tags": [
-    "sunset",
-    "warm",
-    "cinematic",
-    "light"
-  ],
+  "tags": ["sunset", "warm", "cinematic", "light"],
   "darkMode": false,
   "schemeType": "vibrant",
   "gtkTheme": "Orchis-Light-Compact",

--- a/scripts/migrate-rices-to-themes.py
+++ b/scripts/migrate-rices-to-themes.py
@@ -45,7 +45,7 @@ THEME_META: dict[str, dict] = {
         "tags": ["vaporwave", "retro", "synthwave", "dark"],
         "darkMode": True,
         "schemeType": "expressive",
-        "gtkTheme": "Orchis-Dark",
+        "gtkTheme": "Orchis-Light-Compact",
         "iconTheme": "Numix-Circle",
     },
     "neon-city": {
@@ -54,7 +54,7 @@ THEME_META: dict[str, dict] = {
         "tags": ["cyberpunk", "neon", "dark", "city"],
         "darkMode": True,
         "schemeType": "vibrant",
-        "gtkTheme": "Orchis-Dark-Compact",
+        "gtkTheme": "Orchis-Light-Compact",
         "iconTheme": "Numix-Circle",
     },
     "gruvbox": {
@@ -63,7 +63,7 @@ THEME_META: dict[str, dict] = {
         "tags": ["gruvbox", "warm", "retro", "anime", "dark"],
         "darkMode": True,
         "schemeType": "expressive",
-        "gtkTheme": "Orchis-Dark",
+        "gtkTheme": "Orchis-Light-Compact",
         "iconTheme": "Numix-Circle",
     },
     "landscape": {
@@ -72,7 +72,7 @@ THEME_META: dict[str, dict] = {
         "tags": ["nature", "cinematic", "landscape", "dark"],
         "darkMode": True,
         "schemeType": "fidelity",
-        "gtkTheme": "Orchis-Dark",
+        "gtkTheme": "Orchis-Light-Compact",
         "iconTheme": "Numix-Circle",
     },
     "warm-sunset": {
@@ -81,7 +81,7 @@ THEME_META: dict[str, dict] = {
         "tags": ["sunset", "warm", "cinematic", "light"],
         "darkMode": False,
         "schemeType": "vibrant",
-        "gtkTheme": "Orchis-Light",
+        "gtkTheme": "Orchis-Light-Compact",
         "iconTheme": "Numix-Circle",
     },
     "soft-morning": {
@@ -90,7 +90,7 @@ THEME_META: dict[str, dict] = {
         "tags": ["morning", "calm", "pastel", "light"],
         "darkMode": False,
         "schemeType": "neutral",
-        "gtkTheme": "Orchis-Light",
+        "gtkTheme": "Orchis-Light-Compact",
         "iconTheme": "Numix-Circle",
     },
     "catppuccin-mocha": {
@@ -99,7 +99,7 @@ THEME_META: dict[str, dict] = {
         "tags": ["catppuccin", "pastel", "cozy", "dark"],
         "darkMode": True,
         "schemeType": "tonal-spot",
-        "gtkTheme": "Orchis-Dark",
+        "gtkTheme": "Orchis-Light-Compact",
         "iconTheme": "Papirus-Dark",
     },
     "catppuccin-latte": {
@@ -108,7 +108,7 @@ THEME_META: dict[str, dict] = {
         "tags": ["catppuccin", "pastel", "light"],
         "darkMode": False,
         "schemeType": "tonal-spot",
-        "gtkTheme": "catppuccin-latte-mauve-compact",
+        "gtkTheme": "Orchis-Light-Compact",
         "iconTheme": "Papirus",
     },
     "rose-pine": {
@@ -117,7 +117,7 @@ THEME_META: dict[str, dict] = {
         "tags": ["rose-pine", "muted", "dark"],
         "darkMode": True,
         "schemeType": "expressive",
-        "gtkTheme": "Orchis-Dark",
+        "gtkTheme": "Orchis-Light-Compact",
         "iconTheme": "Numix-Circle",
     },
     "nord-dreams": {
@@ -126,7 +126,7 @@ THEME_META: dict[str, dict] = {
         "tags": ["nord", "cool", "minimal", "dark"],
         "darkMode": True,
         "schemeType": "tonal-spot",
-        "gtkTheme": "Orchis-Dark-Compact",
+        "gtkTheme": "Orchis-Light-Compact",
         "iconTheme": "Numix-Circle",
     },
     "everforest": {
@@ -135,7 +135,7 @@ THEME_META: dict[str, dict] = {
         "tags": ["everforest", "nature", "green", "dark"],
         "darkMode": True,
         "schemeType": "fidelity",
-        "gtkTheme": "Orchis-Dark",
+        "gtkTheme": "Orchis-Light-Compact",
         "iconTheme": "Numix-Circle",
     },
     "monochrome": {

--- a/scripts/test-appearance-consistency.sh
+++ b/scripts/test-appearance-consistency.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Appearance system consistency tests (theme packs + GTK + wal contract).
+# Copyright (C) 2019-2026 Ulises Jeremias Cornejo Fandos
+# Licensed under MIT.
+#
+# Usage:
+#   ./scripts/test-appearance-consistency.sh           # live ($HOME)
+#   ./scripts/test-appearance-consistency.sh --source  # validate repo tree only
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SOURCE_ONLY=false
+[[ ${1:-} == "--source" ]] && SOURCE_ONLY=true
+
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() {
+  PASS=$((PASS + 1))
+  printf '  PASS  %s\n' "$*"
+}
+fail() {
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n' "$*" >&2
+}
+skip() {
+  SKIP=$((SKIP + 1))
+  printf '  SKIP  %s\n' "$*"
+}
+
+echo "== appearance consistency =="
+
+# ── Source tree ──────────────────────────────────────────────────────────────
+THEMES_SRC="${ROOT}/home/dot_local/share/dots/themes"
+LIST_THEMES="${ROOT}/home/dot_local/lib/dots/list-themes.py"
+GTK_MGR="${ROOT}/home/dot_local/lib/dots/gtk-theme-manager.sh"
+GTK_BIN="${ROOT}/home/dot_local/bin/executable_dots-gtk-theme"
+QS_PIPE="${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml"
+
+[[ -d $THEMES_SRC ]] || {
+  echo "missing themes dir: $THEMES_SRC" >&2
+  exit 1
+}
+
+theme_count=0
+for theme_json in "$THEMES_SRC"/*/theme.json; do
+  [[ -f $theme_json ]] || continue
+  theme_count=$((theme_count + 1))
+  dir="$(dirname "$theme_json")"
+  id="$(basename "$dir")"
+  if python3 - "$theme_json" "$id" <<'PY'; then
+import json, sys
+path, expected = sys.argv[1], sys.argv[2]
+data = json.load(open(path, encoding="utf-8"))
+required = ("schemaVersion", "id", "name", "darkMode", "schemeType", "gtkTheme", "iconTheme", "defaultWallpaper", "wallpaperDir")
+missing = [k for k in required if k not in data]
+if missing:
+    raise SystemExit(f"missing keys {missing}")
+if data.get("id") != expected:
+    raise SystemExit(f"id mismatch: {data.get('id')!r} != {expected!r}")
+if not isinstance(data.get("tags", []), list):
+    raise SystemExit("tags must be a list")
+PY
+    pass "theme.json valid: $id"
+  else
+    fail "theme.json invalid: $id"
+  fi
+  if [[ -f $dir/preview.jpg || -f $dir/preview.png || -f $dir/preview.webp ]]; then
+    pass "preview asset: $id"
+  else
+    fail "missing preview for $id"
+  fi
+done
+[[ $theme_count -ge 1 ]] && pass "found $theme_count theme packs" || fail "no theme packs"
+
+if [[ -f $LIST_THEMES ]]; then
+  if DOTS_THEMES_DIR="$THEMES_SRC" DOTS_WALLPAPERS_DIR="${ROOT}/home/dot_local/share/dots/wallpapers" \
+    python3 "$LIST_THEMES" "$THEMES_SRC" >/tmp/dots-themes-test.json 2>/tmp/dots-themes-test.err; then
+    if python3 - <<'PY'; then
+import json
+data = json.load(open("/tmp/dots-themes-test.json", encoding="utf-8"))
+assert isinstance(data, list) and data, "empty theme list"
+for t in data:
+    assert "wallpaperPaths" in t, f"{t.get('id')}: missing wallpaperPaths"
+    assert isinstance(t["wallpaperPaths"], dict)
+    for name in t.get("wallpapers", []):
+        assert name in t["wallpaperPaths"], f"{t.get('id')}: {name} missing from wallpaperPaths"
+print("ok", len(data))
+PY
+      pass "list-themes.py JSON + wallpaperPaths"
+    else
+      fail "list-themes.py schema check"
+    fi
+  else
+    fail "list-themes.py failed: $(head -c 200 /tmp/dots-themes-test.err)"
+  fi
+else
+  fail "list-themes.py missing"
+fi
+
+# No stale rice IPC / sticky current writers in QS appearance path
+if rg -n 'target:\s*"rice"|IpcHandler.*rice|dots-rice|nwg-look' "$QS_PIPE" \
+  "${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance" 2>/dev/null; then
+  fail "stale rice/nwg-look references in appearance QS"
+else
+  pass "no stale rice IPC in appearance QS"
+fi
+
+if rg -n 'gsettings set org.gnome.desktop.interface (gtk-theme|icon-theme)' \
+  "${ROOT}/home/dot_config/quickshell" 2>/dev/null; then
+  fail "raw gsettings GTK/icon writes in Quickshell"
+else
+  pass "Quickshell does not write GTK/icons via gsettings"
+fi
+
+if rg -n 'gtk-theme-manager\.sh' "${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml" 2>/dev/null; then
+  fail "ThemePipeline still sources gtk-theme-manager.sh"
+else
+  pass "ThemePipeline uses dots-gtk-theme CLI"
+fi
+
+if rg -n 'readlink -f "\$HOME/\.cache/wal/wal"|readlink -f \$HOME/\.cache/wal/wal' \
+  "$GTK_MGR" "$GTK_BIN" "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" 2>/dev/null; then
+  fail "unsafe readlink on wal text pointer"
+else
+  pass "no unsafe wal readlink in GTK apply path"
+fi
+
+[[ $SOURCE_ONLY == true ]] && {
+  echo
+  echo "Results: $PASS pass, $FAIL fail, $SKIP skip (source-only)"
+  [[ $FAIL -eq 0 ]]
+  exit $?
+}
+
+# ── Live environment ─────────────────────────────────────────────────────────
+if ! command -v dots-gtk-theme >/dev/null 2>&1; then
+  skip "dots-gtk-theme not on PATH (live checks)"
+else
+  if out="$(dots-gtk-theme -q -p current 2>/dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
+    pass "dots-gtk-theme current: $out"
+  else
+    fail "dots-gtk-theme current"
+  fi
+  if out="$(dots-gtk-theme -q -p current-icon 2>/dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
+    pass "dots-gtk-theme current-icon: $out"
+  else
+    fail "dots-gtk-theme current-icon"
+  fi
+  if mapfile -t themes < <(dots-gtk-theme -q -p list 2>/dev/null); then
+    [[ ${#themes[@]} -gt 0 ]] && pass "dots-gtk-theme list (${#themes[@]} themes)" || fail "dots-gtk-theme list empty"
+  else
+    fail "dots-gtk-theme list"
+  fi
+fi
+
+if command -v dots-appearance >/dev/null 2>&1; then
+  if dots appearance doctor >/tmp/dots-appearance-doctor.txt 2>&1; then
+    if grep -q '^OK:' /tmp/dots-appearance-doctor.txt; then
+      pass "dots appearance doctor OK"
+    else
+      fail "dots appearance doctor missing OK"
+      cat /tmp/dots-appearance-doctor.txt >&2 || true
+    fi
+  else
+    fail "dots appearance doctor exited nonzero"
+    cat /tmp/dots-appearance-doctor.txt >&2 || true
+  fi
+else
+  skip "dots-appearance not on PATH"
+fi
+
+wal="$HOME/.cache/wal/wal"
+if [[ -L $wal ]]; then
+  fail "$HOME/.cache/wal/wal is a symlink (must be text path file)"
+elif [[ -f $wal ]]; then
+  line="$(head -n 1 "$wal" | tr -d '\r')"
+  if [[ -f $line ]]; then
+    pass "wal pointer is text path -> image"
+  else
+    fail "wal pointer does not resolve to an image: $line"
+  fi
+else
+  skip "wal pointer missing"
+fi
+
+echo
+echo "Results: $PASS pass, $FAIL fail, $SKIP skip"
+[[ $FAIL -eq 0 ]]

--- a/scripts/test-appearance-consistency.sh
+++ b/scripts/test-appearance-consistency.sh
@@ -67,7 +67,7 @@ PY
     for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
       jq -e --arg k "$key" 'has($k)' "$theme_json" >/dev/null || return 1
     done
-    jq -e '.tags == null or (type == "array")' "$theme_json" >/dev/null || return 1
+    jq -e '(.tags == null) or ((.tags | type) == "array")' "$theme_json" >/dev/null || return 1
     return 0
   fi
 

--- a/scripts/test-appearance-consistency.sh
+++ b/scripts/test-appearance-consistency.sh
@@ -110,7 +110,11 @@ for theme_json in "$THEMES_SRC"/*/theme.json; do
     fail "missing preview for $id"
   fi
 done
-[[ $theme_count -ge 1 ]] && pass "found $theme_count theme packs" || fail "no theme packs"
+if [[ $theme_count -ge 1 ]]; then
+  pass "found $theme_count theme packs"
+else
+  fail "no theme packs"
+fi
 
 if [[ -f $LIST_THEMES ]]; then
   if [[ -z $PYTHON_BIN ]]; then
@@ -160,6 +164,8 @@ else
   pass "ThemePipeline uses dots-gtk-theme CLI"
 fi
 
+# Intentional: match the literal shell source pattern containing $HOME.
+# shellcheck disable=SC2016
 if grep -En 'readlink -f "\$HOME/\.cache/wal/wal"|readlink -f \$HOME/\.cache/wal/wal' \
   "$GTK_MGR" "$GTK_BIN" "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" >/dev/null 2>&1; then
   fail "unsafe readlink on wal text pointer"
@@ -189,7 +195,11 @@ else
     fail "dots-gtk-theme current-icon"
   fi
   if mapfile -t themes < <(dots-gtk-theme -q -p list 2>/dev/null); then
-    [[ ${#themes[@]} -gt 0 ]] && pass "dots-gtk-theme list (${#themes[@]} themes)" || fail "dots-gtk-theme list empty"
+    if [[ ${#themes[@]} -gt 0 ]]; then
+      pass "dots-gtk-theme list (${#themes[@]} themes)"
+    else
+      fail "dots-gtk-theme list empty"
+    fi
   else
     fail "dots-gtk-theme list"
   fi

--- a/scripts/test-appearance-consistency.sh
+++ b/scripts/test-appearance-consistency.sh
@@ -19,32 +19,32 @@ FAIL=0
 SKIP=0
 
 pass() {
-  PASS=$((PASS + 1))
-  printf '  PASS  %s\n' "$*"
+	PASS=$((PASS + 1))
+	printf '  PASS  %s\n' "$*"
 }
 fail() {
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  %s\n' "$*" >&2
+	FAIL=$((FAIL + 1))
+	printf '  FAIL  %s\n' "$*" >&2
 }
 skip() {
-  SKIP=$((SKIP + 1))
-  printf '  SKIP  %s\n' "$*"
+	SKIP=$((SKIP + 1))
+	printf '  SKIP  %s\n' "$*"
 }
 
 PYTHON_BIN=""
-if command -v python3 >/dev/null 2>&1; then
-  PYTHON_BIN="$(command -v python3)"
-elif command -v python >/dev/null 2>&1; then
-  PYTHON_BIN="$(command -v python)"
+if command -v python3 > /dev/null 2>&1; then
+	PYTHON_BIN="$(command -v python3)"
+elif command -v python > /dev/null 2>&1; then
+	PYTHON_BIN="$(command -v python)"
 fi
 
 validate_theme_json() {
-  local theme_json="$1"
-  local expected_id="$2"
-  local key
+	local theme_json="$1"
+	local expected_id="$2"
+	local key
 
-  if [[ -n $PYTHON_BIN ]]; then
-    "$PYTHON_BIN" - "$theme_json" "$expected_id" <<'PY'
+	if [[ -n $PYTHON_BIN ]]; then
+		"$PYTHON_BIN" - "$theme_json" "$expected_id" << 'PY'
 import json, sys
 path, expected = sys.argv[1], sys.argv[2]
 data = json.load(open(path, encoding="utf-8"))
@@ -57,26 +57,26 @@ if data.get("id") != expected:
 if not isinstance(data.get("tags", []), list):
     raise SystemExit("tags must be a list")
 PY
-    return $?
-  fi
+		return $?
+	fi
 
-  if command -v jq >/dev/null 2>&1; then
-    local id_val
-    id_val="$(jq -r '.id // empty' "$theme_json")"
-    [[ $id_val == "$expected_id" ]] || return 1
-    for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
-      jq -e --arg k "$key" 'has($k)' "$theme_json" >/dev/null || return 1
-    done
-    jq -e '(.tags == null) or ((.tags | type) == "array")' "$theme_json" >/dev/null || return 1
-    return 0
-  fi
+	if command -v jq > /dev/null 2>&1; then
+		local id_val
+		id_val="$(jq -r '.id // empty' "$theme_json")"
+		[[ $id_val == "$expected_id" ]] || return 1
+		for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
+			jq -e --arg k "$key" 'has($k)' "$theme_json" > /dev/null || return 1
+		done
+		jq -e '(.tags == null) or ((.tags | type) == "array")' "$theme_json" > /dev/null || return 1
+		return 0
+	fi
 
-  # Minimal grep fallback for CI images without Python/jq.
-  for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
-    grep -q "\"$key\"" "$theme_json" || return 1
-  done
-  grep -Eq "\"id\"[[:space:]]*:[[:space:]]*\"${expected_id}\"" "$theme_json" || return 1
-  return 0
+	# Minimal grep fallback for CI images without Python/jq.
+	for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
+		grep -q "\"$key\"" "$theme_json" || return 1
+	done
+	grep -Eq "\"id\"[[:space:]]*:[[:space:]]*\"${expected_id}\"" "$theme_json" || return 1
+	return 0
 }
 
 echo "== appearance consistency =="
@@ -89,39 +89,39 @@ GTK_BIN="${ROOT}/home/dot_local/bin/executable_dots-gtk-theme"
 QS_PIPE="${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml"
 
 [[ -d $THEMES_SRC ]] || {
-  echo "missing themes dir: $THEMES_SRC" >&2
-  exit 1
+	echo "missing themes dir: $THEMES_SRC" >&2
+	exit 1
 }
 
 theme_count=0
 for theme_json in "$THEMES_SRC"/*/theme.json; do
-  [[ -f $theme_json ]] || continue
-  theme_count=$((theme_count + 1))
-  dir="$(dirname "$theme_json")"
-  id="$(basename "$dir")"
-  if validate_theme_json "$theme_json" "$id"; then
-    pass "theme.json valid: $id"
-  else
-    fail "theme.json invalid: $id"
-  fi
-  if [[ -f $dir/preview.jpg || -f $dir/preview.png || -f $dir/preview.webp ]]; then
-    pass "preview asset: $id"
-  else
-    fail "missing preview for $id"
-  fi
+	[[ -f $theme_json ]] || continue
+	theme_count=$((theme_count + 1))
+	dir="$(dirname "$theme_json")"
+	id="$(basename "$dir")"
+	if validate_theme_json "$theme_json" "$id"; then
+		pass "theme.json valid: $id"
+	else
+		fail "theme.json invalid: $id"
+	fi
+	if [[ -f $dir/preview.jpg || -f $dir/preview.png || -f $dir/preview.webp ]]; then
+		pass "preview asset: $id"
+	else
+		fail "missing preview for $id"
+	fi
 done
 if [[ $theme_count -ge 1 ]]; then
-  pass "found $theme_count theme packs"
+	pass "found $theme_count theme packs"
 else
-  fail "no theme packs"
+	fail "no theme packs"
 fi
 
 if [[ -f $LIST_THEMES ]]; then
-  if [[ -z $PYTHON_BIN ]]; then
-    skip "list-themes.py check (python not available)"
-  elif DOTS_THEMES_DIR="$THEMES_SRC" DOTS_WALLPAPERS_DIR="${ROOT}/home/dot_local/share/dots/wallpapers" \
-    "$PYTHON_BIN" "$LIST_THEMES" "$THEMES_SRC" >/tmp/dots-themes-test.json 2>/tmp/dots-themes-test.err; then
-    if "$PYTHON_BIN" - <<'PY'; then
+	if [[ -z $PYTHON_BIN ]]; then
+		skip "list-themes.py check (python not available)"
+	elif DOTS_THEMES_DIR="$THEMES_SRC" DOTS_WALLPAPERS_DIR="${ROOT}/home/dot_local/share/dots/wallpapers" \
+		"$PYTHON_BIN" "$LIST_THEMES" "$THEMES_SRC" > /tmp/dots-themes-test.json 2> /tmp/dots-themes-test.err; then
+		if "$PYTHON_BIN" - << 'PY'; then
 import json
 data = json.load(open("/tmp/dots-themes-test.json", encoding="utf-8"))
 assert isinstance(data, list) and data, "empty theme list"
@@ -132,107 +132,107 @@ for t in data:
         assert name in t["wallpaperPaths"], f"{t.get('id')}: {name} missing from wallpaperPaths"
 print("ok", len(data))
 PY
-      pass "list-themes.py JSON + wallpaperPaths"
-    else
-      fail "list-themes.py schema check"
-    fi
-  else
-    fail "list-themes.py failed: $(head -c 200 /tmp/dots-themes-test.err 2>/dev/null || true)"
-  fi
+			pass "list-themes.py JSON + wallpaperPaths"
+		else
+			fail "list-themes.py schema check"
+		fi
+	else
+		fail "list-themes.py failed: $(head -c 200 /tmp/dots-themes-test.err 2> /dev/null || true)"
+	fi
 else
-  fail "list-themes.py missing"
+	fail "list-themes.py missing"
 fi
 
 # No stale rice IPC / sticky current writers in QS appearance path
 if grep -REn 'target:[[:space:]]*"rice"|IpcHandler.*rice|dots-rice|nwg-look' "$QS_PIPE" \
-  "${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance" >/dev/null 2>&1; then
-  fail "stale rice/nwg-look references in appearance QS"
+	"${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance" > /dev/null 2>&1; then
+	fail "stale rice/nwg-look references in appearance QS"
 else
-  pass "no stale rice IPC in appearance QS"
+	pass "no stale rice IPC in appearance QS"
 fi
 
 if grep -REn 'gsettings set org\.gnome\.desktop\.interface (gtk-theme|icon-theme)' \
-  "${ROOT}/home/dot_config/quickshell" >/dev/null 2>&1; then
-  fail "raw gsettings GTK/icon writes in Quickshell"
+	"${ROOT}/home/dot_config/quickshell" > /dev/null 2>&1; then
+	fail "raw gsettings GTK/icon writes in Quickshell"
 else
-  pass "Quickshell does not write GTK/icons via gsettings"
+	pass "Quickshell does not write GTK/icons via gsettings"
 fi
 
-if grep -En 'gtk-theme-manager\.sh' "${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml" >/dev/null 2>&1; then
-  fail "ThemePipeline still sources gtk-theme-manager.sh"
+if grep -En 'gtk-theme-manager\.sh' "${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml" > /dev/null 2>&1; then
+	fail "ThemePipeline still sources gtk-theme-manager.sh"
 else
-  pass "ThemePipeline uses dots-gtk-theme CLI"
+	pass "ThemePipeline uses dots-gtk-theme CLI"
 fi
 
 # Intentional: match the literal shell source pattern containing $HOME.
 # shellcheck disable=SC2016
 if grep -En 'readlink -f "\$HOME/\.cache/wal/wal"|readlink -f \$HOME/\.cache/wal/wal' \
-  "$GTK_MGR" "$GTK_BIN" "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" >/dev/null 2>&1; then
-  fail "unsafe readlink on wal text pointer"
+	"$GTK_MGR" "$GTK_BIN" "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" > /dev/null 2>&1; then
+	fail "unsafe readlink on wal text pointer"
 else
-  pass "no unsafe wal readlink in GTK apply path"
+	pass "no unsafe wal readlink in GTK apply path"
 fi
 
 [[ $SOURCE_ONLY == true ]] && {
-  echo
-  echo "Results: $PASS pass, $FAIL fail, $SKIP skip (source-only)"
-  [[ $FAIL -eq 0 ]]
-  exit $?
+	echo
+	echo "Results: $PASS pass, $FAIL fail, $SKIP skip (source-only)"
+	[[ $FAIL -eq 0 ]]
+	exit $?
 }
 
 # ── Live environment ─────────────────────────────────────────────────────────
-if ! command -v dots-gtk-theme >/dev/null 2>&1; then
-  skip "dots-gtk-theme not on PATH (live checks)"
+if ! command -v dots-gtk-theme > /dev/null 2>&1; then
+	skip "dots-gtk-theme not on PATH (live checks)"
 else
-  if out="$(dots-gtk-theme -q -p current 2>/dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
-    pass "dots-gtk-theme current: $out"
-  else
-    fail "dots-gtk-theme current"
-  fi
-  if out="$(dots-gtk-theme -q -p current-icon 2>/dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
-    pass "dots-gtk-theme current-icon: $out"
-  else
-    fail "dots-gtk-theme current-icon"
-  fi
-  if mapfile -t themes < <(dots-gtk-theme -q -p list 2>/dev/null); then
-    if [[ ${#themes[@]} -gt 0 ]]; then
-      pass "dots-gtk-theme list (${#themes[@]} themes)"
-    else
-      fail "dots-gtk-theme list empty"
-    fi
-  else
-    fail "dots-gtk-theme list"
-  fi
+	if out="$(dots-gtk-theme -q -p current 2> /dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
+		pass "dots-gtk-theme current: $out"
+	else
+		fail "dots-gtk-theme current"
+	fi
+	if out="$(dots-gtk-theme -q -p current-icon 2> /dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
+		pass "dots-gtk-theme current-icon: $out"
+	else
+		fail "dots-gtk-theme current-icon"
+	fi
+	if mapfile -t themes < <(dots-gtk-theme -q -p list 2> /dev/null); then
+		if [[ ${#themes[@]} -gt 0 ]]; then
+			pass "dots-gtk-theme list (${#themes[@]} themes)"
+		else
+			fail "dots-gtk-theme list empty"
+		fi
+	else
+		fail "dots-gtk-theme list"
+	fi
 fi
 
-if command -v dots-appearance >/dev/null 2>&1; then
-  if dots appearance doctor >/tmp/dots-appearance-doctor.txt 2>&1; then
-    if grep -q '^OK:' /tmp/dots-appearance-doctor.txt; then
-      pass "dots appearance doctor OK"
-    else
-      fail "dots appearance doctor missing OK"
-      cat /tmp/dots-appearance-doctor.txt >&2 || true
-    fi
-  else
-    fail "dots appearance doctor exited nonzero"
-    cat /tmp/dots-appearance-doctor.txt >&2 || true
-  fi
+if command -v dots-appearance > /dev/null 2>&1; then
+	if dots appearance doctor > /tmp/dots-appearance-doctor.txt 2>&1; then
+		if grep -q '^OK:' /tmp/dots-appearance-doctor.txt; then
+			pass "dots appearance doctor OK"
+		else
+			fail "dots appearance doctor missing OK"
+			cat /tmp/dots-appearance-doctor.txt >&2 || true
+		fi
+	else
+		fail "dots appearance doctor exited nonzero"
+		cat /tmp/dots-appearance-doctor.txt >&2 || true
+	fi
 else
-  skip "dots-appearance not on PATH"
+	skip "dots-appearance not on PATH"
 fi
 
 wal="$HOME/.cache/wal/wal"
 if [[ -L $wal ]]; then
-  fail "$HOME/.cache/wal/wal is a symlink (must be text path file)"
+	fail "$HOME/.cache/wal/wal is a symlink (must be text path file)"
 elif [[ -f $wal ]]; then
-  line="$(head -n 1 "$wal" | tr -d '\r')"
-  if [[ -f $line ]]; then
-    pass "wal pointer is text path -> image"
-  else
-    fail "wal pointer does not resolve to an image: $line"
-  fi
+	line="$(head -n 1 "$wal" | tr -d '\r')"
+	if [[ -f $line ]]; then
+		pass "wal pointer is text path -> image"
+	else
+		fail "wal pointer does not resolve to an image: $line"
+	fi
 else
-  skip "wal pointer missing"
+	skip "wal pointer missing"
 fi
 
 echo

--- a/scripts/test-appearance-consistency.sh
+++ b/scripts/test-appearance-consistency.sh
@@ -31,6 +31,54 @@ skip() {
   printf '  SKIP  %s\n' "$*"
 }
 
+PYTHON_BIN=""
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="$(command -v python3)"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN="$(command -v python)"
+fi
+
+validate_theme_json() {
+  local theme_json="$1"
+  local expected_id="$2"
+  local key
+
+  if [[ -n $PYTHON_BIN ]]; then
+    "$PYTHON_BIN" - "$theme_json" "$expected_id" <<'PY'
+import json, sys
+path, expected = sys.argv[1], sys.argv[2]
+data = json.load(open(path, encoding="utf-8"))
+required = ("schemaVersion", "id", "name", "darkMode", "schemeType", "gtkTheme", "iconTheme", "defaultWallpaper", "wallpaperDir")
+missing = [k for k in required if k not in data]
+if missing:
+    raise SystemExit(f"missing keys {missing}")
+if data.get("id") != expected:
+    raise SystemExit(f"id mismatch: {data.get('id')!r} != {expected!r}")
+if not isinstance(data.get("tags", []), list):
+    raise SystemExit("tags must be a list")
+PY
+    return $?
+  fi
+
+  if command -v jq >/dev/null 2>&1; then
+    local id_val
+    id_val="$(jq -r '.id // empty' "$theme_json")"
+    [[ $id_val == "$expected_id" ]] || return 1
+    for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
+      jq -e --arg k "$key" 'has($k)' "$theme_json" >/dev/null || return 1
+    done
+    jq -e '.tags == null or (type == "array")' "$theme_json" >/dev/null || return 1
+    return 0
+  fi
+
+  # Minimal grep fallback for CI images without Python/jq.
+  for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
+    grep -q "\"$key\"" "$theme_json" || return 1
+  done
+  grep -Eq "\"id\"[[:space:]]*:[[:space:]]*\"${expected_id}\"" "$theme_json" || return 1
+  return 0
+}
+
 echo "== appearance consistency =="
 
 # ── Source tree ──────────────────────────────────────────────────────────────
@@ -51,19 +99,7 @@ for theme_json in "$THEMES_SRC"/*/theme.json; do
   theme_count=$((theme_count + 1))
   dir="$(dirname "$theme_json")"
   id="$(basename "$dir")"
-  if python3 - "$theme_json" "$id" <<'PY'; then
-import json, sys
-path, expected = sys.argv[1], sys.argv[2]
-data = json.load(open(path, encoding="utf-8"))
-required = ("schemaVersion", "id", "name", "darkMode", "schemeType", "gtkTheme", "iconTheme", "defaultWallpaper", "wallpaperDir")
-missing = [k for k in required if k not in data]
-if missing:
-    raise SystemExit(f"missing keys {missing}")
-if data.get("id") != expected:
-    raise SystemExit(f"id mismatch: {data.get('id')!r} != {expected!r}")
-if not isinstance(data.get("tags", []), list):
-    raise SystemExit("tags must be a list")
-PY
+  if validate_theme_json "$theme_json" "$id"; then
     pass "theme.json valid: $id"
   else
     fail "theme.json invalid: $id"
@@ -77,9 +113,11 @@ done
 [[ $theme_count -ge 1 ]] && pass "found $theme_count theme packs" || fail "no theme packs"
 
 if [[ -f $LIST_THEMES ]]; then
-  if DOTS_THEMES_DIR="$THEMES_SRC" DOTS_WALLPAPERS_DIR="${ROOT}/home/dot_local/share/dots/wallpapers" \
-    python3 "$LIST_THEMES" "$THEMES_SRC" >/tmp/dots-themes-test.json 2>/tmp/dots-themes-test.err; then
-    if python3 - <<'PY'; then
+  if [[ -z $PYTHON_BIN ]]; then
+    skip "list-themes.py check (python not available)"
+  elif DOTS_THEMES_DIR="$THEMES_SRC" DOTS_WALLPAPERS_DIR="${ROOT}/home/dot_local/share/dots/wallpapers" \
+    "$PYTHON_BIN" "$LIST_THEMES" "$THEMES_SRC" >/tmp/dots-themes-test.json 2>/tmp/dots-themes-test.err; then
+    if "$PYTHON_BIN" - <<'PY'; then
 import json
 data = json.load(open("/tmp/dots-themes-test.json", encoding="utf-8"))
 assert isinstance(data, list) and data, "empty theme list"
@@ -95,35 +133,35 @@ PY
       fail "list-themes.py schema check"
     fi
   else
-    fail "list-themes.py failed: $(head -c 200 /tmp/dots-themes-test.err)"
+    fail "list-themes.py failed: $(head -c 200 /tmp/dots-themes-test.err 2>/dev/null || true)"
   fi
 else
   fail "list-themes.py missing"
 fi
 
 # No stale rice IPC / sticky current writers in QS appearance path
-if rg -n 'target:\s*"rice"|IpcHandler.*rice|dots-rice|nwg-look' "$QS_PIPE" \
-  "${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance" 2>/dev/null; then
+if grep -REn 'target:[[:space:]]*"rice"|IpcHandler.*rice|dots-rice|nwg-look' "$QS_PIPE" \
+  "${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance" >/dev/null 2>&1; then
   fail "stale rice/nwg-look references in appearance QS"
 else
   pass "no stale rice IPC in appearance QS"
 fi
 
-if rg -n 'gsettings set org.gnome.desktop.interface (gtk-theme|icon-theme)' \
-  "${ROOT}/home/dot_config/quickshell" 2>/dev/null; then
+if grep -REn 'gsettings set org\.gnome\.desktop\.interface (gtk-theme|icon-theme)' \
+  "${ROOT}/home/dot_config/quickshell" >/dev/null 2>&1; then
   fail "raw gsettings GTK/icon writes in Quickshell"
 else
   pass "Quickshell does not write GTK/icons via gsettings"
 fi
 
-if rg -n 'gtk-theme-manager\.sh' "${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml" 2>/dev/null; then
+if grep -En 'gtk-theme-manager\.sh' "${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml" >/dev/null 2>&1; then
   fail "ThemePipeline still sources gtk-theme-manager.sh"
 else
   pass "ThemePipeline uses dots-gtk-theme CLI"
 fi
 
-if rg -n 'readlink -f "\$HOME/\.cache/wal/wal"|readlink -f \$HOME/\.cache/wal/wal' \
-  "$GTK_MGR" "$GTK_BIN" "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" 2>/dev/null; then
+if grep -En 'readlink -f "\$HOME/\.cache/wal/wal"|readlink -f \$HOME/\.cache/wal/wal' \
+  "$GTK_MGR" "$GTK_BIN" "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" >/dev/null 2>&1; then
   fail "unsafe readlink on wal text pointer"
 else
   pass "no unsafe wal readlink in GTK apply path"

--- a/scripts/validate-dots-scripts.sh
+++ b/scripts/validate-dots-scripts.sh
@@ -15,8 +15,8 @@ ENTRYPOINT_SCRIPTS=(
 
 # Scripts to exclude from validation (third-party or special cases)
 EXCLUDED_SCRIPTS=(
-  "executable_dots-checkupdates"       # Third-party script from pacman-contrib
-  "executable_dots-git-notify"         # Third-party script with custom argument parsing
+  "executable_dots-checkupdates" # Third-party script from pacman-contrib
+  "executable_dots-git-notify"   # Third-party script with custom argument parsing
 )
 
 errors=0
@@ -107,6 +107,17 @@ if ! diff -q <(echo "$scripts_in_dir") <(echo "$scripts_in_list") >/dev/null; th
   comm -23 <(echo "$scripts_in_dir") <(echo "$scripts_in_list")
   echo "Scripts in list but not in directory:"
   comm -13 <(echo "$scripts_in_dir") <(echo "$scripts_in_list")
+  errors=$((errors + 1))
+fi
+
+# Appearance theme pack + GTK/wal contract (source tree)
+if [[ -x ${DOTFILES_ROOT}/scripts/test-appearance-consistency.sh ]]; then
+  if ! "${DOTFILES_ROOT}/scripts/test-appearance-consistency.sh" --source; then
+    echo "❌ Appearance consistency checks failed"
+    errors=$((errors + 1))
+  fi
+else
+  echo "⚠️  scripts/test-appearance-consistency.sh missing or not executable"
   errors=$((errors + 1))
 fi
 

--- a/scripts/validate-dots-scripts.sh
+++ b/scripts/validate-dots-scripts.sh
@@ -10,13 +10,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOTFILES_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 DOTS_BIN_DIR="${DOTFILES_ROOT}/home/dot_local/bin"
 ENTRYPOINT_SCRIPTS=(
-  "${DOTFILES_ROOT}/home/dot_local/bin/executable_dots"
+	"${DOTFILES_ROOT}/home/dot_local/bin/executable_dots"
 )
 
 # Scripts to exclude from validation (third-party or special cases)
 EXCLUDED_SCRIPTS=(
-  "executable_dots-checkupdates" # Third-party script from pacman-contrib
-  "executable_dots-git-notify"   # Third-party script with custom argument parsing
+	"executable_dots-checkupdates" # Third-party script from pacman-contrib
+	"executable_dots-git-notify"   # Third-party script with custom argument parsing
 )
 
 errors=0
@@ -25,106 +25,106 @@ echo "🔍 Validating dots scripts..."
 
 # Check if script should be excluded
 is_excluded() {
-  local script_name="$1"
-  for excluded in "${EXCLUDED_SCRIPTS[@]}"; do
-    if [[ $script_name == "$excluded" ]]; then
-      return 0
-    fi
-  done
-  return 1
+	local script_name="$1"
+	for excluded in "${EXCLUDED_SCRIPTS[@]}"; do
+		if [[ $script_name == "$excluded" ]]; then
+			return 0
+		fi
+	done
+	return 1
 }
 
 # Check if all scripts have proper headers
 for script in "${DOTS_BIN_DIR}"/executable_dots-*; do
-  if [[ -f $script ]]; then
-    script_name=$(basename "$script")
+	if [[ -f $script ]]; then
+		script_name=$(basename "$script")
 
-    # Skip excluded scripts
-    if is_excluded "$script_name"; then
-      continue
-    fi
+		# Skip excluded scripts
+		if is_excluded "$script_name"; then
+			continue
+		fi
 
-    # Check for copyright header
-    if ! head -n 10 "$script" | grep -q "Copyright"; then
-      echo "❌ Missing copyright header: $script_name"
-      errors=$((errors + 1))
-    fi
+		# Check for copyright header
+		if ! head -n 10 "$script" | grep -q "Copyright"; then
+			echo "❌ Missing copyright header: $script_name"
+			errors=$((errors + 1))
+		fi
 
-    # Check for license header
-    if ! head -n 15 "$script" | grep -q -E "(Licensed under MIT|GNU General Public License)"; then
-      echo "❌ Missing license header: $script_name"
-      errors=$((errors + 1))
-    fi
+		# Check for license header
+		if ! head -n 15 "$script" | grep -q -E "(Licensed under MIT|GNU General Public License)"; then
+			echo "❌ Missing license header: $script_name"
+			errors=$((errors + 1))
+		fi
 
-    # Check for set -euo pipefail (required for robustness)
-    if ! grep -q "^set -euo pipefail" "$script"; then
-      echo "❌ Missing 'set -euo pipefail': $script_name"
-      errors=$((errors + 1))
-    fi
+		# Check for set -euo pipefail (required for robustness)
+		if ! grep -q "^set -euo pipefail" "$script"; then
+			echo "❌ Missing 'set -euo pipefail': $script_name"
+			errors=$((errors + 1))
+		fi
 
-    # Check for easyoptions usage (warning only, not error for simple scripts)
-    # Skip check for scripts that don't need argument parsing
-    if ! grep -q "easyoptions.sh" "$script"; then
-      # Check if script has any argument parsing (getopt, case statements with $1, etc.)
-      if grep -qE "(getopt|case.*\$1|parse_cmd_args|usage\(\))" "$script"; then
-        echo "⚠️  Script has argument parsing but doesn't use easyoptions: $script_name"
-      fi
-    fi
+		# Check for easyoptions usage (warning only, not error for simple scripts)
+		# Skip check for scripts that don't need argument parsing
+		if ! grep -q "easyoptions.sh" "$script"; then
+			# Check if script has any argument parsing (getopt, case statements with $1, etc.)
+			if grep -qE "(getopt|case.*\$1|parse_cmd_args|usage\(\))" "$script"; then
+				echo "⚠️  Script has argument parsing but doesn't use easyoptions: $script_name"
+			fi
+		fi
 
-    # Note: Script executability is handled by chezmoi when applied
-    # No need to check executable bit in source directory
-  fi
+		# Note: Script executability is handled by chezmoi when applied
+		# No need to check executable bit in source directory
+	fi
 done
 
 # Validate critical entrypoint scripts (strict mode + EasyOptions)
 for script in "${ENTRYPOINT_SCRIPTS[@]}"; do
-  if [[ ! -f $script ]]; then
-    echo "❌ Missing critical entrypoint script: $script"
-    errors=$((errors + 1))
-    continue
-  fi
+	if [[ ! -f $script ]]; then
+		echo "❌ Missing critical entrypoint script: $script"
+		errors=$((errors + 1))
+		continue
+	fi
 
-  script_name=$(basename "$script")
+	script_name=$(basename "$script")
 
-  if ! grep -q "^set -euo pipefail" "$script"; then
-    echo "❌ Missing 'set -euo pipefail' in entrypoint: $script_name"
-    errors=$((errors + 1))
-  fi
+	if ! grep -q "^set -euo pipefail" "$script"; then
+		echo "❌ Missing 'set -euo pipefail' in entrypoint: $script_name"
+		errors=$((errors + 1))
+	fi
 
-  if ! grep -q "easyoptions.sh" "$script"; then
-    echo "❌ Missing EasyOptions usage in entrypoint: $script_name"
-    errors=$((errors + 1))
-  fi
+	if ! grep -q "easyoptions.sh" "$script"; then
+		echo "❌ Missing EasyOptions usage in entrypoint: $script_name"
+		errors=$((errors + 1))
+	fi
 done
 
 # Validate dots-scripts.sh is up to date
 scripts_in_dir=$(find "${DOTS_BIN_DIR}" -name "executable_dots-*" -printf "%f\n" | sed 's/executable_dots-//' | sort)
 scripts_in_list=$(grep -o '[a-zA-Z0-9-]*:' "${DOTFILES_ROOT}/home/dot_local/lib/dots/dots-scripts.sh" | sed 's/://' | sort)
 
-if ! diff -q <(echo "$scripts_in_dir") <(echo "$scripts_in_list") >/dev/null; then
-  echo "❌ dots-scripts.sh is out of sync with actual scripts"
-  echo "Scripts in directory but not in list:"
-  comm -23 <(echo "$scripts_in_dir") <(echo "$scripts_in_list")
-  echo "Scripts in list but not in directory:"
-  comm -13 <(echo "$scripts_in_dir") <(echo "$scripts_in_list")
-  errors=$((errors + 1))
+if ! diff -q <(echo "$scripts_in_dir") <(echo "$scripts_in_list") > /dev/null; then
+	echo "❌ dots-scripts.sh is out of sync with actual scripts"
+	echo "Scripts in directory but not in list:"
+	comm -23 <(echo "$scripts_in_dir") <(echo "$scripts_in_list")
+	echo "Scripts in list but not in directory:"
+	comm -13 <(echo "$scripts_in_dir") <(echo "$scripts_in_list")
+	errors=$((errors + 1))
 fi
 
 # Appearance theme pack + GTK/wal contract (source tree)
 if [[ -x ${DOTFILES_ROOT}/scripts/test-appearance-consistency.sh ]]; then
-  if ! "${DOTFILES_ROOT}/scripts/test-appearance-consistency.sh" --source; then
-    echo "❌ Appearance consistency checks failed"
-    errors=$((errors + 1))
-  fi
+	if ! "${DOTFILES_ROOT}/scripts/test-appearance-consistency.sh" --source; then
+		echo "❌ Appearance consistency checks failed"
+		errors=$((errors + 1))
+	fi
 else
-  echo "⚠️  scripts/test-appearance-consistency.sh missing or not executable"
-  errors=$((errors + 1))
+	echo "⚠️  scripts/test-appearance-consistency.sh missing or not executable"
+	errors=$((errors + 1))
 fi
 
 if [[ $errors -eq 0 ]]; then
-  echo "✅ All dots scripts validation passed!"
-  exit 0
+	echo "✅ All dots scripts validation passed!"
+	exit 0
 else
-  echo "❌ Found $errors validation errors"
-  exit 1
+	echo "❌ Found $errors validation errors"
+	exit 1
 fi


### PR DESCRIPTION
## Summary
- ThemePipeline / CC GTK+icon sections now call `dots-gtk-theme` instead of inlining `gtk-theme-manager.sh` or raw `gsettings`
- Extend `dots-gtk-theme` with `set-icons`, `color-scheme`, and `-p/--plain` listing for QML
- Shell fallback (`apply-appearance`, `dots-appearance set-gtk/set-icons`, theme-selector) passes icon + prefer-dark correctly
- Theme apply also syncs snappy-switcher; seed live GTK/icon checkmarks in Appearance pane
- System pane GTK tile opens Appearance via `dots-theme-selector` (no more `nwg-look`)

## Test plan
- [ ] `dots-gtk-theme -q -p list` / `icons` / `current` print plain names
- [ ] `dots-gtk-theme -q apply Orchis-Dark Numix-Circle true` then `dots appearance doctor` OK
- [ ] CC Appearance: stage GTK theme → Apply uses `dots-gtk-theme`
- [ ] CC Icon theme Apply updates gtk settings.ini, not only gsettings
- [ ] `dots appearance theme apply vapor-dreams` with QS up stays doctor-green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added theme pack support for GTK themes, icons, wallpapers, and light/dark preferences.
  * Added controls for listing themes, changing icons, selecting color schemes, and applying theme packs.
  * Appearance controls now show staged, applying, and failure states with progress feedback.
  * Added improved wallpaper previews and path handling.

* **Bug Fixes**
  * Improved fallback behavior when applying themes or detecting current settings.
  * Replaced legacy theme-selection flows with the integrated Appearance selector.

* **Documentation**
  * Updated appearance and theme-management guidance to reflect current commands and workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->