### PR TITLE
fix(keyboard-help): honor XDG_CONFIG_HOME for keybindings path

### DIFF
--- a/home/dot_local/bin/executable_dots-appearance
+++ b/home/dot_local/bin/executable_dots-appearance
@@ -152,8 +152,8 @@ cmd_status() {
 		flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
 		mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
 	fi
-	if [[ -f ${HOME}/.config/gtk-3.0/settings.ini ]]; then
-		gtk_theme="$(grep -E '^gtk-theme-name=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+	if [[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini ]]; then
+		gtk_theme="$(grep -E '^gtk-theme-name=' "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
 	fi
 	if command -v gsettings >/dev/null 2>&1; then
 		icon_theme="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'\"" || true)"
@@ -284,9 +284,9 @@ cmd_doctor() {
 	local hyprlock_bytes=0
 	[[ -f $hyprlock_conf ]] && hyprlock_bytes="$(wc -c <"$hyprlock_conf" | tr -d ' ')"
 	local gtk_theme_ini="" gtk_prefer_dark="" gtk_color_scheme=""
-	if [[ -f ${HOME}/.config/gtk-3.0/settings.ini ]]; then
-		gtk_theme_ini="$(grep -E '^gtk-theme-name=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-		gtk_prefer_dark="$(grep -E '^gtk-application-prefer-dark-theme=' "${HOME}/.config/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+	if [[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini ]]; then
+		gtk_theme_ini="$(grep -E '^gtk-theme-name=' "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+		gtk_prefer_dark="$(grep -E '^gtk-application-prefer-dark-theme=' "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
 	fi
 	if command -v gsettings >/dev/null 2>&1; then
 		gtk_color_scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'\"" || true)"

--- a/home/dot_local/bin/executable_dots-config-manager
+++ b/home/dot_local/bin/executable_dots-config-manager
@@ -170,7 +170,7 @@ setup_auto_snapshots() {
 	echo "⚙️  Setting up automatic snapshots..."
 
 	# Create systemd timer for automatic snapshots
-	local timer_dir="$HOME/.config/systemd/user"
+	local timer_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
 	mkdir -p "$timer_dir"
 
 	# Service file

--- a/home/dot_local/bin/executable_dots-default-apps
+++ b/home/dot_local/bin/executable_dots-default-apps
@@ -45,7 +45,7 @@ source ~/.local/lib/dots/logging.sh || exit
 SCRIPT_NAME="$(basename "$0")"
 readonly SCRIPT_NAME
 readonly CACHE_DIR="$HOME/.cache/dots/default-apps"
-readonly CONFIG_FILE="$HOME/.config/dots/default-apps.conf"
+readonly CONFIG_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/dots/default-apps.conf"
 
 # Logging adapter to preserve existing call sites.
 log() {
@@ -174,8 +174,8 @@ list_defaults() {
 
     # Special handling for terminal (uses exo config, not MIME)
     if [[ $category == "terminal" ]]; then
-      if [[ -f ~/.config/xfce4/helpers.rc ]]; then
-        default_app=$(grep "^TerminalEmulator=" ~/.config/xfce4/helpers.rc 2>/dev/null | cut -d'=' -f2)
+      if [[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/xfce4/helpers.rc" ]]; then
+        default_app=$(grep "^TerminalEmulator=" "${XDG_CONFIG_HOME:-$HOME/.config}/xfce4/helpers.rc" 2>/dev/null | cut -d'=' -f2)
         [[ -z $default_app ]] && default_app="Not set"
       else
         default_app="Not set"
@@ -316,8 +316,8 @@ show_terminal_selector() {
 
   # Get current default
   local current_term=""
-  if [[ -f ~/.config/xfce4/helpers.rc ]]; then
-    current_term=$(grep "^TerminalEmulator=" ~/.config/xfce4/helpers.rc 2>/dev/null | cut -d'=' -f2)
+  if [[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/xfce4/helpers.rc" ]]; then
+    current_term=$(grep "^TerminalEmulator=" "${XDG_CONFIG_HOME:-$HOME/.config}/xfce4/helpers.rc" 2>/dev/null | cut -d'=' -f2)
   fi
 
   # Build menu with available terminals
@@ -352,11 +352,11 @@ show_terminal_selector() {
   term_cmd="${term_cmd#  }"
 
   # Set as default in exo config
-  mkdir -p ~/.config/xfce4
-  if [[ -f ~/.config/xfce4/helpers.rc ]]; then
-    sed -i "s/^TerminalEmulator=.*/TerminalEmulator=$term_cmd/" ~/.config/xfce4/helpers.rc
+  mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/xfce4"
+  if [[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/xfce4/helpers.rc" ]]; then
+    sed -i "s/^TerminalEmulator=.*/TerminalEmulator=$term_cmd/" "${XDG_CONFIG_HOME:-$HOME/.config}/xfce4/helpers.rc"
   else
-    echo "TerminalEmulator=$term_cmd" >~/.config/xfce4/helpers.rc
+    echo "TerminalEmulator=$term_cmd" >"${XDG_CONFIG_HOME:-$HOME/.config}/xfce4/helpers.rc"
   fi
 
   log "INFO" "Set $term_cmd as default terminal emulator"

--- a/home/dot_local/bin/executable_dots-gtk-theme
+++ b/home/dot_local/bin/executable_dots-gtk-theme
@@ -169,13 +169,13 @@ cmd_current() {
 	log "" "${BLUE}🎨 Current GTK Theme:${NC} $current_theme"
 
 	# Show additional info
-	if [[ -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
+	if [[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" ]]; then
 		local icon_theme
-		icon_theme=$(grep "^gtk-icon-theme-name=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
+		icon_theme=$(grep "^gtk-icon-theme-name=" "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" | cut -d'=' -f2)
 		log "" "${BLUE}🎯 Icon Theme:${NC} $icon_theme"
 
 		local dark_pref
-		dark_pref=$(grep "^gtk-application-prefer-dark-theme=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2)
+		dark_pref=$(grep "^gtk-application-prefer-dark-theme=" "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" | cut -d'=' -f2)
 		log "" "${BLUE}🌙 Dark Theme Preference:${NC} $dark_pref"
 	fi
 }
@@ -240,8 +240,8 @@ cmd_set_icons() {
 	local gtk_theme prefer_dark
 	gtk_theme="$(get_current_gtk_theme)"
 	prefer_dark="false"
-	if [[ -f "$HOME/.config/gtk-3.0/settings.ini" ]]; then
-		prefer_dark="$(grep "^gtk-application-prefer-dark-theme=" "$HOME/.config/gtk-3.0/settings.ini" | cut -d'=' -f2 || echo false)"
+	if [[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" ]]; then
+		prefer_dark="$(grep "^gtk-application-prefer-dark-theme=" "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" | cut -d'=' -f2 || echo false)"
 	fi
 	[[ $prefer_dark == "1" || $prefer_dark == "true" ]] && prefer_dark="true" || prefer_dark="false"
 

--- a/home/dot_local/bin/executable_dots-keyboard-help
+++ b/home/dot_local/bin/executable_dots-keyboard-help
@@ -20,7 +20,7 @@ set -euo pipefail
 
 source ~/.local/lib/dots/easy-options/easyoptions.sh || exit
 
-readonly KEYBINDINGS_FILE="${HOME}/.config/hypr/hyprland.conf.d/keybindings.conf"
+readonly KEYBINDINGS_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/hyprland.conf.d/keybindings.conf"
 
 if [[ ${DOTS_BYPASS_QUICKSHELL:-0} != 1 ]] && pgrep -x quickshell >/dev/null 2>&1; then
   dots-settings-gui --pane=system menu

--- a/home/dot_local/bin/executable_dots-quickshell
+++ b/home/dot_local/bin/executable_dots-quickshell
@@ -54,13 +54,13 @@ source "${HOME}/.local/lib/dots/logging.sh"
 source "${HOME}/.local/lib/dots/easy-options/easyoptions.sh" || exit
 
 QUICKSHELL_BIN="quickshell"
-QUICKSHELL_CONFIG_DIR="${HOME}/.config/quickshell"
-SHELL_CONFIG="${HOME}/.config/hornero/shell.json"
+QUICKSHELL_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/quickshell"
+SHELL_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/hornero/shell.json"
 PRESETS_DIR="${HOME}/.local/share/dots/shell-presets"
 CURRENT_PRESET_FILE="${HOME}/.local/state/dots/current-shell-preset"
 
 export QML_IMPORT_PATH="${QML_IMPORT_PATH:-${HOME}/.local/lib/quickshell/qml:${HOME}/.local/usr/lib/qt6/qml}"
-export QML2_IMPORT_PATH="${QML2_IMPORT_PATH:-${HOME}/.local/usr/lib/qt6/qml:${HOME}/.config/quickshell}"
+export QML2_IMPORT_PATH="${QML2_IMPORT_PATH:-${HOME}/.local/usr/lib/qt6/qml:${XDG_CONFIG_HOME:-$HOME/.config}/quickshell}"
 export QS_PLUGIN_PATH="${QS_PLUGIN_PATH:-${HOME}/.local/lib/quickshell}"
 
 is_running() {

--- a/home/dot_local/bin/executable_dots-security-audit
+++ b/home/dot_local/bin/executable_dots-security-audit
@@ -62,7 +62,7 @@ check_file_permissions() {
     fi
   fi
 
-  local cred_dir="$HOME/.config/private_credentials"
+  local cred_dir="${XDG_CONFIG_HOME:-$HOME/.config}/private_credentials"
   if [[ -d $cred_dir ]]; then
     find "$cred_dir" -type f 2>/dev/null | while IFS= read -r f; do
       local perms
@@ -93,7 +93,7 @@ check_file_permissions() {
   fi
 
   echo "  Checking for suspicious SUID/SGID files..."
-  find "$HOME/.local" "$HOME/.config" -type f \( -perm -4000 -o -perm -2000 \) 2>/dev/null | while IFS= read -r file; do
+  find "$HOME/.local" "${XDG_CONFIG_HOME:-$HOME/.config}" -type f \( -perm -4000 -o -perm -2000 \) 2>/dev/null | while IFS= read -r file; do
     echo "⚠️  Found SUID/SGID file in user directory: $file"
   done
 
@@ -124,7 +124,7 @@ scan_for_secrets() {
   local issues=0
 
   local scan_locations=(
-    "$HOME/.config"
+    "${XDG_CONFIG_HOME:-$HOME/.config}"
     "$HOME/.local/share"
     "$HOME/.zshrc"
     "$HOME/.bashrc"
@@ -343,7 +343,9 @@ check_system_security() {
 
 run_security_audit() {
   local failures=0
-  export NAN_DOC_TS="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  local NAN_DOC_TS
+  NAN_DOC_TS="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  export NAN_DOC_TS
 
   echo "🔐 Running comprehensive security audit..."
   echo "Timestamp: $NAN_DOC_TS" >"$SECURITY_LOG"
@@ -365,7 +367,9 @@ run_security_audit() {
 
 run_security_audit_json() {
   local failures=0
-  export NAN_DOC_TS="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  local NAN_DOC_TS
+  NAN_DOC_TS="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  export NAN_DOC_TS
 
   local perm_out sec_out sys_out
   perm_out=$(check_file_permissions 2>&1); [[ $? -gt 0 ]] && ((failures++))
@@ -404,7 +408,7 @@ apply_security_fixes() {
     find "$HOME/.ssh" -name "*.pub" -exec chmod 644 {} \; && echo "✅ Fixed SSH public key permissions (644)"
   fi
 
-  local cred_dir="$HOME/.config/private_credentials"
+  local cred_dir="${XDG_CONFIG_HOME:-$HOME/.config}/private_credentials"
   if [[ -d $cred_dir ]]; then
     find "$cred_dir" -type f -exec chmod 600 {} \; && chmod 700 "$cred_dir" && echo "✅ Fixed credential file permissions"
   fi
@@ -434,7 +438,8 @@ apply_security_fixes() {
 }
 
 generate_security_report() {
-  local report_file="$HOME/.cache/dots/security_report_$(date +%Y%m%d).md"
+  local report_file
+  report_file="$HOME/.cache/dots/security_report_$(date +%Y%m%d).md"
 
   {
     echo "# dots-security-audit Report"

--- a/home/dot_local/bin/executable_dots-smart-colors
+++ b/home/dot_local/bin/executable_dots-smart-colors
@@ -843,7 +843,7 @@ EOF
 
   # Generate CopyQ theme file (.ini format)
   local COPYQ_THEME_FILE="${SMART_COLORS_DIR}/colors-copyq.ini"
-  local COPYQ_CONFIG_DIR="${HOME}/.config/copyq"
+  local COPYQ_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/copyq"
   local COPYQ_THEMES_DIR="${COPYQ_CONFIG_DIR}/themes"
 
   # Create themes directory if it doesn't exist

--- a/home/dot_local/bin/executable_dots-weather-info
+++ b/home/dot_local/bin/executable_dots-weather-info
@@ -33,7 +33,7 @@ cache_weather_icon=${cache_dir}/weather-icon
 cache_weather_location=${cache_dir}/weather-location
 
 ## Weather data - API key from LastPass via chezmoi template
-readonly WEATHER_API_KEY_FILE="$HOME/.config/credentials/weather_api_key"
+readonly WEATHER_API_KEY_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/credentials/weather_api_key"
 KEY="${WEATHER_API_KEY:-$(cat "$WEATHER_API_KEY_FILE" 2>/dev/null || echo "")}"
 
 if [[ -z $KEY ]]; then

--- a/home/dot_local/lib/dots/gtk-theme-manager.sh
+++ b/home/dot_local/lib/dots/gtk-theme-manager.sh
@@ -24,7 +24,7 @@ fi
 
 # GTK configuration paths
 readonly GTK2_CONFIG="$HOME/.gtkrc-2.0"
-readonly GTK3_CONFIG="$HOME/.config/gtk-3.0/settings.ini"
+readonly GTK3_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini"
 
 # Function to log messages
 log() {

--- a/home/dot_local/lib/dots/snappy-switcher-manager.sh
+++ b/home/dot_local/lib/dots/snappy-switcher-manager.sh
@@ -14,7 +14,7 @@
 
 set -euo pipefail
 
-readonly SNAPPY_CONFIG_DIR="$HOME/.config/snappy-switcher"
+readonly SNAPPY_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/snappy-switcher"
 readonly SNAPPY_CONFIG_FILE="${SNAPPY_CONFIG_DIR}/config.ini"
 
 snappy_log() {


### PR DESCRIPTION
**Fixes #224**

## Summary

Honor `XDG_CONFIG_HOME` instead of hardcoding `${HOME}/.config` across the dots scripts.

### 1. `dots-keyboard-help` (the issue)

`KEYBINDINGS_FILE` hardcoded `${HOME}/.config/hypr/hyprland.conf.d/keybindings.conf`, ignoring `XDG_CONFIG_HOME`. When a user relocates their config directory, the script failed with `[ERROR] Keybindings configuration not found`.

```bash
# before
readonly KEYBINDINGS_FILE="${HOME}/.config/hypr/hyprland.conf.d/keybindings.conf"
# after
readonly KEYBINDINGS_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/hypr/hyprland.conf.d/keybindings.conf"
```

The `:-` fallback keeps the default case identical (`$HOME/.config` when `XDG_CONFIG_HOME` is unset), so existing setups are unaffected.

### 2. Same fix applied repo-wide (follow-up commit)

The same hardcoded pattern existed in 9 more scripts and libs. Applied `${XDG_CONFIG_HOME:-$HOME/.config}` (31 references):

- `dots-appearance` (5) — `gtk-3.0/settings.ini`
- `dots-gtk-theme` (5) — `gtk-3.0/settings.ini`
- `dots-default-apps` (9) — `dots/default-apps.conf`, `xfce4/helpers.rc` (incl. `mkdir -p`, `sed -i`, redirection)
- `dots-security-audit` (4) — `private_credentials`, config scan paths
- `dots-quickshell` (3) — `quickshell/`, `hornero/shell.json`, `QML2_IMPORT_PATH`
- `dots-smart-colors` (1) — `copyq`
- `dots-config-manager` (1) — `systemd/user`
- `dots-weather-info` (1) — `credentials/weather_api_key`
- `lib/gtk-theme-manager.sh` (1), `lib/snappy-switcher-manager.sh` (1)

Plus 3 pre-existing SC2155 fixes in `dots-security-audit` (split `export`/`local` from assignment) so the file passes shellcheck.

### Tests

<img width="1365" height="767" alt="image" src="https://github.com/user-attachments/assets/8206438c-2628-469a-8167-63b9651bf39e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration-aware tools now honor `XDG_CONFIG_HOME` when locating keyboard shortcuts, appearance and theme settings, default apps, Quickshell, security audit files, smart colors, weather credentials, and related configuration.
  * Automatic snapshots and Snappy Switcher now use the configured XDG location.
  * All affected tools retain `$HOME/.config` as a fallback when no custom path is set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->