### PR TITLE
fix(sss): install noocr variant to drop onnxruntime dependency

### DIFF
--- a/home/.chezmoiscripts/linux/run_onchange_before_install-sss.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_before_install-sss.sh.tmpl
@@ -10,16 +10,21 @@ set -eufo pipefail
 {{   $sudo = "" -}}
 {{ end }}
 
-# sss v0.2.1 requires onnxruntime-cpu 1.24.x from extra (VERS_1.24.4 symbol)
-if ! pacman -Q onnxruntime-cpu &>/dev/null; then
-  {{ $sudo }}pacman -S --noconfirm extra/onnxruntime-cpu
-elif ! pacman -Q onnxruntime-cpu | grep -q "1\.24\."; then
-  {{ $sudo }}pacman -S --noconfirm extra/onnxruntime-cpu
-fi
-
-# sss (Super ScreenShot) v0.2.1 — main screenshot CLI with interactive selector
-if ! type -p sss &>/dev/null; then
-  curl -fsSL https://github.com/SergioRibera/sss/releases/download/sss_cli/v0.2.1/install.sh | sh
+# sss (Super ScreenShot) v0.2.1 — main screenshot CLI with interactive selector.
+#
+# We install the `noocr` variant on purpose. The OCR ("system") variant links
+# against libonnxruntime.so.1 with the versioned symbol VERS_1.24.4, which
+# Arch rolling breaks on every onnxruntime bump (onnxruntime-cpu/cuda ship
+# 1.27+/1.28, whose only versioned symbol is VERS_1.28.0). The `noocr`
+# variant drops the onnxruntime dependency entirely and OCR is already
+# disabled in ~/.config/sss/config.toml, so nothing is lost.
+if ! pacman -Q sss-noocr &>/dev/null; then
+  # A previous "system" variant must be removed first or the two packages
+  # collide on /usr/bin/sss.
+  if pacman -Q sss &>/dev/null; then
+    {{ $sudo }}pacman -R --noconfirm sss
+  fi
+  curl -fsSL https://github.com/SergioRibera/sss/releases/download/sss_cli/v0.2.1/install.sh | sh -s -- --variant noocr
 fi
 
 # sss_code v0.3.1 — code-to-PNG renderer


### PR DESCRIPTION
## Summary

Fixes `sss` breaking on Arch rolling with:

```
sss: /usr/lib/libonnxruntime.so.1: version `VERS_1.24.4' not found (required by sss)
```

The OCR (`system`) variant of `sss` v0.2.1 links against `libonnxruntime.so.1` requiring the versioned symbol `VERS_1.24.4` (onnxruntime 1.24.4). Arch's `onnxruntime-cpu`/`onnxruntime-cuda` now ship 1.27+/1.28, whose only versioned symbol is `VERS_1.28.0`, so the loader fails.

## Changes

- Install the `noocr` variant of `sss`, which has **no onnxruntime dependency** (verified: only `fontconfig`, `freetype2`, `gcc-libs`, `glibc`, `wayland`, and the binary does not link `libonnxruntime.so.1`).
- Remove the dead `onnxruntime-cpu 1.24.x` pin — that version no longer exists in `extra`, and `onnxruntime-cpu`/`onnxruntime-cuda` collide on the same soname anyway.
- Handle migration: uninstall a previously installed `system` variant first to avoid a `/usr/bin/sss` file collision.

OCR is already disabled in `~/.config/sss/config.toml` (`ocr.enable = false`), so nothing is lost by dropping OCR support.

## Testing

- `sss --version` works after switching to `sss-noocr`.
- Template renders cleanly with `chezmoi apply` (exit 0) and passes `shellcheck` with the CI exclude list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Arch Linux setup reliability by preventing conflicts between SSS package variants.
  - The setup now installs the no-OCR SSS variant, providing a streamlined installation without unnecessary OCR components.
  - Removed obsolete installation and version-check steps for the CPU-based OCR runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->