### PR TITLE
fix(appearance): avoid wal-restore race with Quickshell ThemePipeline on Hyprland

### DIFF
--- a/home/dot_config/autostart/wal-restore.desktop
+++ b/home/dot_config/autostart/wal-restore.desktop
@@ -4,3 +4,6 @@ Name=Wal Restore Colorscheme
 Comment=Restore pywal + M3 palette from live appearance state
 Exec=dots-wal-reload
 X-GNOME-Autostart-enabled=true
+# Hyprland uses Quickshell ThemePipeline for appearance restore; avoid
+# double-apply race with dex --autostart --environment Hyprland.
+NotShowIn=Hyprland;

--- a/home/dot_local/bin/executable_dots-wal-reload
+++ b/home/dot_local/bin/executable_dots-wal-reload
@@ -10,15 +10,16 @@ set -euo pipefail
 
 # Hyprland race: dex --autostart may fire wal-restore before Quickshell
 # finishes launching (hyprland.conf exec-once ordering). If we are in a
-# Hyprland session but Quickshell is not yet running, wait briefly for it
-# so we can delegate to ThemePipeline instead of doing a direct wal -R +
-# GTK override that ignores theme.json gtkPreferDark.
-if [[ -n "${HYPRLAND_INSTANCE_SIGNATURE:-}" ]] && ! pgrep -x quickshell >/dev/null 2>&1; then
+# Hyprland session, wait briefly for Quickshell IPC to be ready (process
+# plus appearance target) before falling back to direct wal -R + GTK.
+# Verifies IPC readiness, not just process presence, so we do not apply
+# state.json mode via the fallback and ignore theme.json gtkPreferDark.
+if [[ -n "${HYPRLAND_INSTANCE_SIGNATURE:-}" ]]; then
 	for _w in $(seq 1 30); do
-		sleep 0.5
-		if pgrep -x quickshell >/dev/null 2>&1; then
+		if pgrep -x quickshell >/dev/null 2>&1 && quickshell ipc call appearance isBusy >/dev/null 2>&1; then
 			break
 		fi
+		sleep 0.5
 	done
 fi
 

--- a/home/dot_local/bin/executable_dots-wal-reload
+++ b/home/dot_local/bin/executable_dots-wal-reload
@@ -8,6 +8,20 @@
 
 set -euo pipefail
 
+# Hyprland race: dex --autostart may fire wal-restore before Quickshell
+# finishes launching (hyprland.conf exec-once ordering). If we are in a
+# Hyprland session but Quickshell is not yet running, wait briefly for it
+# so we can delegate to ThemePipeline instead of doing a direct wal -R +
+# GTK override that ignores theme.json gtkPreferDark.
+if [[ -n "${HYPRLAND_INSTANCE_SIGNATURE:-}" ]] && ! pgrep -x quickshell >/dev/null 2>&1; then
+	for _w in $(seq 1 30); do
+		sleep 0.5
+		if pgrep -x quickshell >/dev/null 2>&1; then
+			break
+		fi
+	done
+fi
+
 if pgrep -x quickshell >/dev/null 2>&1; then
 	if quickshell ipc call appearance reload >/dev/null 2>&1; then
 		busy=""


### PR DESCRIPTION
Fixes boot race that forced dark GTK over light preference.

**Problem:** On Hyprland, two restores race at login:
1. `dex --autostart --environment Hyprland` launches `wal-restore.desktop → dots-wal-reload`
2. Quickshell ThemePipeline `Component.onCompleted → dots-color-scheme regenerate` is the canonical restore

When dex fires before Quickshell is ready, `dots-wal-reload` takes the direct fallback (`wal -R + M3 + dots-gtk-theme color-scheme $mode`) where $mode is from `state.json` (dark if last theme was dark). That ignores `theme.json gtkPreferDark` and overwrites a user light GTK setting on every boot.

**Solution:**
- `wal-restore.desktop`: add `NotShowIn=Hyprland;` so Hyprland sessions don't double-apply via dex; Quickshell owns restore under Hyprland
- `dots-wal-reload`: if `HYPRLAND_INSTANCE_SIGNATURE` is set but `quickshell` not yet running, wait up to 15s for it to appear before falling back. Ensures ThemePipeline handles GTK correctly via `resolveGtkPreferDark`

**Testing:**
- Hyprland login: `wal-restore` not launched via dex (check `ps`), ThemePipeline handles palette
- Non-Hyprland fallback still works (X11/i3): no Hyprland sig → immediate fallback
- Reboot with light GTK + dark theme: no longer flips to dark


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate wallpaper/theme restoration when running Hyprland.
  * Added startup handling to wait for Quickshell before reloading wallpaper and theme settings.
  * Preserved fallback behavior when Quickshell is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->