### PR TITLE
fix(appearance): doctor no longer fails on light GTK + dark palette

### DIFF
--- a/home/dot_local/bin/executable_dots-appearance
+++ b/home/dot_local/bin/executable_dots-appearance
@@ -368,22 +368,21 @@ cmd_doctor() {
 		echo "FAIL: orphan smart-colors/wallpaper cache present" >&2
 		ok=1
 	fi
+	# GTK light with dark mode is intentional for many theme packs
+	# (e.g. gruvbox darkMode=true + gtkPreferDark=false → Orchis-Light-Compact).
+	# Downgrade to WARN so user light preference + dark wal does not fail doctor.
 	if [[ -n $state_mode && -n $gtk_prefer_dark ]]; then
 		if [[ $state_mode == "dark" && $gtk_prefer_dark == "false" ]]; then
-			echo "FAIL: GTK prefer-dark=false while live mode is dark" >&2
-			ok=1
+			echo "WARN: GTK prefer-dark=false while live mode is dark (light GTK + dark palette — intentional if theme sets gtkPreferDark=false or you prefer light GTK)" >&2
 		elif [[ $state_mode == "light" && $gtk_prefer_dark == "true" ]]; then
-			echo "FAIL: GTK prefer-dark=true while live mode is light" >&2
-			ok=1
+			echo "WARN: GTK prefer-dark=true while live mode is light (dark GTK + light palette — check theme gtkPreferDark)" >&2
 		fi
 	fi
 	if [[ -n $state_mode && -n $gtk_color_scheme ]]; then
 		if [[ $state_mode == "dark" && $gtk_color_scheme != "prefer-dark" ]]; then
-			echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is dark" >&2
-			ok=1
+			echo "WARN: gsettings color-scheme=$gtk_color_scheme while live mode is dark (mismatch — was GTK manually set to light?)" >&2
 		elif [[ $state_mode == "light" && $gtk_color_scheme != "prefer-light" ]]; then
-			echo "FAIL: gsettings color-scheme=$gtk_color_scheme while live mode is light" >&2
-			ok=1
+			echo "WARN: gsettings color-scheme=$gtk_color_scheme while live mode is light (mismatch — was GTK manually set to dark?)" >&2
 		fi
 	fi
 	if [[ -n $wal_target && -f $wal_target ]]; then


### PR DESCRIPTION
Fixes doctor false-positive that blocked light GTK preference.

**Problem:** \~11 theme packs ship `darkMode=true` + `gtkPreferDark=false` (gruvbox, everforest, nord-dreams, etc. → Orchis-Light-Compact) deliberately pairing dark wal/M3 palette with light GTK. Doctor treated `state mode=dark + gtk prefer-dark=false` and `gsettings prefer-light + dark` as `FAIL` (exit 1), signalling broken state. Users who preferred light GTK while keeping dark wal were flagged as broken, and boot logic tried to heal by forcing dark again.

**Solution:**
- Downgrade both GTK vs state mode checks from `FAIL`+`ok=1` to `WARN` with explanatory text
- Doctor now exits 0 for light GTK + dark palette, still warns for visibility
- Keeps other FAILs (flavour mismatch, missing pointer, etc.) strict

**Testing:**
- `dots-appearance doctor` with dark wal + light GTK (gruvbox) → WARN not FAIL, exit 0
- `state light + prefer true` → WARN not FAIL
- Other inconsistencies still FAIL

Related to gtk persistence + wal-restore race PRs.