### PR TITLE
feat(appearance): expose GTK color scheme independent of Theme mode

### DIFF
--- a/docs/adrs/002-rice-system.md
+++ b/docs/adrs/002-rice-system.md
@@ -16,8 +16,10 @@ packs, but they are apply-once recipes — not a live source of truth.
 - **Live SoT**
   - Wallpaper: `~/.local/state/dots/wallpaper/path`
   - Palette: `~/.cache/dots/smart-colors/scheme.json`
-  - Mode/flavour prefs: `~/.local/state/dots/scheme/state.json`
-  - GTK/icons: gtk `settings.ini` + gsettings
+  - Mode/flavour prefs: `~/.local/state/dots/scheme/state.json` (`mode` is shell/M3 only)
+  - GTK color-scheme policy: `gtkColorScheme` in the same `state.json`
+    (`follow` | `default` | `prefer-light` | `prefer-dark`) — independent of `mode`
+  - GTK/icons: gtk-3.0 + gtk-4.0 `settings.ini` + gsettings
   - Shell chrome: QS `Config` / `~/.config/hornero/shell.json`
 - **Theme packs** (optional recipes): `~/.local/share/dots/themes/<id>/theme.json`
   - Apply once via Control Center Themes or `dots appearance theme apply <id>`
@@ -26,7 +28,7 @@ packs, but they are apply-once recipes — not a live source of truth.
   `~/Pictures/Wallpapers/<id>/`
 - **Orchestrator**: Quickshell `ThemePipeline.qml` (IPC target `appearance`) +
   `apply-appearance.sh` shell fallback
-- **CLI**: `dots appearance …` (`theme`, `set-wallpaper`, `set-mode`, `set-gtk`, …)
+- **CLI**: `dots appearance …` (`theme`, `set-wallpaper`, `set-mode`, `set-gtk`, `set-gtk-color-scheme`, …)
 
 Removed: `~/.local/share/dots/rices/`, `dots-rice`, `rice/current`, per-rice
 `config.sh` / `apply.sh`, IPC target `rice`.
@@ -36,7 +38,10 @@ Removed: `~/.local/share/dots/rices/`, `dots-rice`, `rice/current`, per-rice
 ### Positive
 
 - One live appearance model; theme packs are inspiration, not identity
-- Control Center can configure wallpaper, mode, variant, scheme, GTK, icons
+- Control Center can configure wallpaper, mode, variant, scheme, GTK theme,
+  GTK color-scheme (independent of Theme mode), icons, and shell chrome
+- GTK color-scheme is live SoT (`gtkColorScheme`); Theme mode only pushes GTK
+  when the policy is `follow` (missing key = follow for legacy boots)
 - Offline apply without Quickshell
 
 ### Negative

--- a/docs/wiki/Quickshell-Shell.md
+++ b/docs/wiki/Quickshell-Shell.md
@@ -76,7 +76,7 @@ Each appearance theme pack configures its M3 scheme via `theme.json`:
   "schemeType": "vibrant",
   "darkMode": true,
   "gtkTheme": "Orchis-Light-Compact",
-  "gtkPreferDark": false,
+  "gtkColorScheme": "prefer-light",
   "iconTheme": "Numix-Circle"
 }
 ```
@@ -88,6 +88,7 @@ dots appearance list
 dots appearance theme apply vapor-dreams
 dots appearance set-variant tonal-spot
 dots appearance set-mode light
+dots appearance set-gtk-color-scheme prefer-light
 dots appearance doctor
 ```
 

--- a/docs/wiki/Rice-System-Theme-Management.md
+++ b/docs/wiki/Rice-System-Theme-Management.md
@@ -5,14 +5,14 @@ one-shot recipes — they never own a sticky “current theme”.
 
 ## Live sources of truth
 
-| Concern        | Path / tool                                              |
-|----------------|----------------------------------------------------------|
-| Wallpaper      | `~/.local/state/dots/wallpaper/path`                     |
-| Palette        | `~/.cache/dots/smart-colors/scheme.json`                 |
-| Mode / flavour | `~/.local/state/dots/scheme/state.json` (`mode`)         |
-| GTK color scheme | `gtkColorScheme` in the same `state.json`              |
-| GTK / icons    | via `dots-gtk-theme` → gtk-3.0 + gtk-4.0 `settings.ini` + gsettings |
-| Wal pointer    | `~/.cache/wal/wal` (**text path file**, never a symlink) |
+| Concern          | Path / tool                                                         |
+|------------------|---------------------------------------------------------------------|
+| Wallpaper        | `~/.local/state/dots/wallpaper/path`                                |
+| Palette          | `~/.cache/dots/smart-colors/scheme.json`                            |
+| Mode / flavour   | `~/.local/state/dots/scheme/state.json` (`mode`)                    |
+| GTK color scheme | `gtkColorScheme` in the same `state.json`                           |
+| GTK / icons      | via `dots-gtk-theme` → gtk-3.0 + gtk-4.0 `settings.ini` + gsettings |
+| Wal pointer      | `~/.cache/wal/wal` (**text path file**, never a symlink)            |
 
 ## Theme packs
 

--- a/docs/wiki/Rice-System-Theme-Management.md
+++ b/docs/wiki/Rice-System-Theme-Management.md
@@ -9,8 +9,9 @@ one-shot recipes — they never own a sticky “current theme”.
 |----------------|----------------------------------------------------------|
 | Wallpaper      | `~/.local/state/dots/wallpaper/path`                     |
 | Palette        | `~/.cache/dots/smart-colors/scheme.json`                 |
-| Mode / flavour | `~/.local/state/dots/scheme/state.json`                  |
-| GTK / icons    | via `dots-gtk-theme` → `settings.ini` + gsettings        |
+| Mode / flavour | `~/.local/state/dots/scheme/state.json` (`mode`)         |
+| GTK color scheme | `gtkColorScheme` in the same `state.json`              |
+| GTK / icons    | via `dots-gtk-theme` → gtk-3.0 + gtk-4.0 `settings.ini` + gsettings |
 | Wal pointer    | `~/.cache/wal/wal` (**text path file**, never a symlink) |
 
 ## Theme packs
@@ -35,10 +36,19 @@ dots appearance set-wallpaper <path>
 dots appearance set-mode dark|light
 dots appearance set-variant expressive
 dots appearance set-gtk Orchis-Light-Compact
+dots appearance set-gtk-color-scheme follow|default|prefer-light|prefer-dark
 dots appearance set-icons Numix-Circle
 dots appearance status
 dots appearance doctor
 ```
+
+`gtkColorScheme` is independent of shell Theme mode:
+
+- `follow` — GTK tracks Theme mode (legacy default when the key is missing)
+- `default` — GNOME Auto (`color-scheme=default`); apps decide
+- `prefer-light` / `prefer-dark` — sticky, Theme mode does not overwrite GTK
+
+Packs may still ship `gtkPreferDark` (boolean); it maps to `prefer-dark` / `prefer-light`.
 
 GTK entrypoint (canonical for scripts and Quickshell):
 
@@ -46,17 +56,22 @@ GTK entrypoint (canonical for scripts and Quickshell):
 dots-gtk-theme -q -p list
 dots-gtk-theme -q -p current
 dots-gtk-theme -q -p current-icon
-dots-gtk-theme -q apply Orchis-Light-Compact Numix-Circle true
-dots-gtk-theme -q color-scheme dark
+dots-gtk-theme -q -p current-color-scheme
+dots-gtk-theme -q apply Orchis-Light-Compact Numix-Circle prefer-light
+dots-gtk-theme -q color-scheme prefer-light
+dots-gtk-theme -q color-scheme follow
+dots-gtk-theme -q sync-color-scheme
 dots-gtk-theme -q theme vapor-dreams
 ```
 
 ## Quickshell
 
 - Orchestrator: `ThemePipeline` singleton (IPC target `appearance`)
-- Control Center pane configures themes, wallpaper, mode, variant, scheme, GTK, icons
-- GTK/icon apply always goes through `dots-gtk-theme` (never inline `gtk-theme-manager.sh` or raw `gsettings` from QML)
+- Control Center → Appearance groups look packs, shell palette, toolkit (GTK theme + GTK color scheme + icons), then shell chrome (fonts including clock, animations, scales, transparency, border, background)
+- GTK/icon/color-scheme apply always goes through `dots-gtk-theme` (never inline `gtk-theme-manager.sh` or raw `gsettings` from QML)
 - Launcher actions: `theme` / `appearance`
+
+P1 (not in this contract): cursor theme/size, GTK UI font (`gtk-font-name`), Qt6ct / Kvantum.
 
 ## Consistency checks
 

--- a/docs/wiki/Smart-Colors-System.md
+++ b/docs/wiki/Smart-Colors-System.md
@@ -20,8 +20,8 @@ Smart Colors generates semantic colors and Material Design 3 palettes from the c
    - write `~/.local/state/dots/wallpaper/path` (canonical pointer)
    - rewrite `~/.cache/wal/wal` as a **text path file** (never an image symlink)
    - `generate-m3-colors.py` → `scheme.json`
-   - `dots-color-scheme sync-state` → `scheme/state.json`
-   - `dots-gtk-theme color-scheme` to keep GTK/libadwaita in lockstep
+   - `dots-color-scheme sync-state` → `scheme/state.json` (preserves `gtkColorScheme`)
+   - `dots-gtk-theme sync-color-scheme` re-applies the persisted GTK policy (`follow` tracks Theme mode; sticky `prefer-light` / `prefer-dark` / `default` are left alone)
 4. `Colours.qml` reloads via file watch or `dots-quickshell ipc colours reload` (real IPC + touch fallback)
 
 ### Wallpaper resolution priority

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/AppearancePane.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/AppearancePane.qml
@@ -29,6 +29,7 @@ Item {
     property string fontFamilyMaterial: Config.appearance.font.family.material ?? "Material Symbols Rounded"
     property string fontFamilyMono: Config.appearance.font.family.mono ?? "CaskaydiaCove NF"
     property string fontFamilySans: Config.appearance.font.family.sans ?? "Rubik"
+    property string fontFamilyClock: Config.appearance.font.family.clock ?? "Rubik"
     property real fontSizeScale: Config.appearance.font.size.scale ?? 1
     property real paddingScale: Config.appearance.padding.scale ?? 1
     property real roundingScale: Config.appearance.rounding.scale ?? 1
@@ -63,6 +64,7 @@ Item {
     property string stagedThemeWallpaper: ""
     property string pendingGtkTheme: ""
     property string pendingIconTheme: ""
+    property string pendingGtkColorScheme: "follow"
     property string wallpaperScopeDir: ""
     property bool wallpaperShowAll: false
     property bool themeDirty: false
@@ -72,14 +74,16 @@ Item {
     property bool wallpaperDirty: false
     property bool gtkDirty: false
     property bool iconDirty: false
+    property bool gtkColorSchemeDirty: false
     // True only when Theme mode was toggled by the user (not implied by theme stage).
     property bool modeOverrideDirty: false
     property string deferredMode: ""
     property string deferredGtk: ""
     property string deferredIcon: ""
+    property string deferredGtkColorScheme: ""
     property string applyStatusMessage: ""
     property bool applyFailed: false
-    readonly property bool hasPendingChanges: themeDirty || schemeDirty || variantDirty || modeDirty || wallpaperDirty || gtkDirty || iconDirty
+    readonly property bool hasPendingChanges: themeDirty || schemeDirty || variantDirty || modeDirty || wallpaperDirty || gtkDirty || iconDirty || gtkColorSchemeDirty
     readonly property bool pipelineBusy: ThemePipeline.busy
     readonly property bool canApply: hasPendingChanges && !pipelineBusy
     readonly property string footerStatusText: {
@@ -102,6 +106,7 @@ Item {
     property string previewGtkTheme: ""
     property string previewIconTheme: ""
     property string previewGtkPrefer: ""
+    property string previewGtkColorScheme: ""
     property string previewWallpaperLabel: ""
     property string previewThemeId: ""
     property var previewTags: []
@@ -142,6 +147,25 @@ Item {
             return v;
         default:
             return "tonal-spot";
+        }
+    }
+
+    function normalizeGtkColorScheme(value: string): string {
+        return ThemePipeline.normalizeGtkColorScheme(value) || "follow";
+    }
+
+    function gtkColorSchemeLabel(value: string): string {
+        switch (normalizeGtkColorScheme(value)) {
+        case "follow":
+            return qsTr("Follow theme mode");
+        case "default":
+            return qsTr("Auto (apps decide)");
+        case "prefer-light":
+            return qsTr("Prefer light");
+        case "prefer-dark":
+            return qsTr("Prefer dark");
+        default:
+            return value || "—";
         }
     }
 
@@ -225,6 +249,7 @@ Item {
         previewGtkTheme = "";
         previewIconTheme = "";
         previewGtkPrefer = "";
+        previewGtkColorScheme = "";
         previewWallpaperLabel = "";
         previewThemeId = "";
         previewTags = [];
@@ -245,6 +270,8 @@ Item {
         previewMode = pendingMode;
         previewGtkTheme = pendingGtkTheme;
         previewIconTheme = pendingIconTheme;
+        previewGtkColorScheme = pendingGtkColorScheme;
+        previewGtkPrefer = pendingGtkColorScheme;
         previewWallpaperLabel = pendingWallpaperPath ? pendingWallpaperPath.split("/").pop() : "";
         scheduleGeneratedPreview(previewWallpaperPath || pendingWallpaperPath, pendingMode, previewSchemeType);
     }
@@ -265,6 +292,8 @@ Item {
         previewMode = pendingMode;
         previewGtkTheme = pendingGtkTheme;
         previewIconTheme = pendingIconTheme;
+        previewGtkColorScheme = pendingGtkColorScheme;
+        previewGtkPrefer = pendingGtkColorScheme;
         scheduleGeneratedPreview(previewWallpaperPath || pendingWallpaperPath, pendingMode, previewSchemeType);
     }
 
@@ -283,7 +312,27 @@ Item {
         previewVariant = previewSchemeType;
         previewGtkTheme = pendingGtkTheme;
         previewIconTheme = pendingIconTheme;
+        previewGtkColorScheme = pendingGtkColorScheme;
+        previewGtkPrefer = pendingGtkColorScheme;
         scheduleGeneratedPreview(previewWallpaperPath || pendingWallpaperPath, mode, previewSchemeType);
+    }
+
+    function startGtkColorSchemePreview(policy: string): void {
+        const normalized = normalizeGtkColorScheme(policy);
+        previewActive = true;
+        previewSource = "gtk-color-scheme";
+        previewTitle = gtkColorSchemeLabel(normalized);
+        previewSubtitle = qsTr("GTK color scheme");
+        previewGtkColorScheme = normalized;
+        previewGtkPrefer = normalized;
+        previewMode = pendingMode;
+        previewGtkTheme = pendingGtkTheme;
+        previewIconTheme = pendingIconTheme;
+        previewSchemeType = normalizeSchemeType(pendingVariant);
+        previewVariant = previewSchemeType;
+        previewWallpaperPath = previewWallpaperPath || pendingWallpaperPath;
+        previewWallpaperLabel = pendingWallpaperPath ? pendingWallpaperPath.split("/").pop() : "";
+        scheduleGeneratedPreview(previewWallpaperPath || pendingWallpaperPath, pendingMode, previewSchemeType);
     }
 
     function startWallpaperPreview(path: string, label: string): void {
@@ -301,6 +350,8 @@ Item {
             previewMode = previewMode || pendingMode;
             previewGtkTheme = pendingGtkTheme;
             previewIconTheme = pendingIconTheme;
+            previewGtkColorScheme = pendingGtkColorScheme;
+            previewGtkPrefer = pendingGtkColorScheme;
         }
         previewWallpaperPath = path;
         previewSchemeType = normalizeSchemeType(previewVariant || pendingVariant);
@@ -325,17 +376,8 @@ Item {
         previewSchemeType = normalizeSchemeType(modelData.schemeType ?? "");
         previewGtkTheme = modelData.gtkTheme || "Orchis-Light-Compact";
         previewIconTheme = modelData.iconTheme || "";
-        if (modelData.gtkPreferDark !== undefined)
-            previewGtkPrefer = modelData.gtkPreferDark ? "prefer-dark" : "prefer-light";
-        else {
-            const gtk = (previewGtkTheme || "").toLowerCase();
-            if (gtk.indexOf("light") >= 0)
-                previewGtkPrefer = "prefer-light";
-            else if (gtk.indexOf("dark") >= 0)
-                previewGtkPrefer = "prefer-dark";
-            else
-                previewGtkPrefer = modelData.darkMode ? "prefer-dark" : "prefer-light";
-        }
+        previewGtkColorScheme = modelData.gtkColorScheme || ThemePipeline.resolveGtkColorScheme(modelData, !!modelData.darkMode);
+        previewGtkPrefer = previewGtkColorScheme;
         previewWallpaperLabel = modelData.defaultWallpaper || (previewWallpaperPath ? previewWallpaperPath.split("/").pop() : "");
         previewThemeId = modelData.id || "";
         previewTags = modelData.tags ?? [];
@@ -408,9 +450,15 @@ Item {
             else
                 ThemePipeline.setIcons(pendingIconTheme);
         }
+        if (gtkColorSchemeDirty && pendingGtkColorScheme) {
+            if (pipelineJob)
+                deferredGtkColorScheme = pendingGtkColorScheme;
+            else
+                ThemePipeline.setGtkColorScheme(pendingGtkColorScheme);
+        }
 
         // If a pipeline job is in flight, wait for applyFinished. If already idle, flush now.
-        if ((deferredMode || deferredGtk || deferredIcon) && !ThemePipeline.busy)
+        if ((deferredMode || deferredGtk || deferredIcon || deferredGtkColorScheme) && !ThemePipeline.busy)
             root._flushDeferredPipelineExtras();
 
         themeDirty = false;
@@ -421,6 +469,7 @@ Item {
         wallpaperDirty = false;
         gtkDirty = false;
         iconDirty = false;
+        gtkColorSchemeDirty = false;
         stagedThemeWallpaper = "";
         clearPreview();
     }
@@ -458,6 +507,11 @@ Item {
             deferredIcon = "";
             ThemePipeline.setIcons(theme);
         }
+        if (deferredGtkColorScheme) {
+            const policy = deferredGtkColorScheme;
+            deferredGtkColorScheme = "";
+            ThemePipeline.setGtkColorScheme(policy);
+        }
     }
 
     function stageThemeApply(themeId: string): void {
@@ -483,6 +537,8 @@ Item {
                 pendingGtkTheme = theme.gtkTheme;
             if (theme.iconTheme)
                 pendingIconTheme = theme.iconTheme;
+            if (theme.gtkColorScheme)
+                pendingGtkColorScheme = theme.gtkColorScheme;
         }
     }
 
@@ -502,6 +558,11 @@ Item {
     function stageIconTheme(theme: string): void {
         pendingIconTheme = theme;
         iconDirty = !!theme;
+    }
+
+    function stageGtkColorScheme(policy: string): void {
+        pendingGtkColorScheme = normalizeGtkColorScheme(policy);
+        gtkColorSchemeDirty = !!pendingGtkColorScheme;
     }
 
     function stageSchemeApply(name: string, flavour: string): void {
@@ -548,13 +609,16 @@ Item {
         deferredMode = "";
         deferredGtk = "";
         deferredIcon = "";
+        deferredGtkColorScheme = "";
         wallpaperDirty = false;
         gtkDirty = false;
         iconDirty = false;
+        gtkColorSchemeDirty = false;
         // Seed live GTK/icon so section checkmarks reflect current state.
         // Do not overwrite a user-staged selection if a previous seed is still in flight.
         liveGtkProc.running = true;
         liveIconProc.running = true;
+        liveGtkColorSchemeProc.running = true;
         applyFailed = false;
         applyStatusMessage = "";
         if (!previewActive) {
@@ -571,6 +635,7 @@ Item {
         Config.appearance.font.family.material = root.fontFamilyMaterial;
         Config.appearance.font.family.mono = root.fontFamilyMono;
         Config.appearance.font.family.sans = root.fontFamilySans;
+        Config.appearance.font.family.clock = root.fontFamilyClock;
         Config.appearance.font.size.scale = root.fontSizeScale;
 
         Config.appearance.padding.scale = root.paddingScale;
@@ -759,7 +824,7 @@ Item {
 
                     readonly property var rootPane: sidebarFlickable.rootPane
 
-                    readonly property bool allSectionsExpanded: themesSection.expanded && gtkThemeSection.expanded && iconThemeSection.expanded && themeModeSection.expanded && colorVariantSection.expanded && colorSchemeSection.expanded && animationsSection.expanded && fontsSection.expanded && scalesSection.expanded && transparencySection.expanded && borderSection.expanded && backgroundSection.expanded
+                    readonly property bool allSectionsExpanded: themesSection.expanded && themeModeSection.expanded && colorVariantSection.expanded && colorSchemeSection.expanded && gtkThemeSection.expanded && gtkColorSchemeSection.expanded && iconThemeSection.expanded && fontsSection.expanded && animationsSection.expanded && scalesSection.expanded && transparencySection.expanded && borderSection.expanded && backgroundSection.expanded
 
                     RowLayout {
                         spacing: Appearance.spacing.smaller
@@ -781,13 +846,14 @@ Item {
                             onClicked: {
                                 const shouldExpand = !sidebarLayout.allSectionsExpanded;
                                 themesSection.expanded = shouldExpand;
-                                gtkThemeSection.expanded = shouldExpand;
-                                iconThemeSection.expanded = shouldExpand;
                                 themeModeSection.expanded = shouldExpand;
                                 colorVariantSection.expanded = shouldExpand;
                                 colorSchemeSection.expanded = shouldExpand;
-                                animationsSection.expanded = shouldExpand;
+                                gtkThemeSection.expanded = shouldExpand;
+                                gtkColorSchemeSection.expanded = shouldExpand;
+                                iconThemeSection.expanded = shouldExpand;
                                 fontsSection.expanded = shouldExpand;
+                                animationsSection.expanded = shouldExpand;
                                 scalesSection.expanded = shouldExpand;
                                 transparencySection.expanded = shouldExpand;
                                 borderSection.expanded = shouldExpand;
@@ -798,18 +864,6 @@ Item {
 
                     ThemesSection {
                         id: themesSection
-                        session: root.session
-                        previewController: root
-                    }
-
-                    GtkThemeSection {
-                        id: gtkThemeSection
-                        session: root.session
-                        previewController: root
-                    }
-
-                    IconThemeSection {
-                        id: iconThemeSection
                         session: root.session
                         previewController: root
                     }
@@ -832,13 +886,31 @@ Item {
                         previewController: root
                     }
 
-                    AnimationsSection {
-                        id: animationsSection
-                        rootPane: sidebarFlickable.rootPane
+                    GtkThemeSection {
+                        id: gtkThemeSection
+                        session: root.session
+                        previewController: root
+                    }
+
+                    GtkColorSchemeSection {
+                        id: gtkColorSchemeSection
+                        session: root.session
+                        previewController: root
+                    }
+
+                    IconThemeSection {
+                        id: iconThemeSection
+                        session: root.session
+                        previewController: root
                     }
 
                     FontsSection {
                         id: fontsSection
+                        rootPane: sidebarFlickable.rootPane
+                    }
+
+                    AnimationsSection {
+                        id: animationsSection
                         rootPane: sidebarFlickable.rootPane
                     }
 
@@ -940,6 +1012,20 @@ Item {
         }
     }
 
+    Process {
+        id: liveGtkColorSchemeProc
+        command: ["dots-gtk-theme", "-q", "-p", "current-color-scheme"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                if (root.gtkColorSchemeDirty)
+                    return;
+                const policy = root.normalizeGtkColorScheme(text.trim());
+                if (policy)
+                    root.pendingGtkColorScheme = policy;
+            }
+        }
+    }
+
     Connections {
         target: root.session
 
@@ -957,6 +1043,7 @@ Item {
                 root.deferredMode = "";
                 root.deferredGtk = "";
                 root.deferredIcon = "";
+                root.deferredGtkColorScheme = "";
                 root.applyFailed = true;
                 root.applyStatusMessage = ThemePipeline.lastError || qsTr("Appearance apply failed");
                 return;
@@ -969,6 +1056,8 @@ Item {
                 liveGtkProc.running = true;
             if (!root.iconDirty)
                 liveIconProc.running = true;
+            if (!root.gtkColorSchemeDirty)
+                liveGtkColorSchemeProc.running = true;
             // User selected something else while we were busy — apply it now.
             if (root.hasPendingChanges)
                 root.commitPending();

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/AppearancePreviewPane.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/AppearancePreviewPane.qml
@@ -46,6 +46,39 @@ StyledRect {
         return mode === "light" ? qsTr("Light") : qsTr("Dark");
     }
 
+    function gtkColorSchemeLabel(value: string): string {
+        switch ((value || "").toLowerCase()) {
+        case "follow":
+            return qsTr("Follow theme mode");
+        case "default":
+        case "auto":
+            return qsTr("Auto (apps decide)");
+        case "prefer-light":
+        case "light":
+            return qsTr("Prefer light");
+        case "prefer-dark":
+        case "dark":
+            return qsTr("Prefer dark");
+        default:
+            return value || "—";
+        }
+    }
+
+    function gtkColorSchemeIcon(value: string): string {
+        switch ((value || "").toLowerCase()) {
+        case "follow":
+            return "sync";
+        case "default":
+        case "auto":
+            return "contrast";
+        case "prefer-light":
+        case "light":
+            return "light_mode";
+        default:
+            return "dark_mode";
+        }
+    }
+
     function basename(path: string): string {
         if (!path)
             return "";
@@ -324,9 +357,9 @@ StyledRect {
                             }
 
                             RecipeRow {
-                                icon: root.gtkPreferText === "prefer-light" ? "light_mode" : "dark_mode"
-                                label: qsTr("GTK prefer")
-                                value: root.gtkPreferText || "—"
+                                icon: root.gtkColorSchemeIcon(root.gtkPreferText)
+                                label: qsTr("GTK color scheme")
+                                value: root.gtkColorSchemeLabel(root.gtkPreferText)
                             }
 
                             RecipeRow {

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/sections/FontsSection.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/sections/FontsSection.qml
@@ -298,6 +298,99 @@ CollapsibleSection {
         }
     }
 
+    CollapsibleSection {
+        id: clockFontSection
+        title: qsTr("Clock font family")
+        expanded: false
+        showBackground: true
+        nested: true
+
+        Loader {
+            Layout.fillWidth: true
+            Layout.preferredHeight: item ? Math.min(item.contentHeight, 300) : 0
+            active: clockFontSection.expanded
+
+            sourceComponent: StyledListView {
+                id: clockFontList
+                property alias contentHeight: clockFontList.contentHeight
+
+                clip: true
+                spacing: Appearance.spacing.small / 2
+                model: Qt.fontFamilies()
+
+                StyledScrollBar.vertical: StyledScrollBar {
+                    flickable: clockFontList
+                }
+
+                delegate: StyledRect {
+                    required property string modelData
+                    required property int index
+
+                    width: ListView.view.width
+
+                    readonly property bool isCurrent: modelData === rootPane.fontFamilyClock
+                    color: Qt.alpha(Colours.tPalette.m3surfaceContainer, isCurrent ? Colours.tPalette.m3surfaceContainer.a : 0)
+                    radius: Appearance.rounding.normal
+                    border.width: isCurrent ? 1 : 0
+                    border.color: Colours.palette.m3primary
+
+                    StateLayer {
+                        function onClicked(): void {
+                            rootPane.fontFamilyClock = modelData;
+                            rootPane.saveConfig();
+                        }
+                    }
+
+                    ColumnLayout {
+                        id: fontFamilyClockRow
+
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.margins: Appearance.padding.normal
+
+                        spacing: 1
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: Appearance.spacing.normal
+
+                            StyledText {
+                                text: modelData
+                                font.pointSize: Appearance.font.size.normal
+                            }
+
+                            Item {
+                                Layout.fillWidth: true
+                            }
+
+                            Loader {
+                                active: isCurrent
+
+                                sourceComponent: MaterialIcon {
+                                    text: "check"
+                                    color: Colours.palette.m3onSurfaceVariant
+                                    font.pointSize: Appearance.font.size.large
+                                }
+                            }
+                        }
+
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: "12:34 · Thursday 13 Aug"
+                            font.family: modelData
+                            font.pointSize: Appearance.font.size.small
+                            color: Colours.palette.m3onSurfaceVariant
+                            elide: Text.ElideRight
+                        }
+                    }
+
+                    implicitHeight: fontFamilyClockRow.implicitHeight + Appearance.padding.normal * 2
+                }
+            }
+        }
+    }
+
     SectionContainer {
         contentSpacing: Appearance.spacing.normal
 

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/sections/GtkColorSchemeSection.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/sections/GtkColorSchemeSection.qml
@@ -1,0 +1,133 @@
+pragma ComponentBehavior: Bound
+
+import ".."
+import "../../../launcher/services"
+import qs.components
+import qs.components.controls
+import qs.components.containers
+import qs.services
+import qs.config
+import QtQuick
+import QtQuick.Layouts
+
+CollapsibleSection {
+    id: root
+
+    required property var previewController
+    required property var session
+
+    title: qsTr("GTK color scheme")
+    description: qsTr("Libadwaita / portals — independent from Theme mode. Auto lets apps decide.")
+    showBackground: true
+
+    readonly property var schemeOptions: [
+        {
+            id: "follow",
+            icon: "sync",
+            name: qsTr("Follow theme mode")
+        },
+        {
+            id: "default",
+            icon: "contrast",
+            name: qsTr("Auto (apps decide)")
+        },
+        {
+            id: "prefer-light",
+            icon: "light_mode",
+            name: qsTr("Prefer light")
+        },
+        {
+            id: "prefer-dark",
+            icon: "dark_mode",
+            name: qsTr("Prefer dark")
+        }
+    ]
+
+    readonly property string themeDefaultScheme: {
+        const id = previewController.pendingThemeId;
+        if (!id)
+            return "";
+        const theme = Themes.themeById(id);
+        if (!theme)
+            return "";
+        return theme.gtkColorScheme || "";
+    }
+
+    readonly property bool schemeDivergesFromTheme: themeDefaultScheme !== "" && previewController.pendingGtkColorScheme !== themeDefaultScheme
+
+    ColumnLayout {
+        Layout.fillWidth: true
+        spacing: Appearance.spacing.small / 2
+
+        Repeater {
+            model: root.schemeOptions
+
+            delegate: StyledRect {
+                required property var modelData
+
+                Layout.fillWidth: true
+
+                readonly property bool isCurrent: modelData.id === previewController.pendingGtkColorScheme
+
+                color: Qt.alpha(Colours.tPalette.m3surfaceContainer, isCurrent ? Colours.tPalette.m3surfaceContainer.a : 0)
+                radius: Appearance.rounding.normal
+                border.width: isCurrent ? 1 : 0
+                border.color: Colours.palette.m3primary
+
+                StateLayer {
+                    function onClicked(): void {
+                        previewController.startGtkColorSchemePreview(modelData.id);
+                        previewController.stageGtkColorScheme(modelData.id);
+                        previewController.commitPending();
+                    }
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.NoButton
+                    hoverEnabled: true
+                    onEntered: previewController.startGtkColorSchemePreview(modelData.id)
+                }
+
+                RowLayout {
+                    id: schemeRow
+
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.margins: Appearance.padding.normal
+
+                    spacing: Appearance.spacing.normal
+
+                    MaterialIcon {
+                        text: modelData.icon
+                        font.pointSize: Appearance.font.size.large
+                        fill: isCurrent ? 1 : 0
+                    }
+
+                    StyledText {
+                        Layout.fillWidth: true
+                        text: modelData.name
+                        font.weight: isCurrent ? 500 : 400
+                    }
+
+                    MaterialIcon {
+                        visible: isCurrent
+                        text: "check"
+                        color: Colours.palette.m3primary
+                        font.pointSize: Appearance.font.size.large
+                    }
+                }
+
+                implicitHeight: schemeRow.implicitHeight + Appearance.padding.normal * 2
+            }
+        }
+
+        StyledText {
+            visible: root.schemeDivergesFromTheme
+            text: qsTr("Differs from theme default (%1)").arg(root.themeDefaultScheme)
+            color: Colours.palette.m3outline
+            font.pointSize: Appearance.font.size.small
+        }
+    }
+}

--- a/home/dot_config/quickshell/modules/controlcenter/appearance/sections/ThemesSection.qml
+++ b/home/dot_config/quickshell/modules/controlcenter/appearance/sections/ThemesSection.qml
@@ -143,9 +143,9 @@ CollapsibleSection {
                                             bits.push(modelData.schemeType);
                                         if (modelData.gtkTheme)
                                             bits.push(modelData.gtkTheme);
-                                        const prefer = modelData.gtkPreferDark === undefined ? "" : (modelData.gtkPreferDark ? "prefer-dark" : "prefer-light");
-                                        if (prefer)
-                                            bits.push(prefer);
+                                        const scheme = modelData.gtkColorScheme || "";
+                                        if (scheme)
+                                            bits.push(scheme);
                                         if (modelData.iconTheme)
                                             bits.push(modelData.iconTheme);
                                         return bits.join(" · ");

--- a/home/dot_config/quickshell/modules/launcher/services/Themes.qml
+++ b/home/dot_config/quickshell/modules/launcher/services/Themes.qml
@@ -93,16 +93,25 @@ Searcher {
         readonly property string schemeType: modelData.schemeType || "tonal-spot"
         readonly property string gtkTheme: modelData.gtkTheme || "Orchis-Light-Compact"
         readonly property string iconTheme: modelData.iconTheme || ""
-        readonly property bool gtkPreferDark: {
+        readonly property string gtkColorScheme: {
+            const raw = (modelData.gtkColorScheme ?? "").toString().toLowerCase().replace(/_/g, "-");
+            switch (raw) {
+            case "follow":
+            case "default":
+            case "prefer-light":
+            case "prefer-dark":
+                return raw;
+            }
             if (modelData.gtkPreferDark !== undefined)
-                return !!modelData.gtkPreferDark;
+                return modelData.gtkPreferDark ? "prefer-dark" : "prefer-light";
             const gtk = gtkTheme.toLowerCase();
             if (gtk.indexOf("light") >= 0)
-                return false;
+                return "prefer-light";
             if (gtk.indexOf("dark") >= 0)
-                return true;
-            return darkMode;
+                return "prefer-dark";
+            return darkMode ? "prefer-dark" : "prefer-light";
         }
+        readonly property bool gtkPreferDark: gtkColorScheme === "prefer-dark" || gtkColorScheme === "follow" && darkMode
         function onClicked(list: AppList): void {
             list.visibilities.launcher = false;
             ThemePipeline.applyTheme(id, wallpaperPath || "");

--- a/home/dot_config/quickshell/services/ThemePipeline.qml
+++ b/home/dot_config/quickshell/services/ThemePipeline.qml
@@ -30,6 +30,8 @@ Singleton {
     property string _pendingThemeId: ""
     // "true" | "false" | "" (infer from gtk theme name / shell mode)
     property string _pendingGtkPreferDark: ""
+    // follow | default | prefer-light | prefer-dark | "" (wallpaper jobs sync live policy)
+    property string _pendingGtkColorScheme: ""
     property bool _runThemeSideEffects: false
     property string _lastError: ""
     readonly property string lastError: _lastError
@@ -38,14 +40,8 @@ Singleton {
     signal applyFinished(bool ok)
 
     function resolveGtkPreferDark(cfg: var, darkMode: bool): string {
-        if (cfg && cfg.gtkPreferDark !== undefined && cfg.gtkPreferDark !== null && cfg.gtkPreferDark !== "")
-            return cfg.gtkPreferDark ? "true" : "false";
-        const gtk = ((cfg && cfg.gtkTheme) ? cfg.gtkTheme : "").toLowerCase();
-        if (gtk.indexOf("light") >= 0)
-            return "false";
-        if (gtk.indexOf("dark") >= 0)
-            return "true";
-        return darkMode ? "true" : "false";
+        const scheme = root.resolveGtkColorScheme(cfg, darkMode);
+        return scheme === "prefer-light" || scheme === "default" ? "false" : "true";
     }
 
     function resolveGtkPreferFromName(gtkTheme: string, darkMode: bool): string {
@@ -55,6 +51,50 @@ Singleton {
         if (gtk.indexOf("dark") >= 0)
             return "true";
         return darkMode ? "true" : "false";
+    }
+
+    function normalizeGtkColorScheme(value: string): string {
+        const raw = (value ?? "").toLowerCase().replace(/_/g, "-");
+        switch (raw) {
+        case "follow":
+        case "follow-mode":
+        case "follow-theme":
+        case "follow-theme-mode":
+            return "follow";
+        case "default":
+        case "auto":
+        case "apps":
+        case "apps-decide":
+            return "default";
+        case "prefer-light":
+        case "light":
+        case "false":
+        case "0":
+        case "no":
+            return "prefer-light";
+        case "prefer-dark":
+        case "dark":
+        case "true":
+        case "1":
+        case "yes":
+            return "prefer-dark";
+        default:
+            return "";
+        }
+    }
+
+    function resolveGtkColorScheme(cfg: var, darkMode: bool): string {
+        const fromField = root.normalizeGtkColorScheme((cfg && cfg.gtkColorScheme) ? String(cfg.gtkColorScheme) : "");
+        if (fromField)
+            return fromField;
+        if (cfg && cfg.gtkPreferDark !== undefined && cfg.gtkPreferDark !== null && cfg.gtkPreferDark !== "")
+            return cfg.gtkPreferDark ? "prefer-dark" : "prefer-light";
+        const gtk = ((cfg && cfg.gtkTheme) ? cfg.gtkTheme : "").toLowerCase();
+        if (gtk.indexOf("light") >= 0)
+            return "prefer-light";
+        if (gtk.indexOf("dark") >= 0)
+            return "prefer-dark";
+        return darkMode ? "prefer-dark" : "prefer-light";
     }
 
     function applyTheme(id: string, wallpaperPath: string): void {
@@ -91,6 +131,16 @@ Singleton {
         });
     }
 
+    function setGtkColorScheme(policy: string): void {
+        const normalized = root.normalizeGtkColorScheme(policy);
+        if (!normalized)
+            return;
+        _enqueue({
+            kind: "gtk-color-scheme",
+            gtkColorScheme: normalized
+        });
+    }
+
     function setIcons(theme: string): void {
         if (!theme)
             return;
@@ -102,7 +152,7 @@ Singleton {
 
     function _enqueue(job: var): void {
         const tail = _queue.length ? _queue[_queue.length - 1] : null;
-        if (tail && tail.kind === job.kind && tail.themeId === job.themeId && tail.wallpaper === job.wallpaper && tail.gtkTheme === job.gtkTheme && tail.iconTheme === job.iconTheme)
+        if (tail && tail.kind === job.kind && tail.themeId === job.themeId && tail.wallpaper === job.wallpaper && tail.gtkTheme === job.gtkTheme && tail.iconTheme === job.iconTheme && tail.gtkColorScheme === job.gtkColorScheme)
             return;
         _queue = _queue.concat([job]);
         _pump();
@@ -122,6 +172,7 @@ Singleton {
         _pendingThemeName = "";
         _pendingThemeId = "";
         _pendingGtkPreferDark = "";
+        _pendingGtkColorScheme = "";
 
         if (job.kind === "theme") {
             _runThemeSideEffects = true;
@@ -141,9 +192,10 @@ Singleton {
             walReloadProc.running = true;
         } else if (job.kind === "gtk") {
             gtkStandaloneProc.themeName = job.gtkTheme || "";
-            gtkStandaloneProc.mode = Colours.currentLight ? "light" : "dark";
-            gtkStandaloneProc.preferDark = root.resolveGtkPreferFromName(job.gtkTheme || "", !Colours.currentLight);
             gtkStandaloneProc.running = true;
+        } else if (job.kind === "gtk-color-scheme") {
+            gtkColorSchemeProc.policy = job.gtkColorScheme || "follow";
+            gtkColorSchemeProc.running = true;
         } else if (job.kind === "icons") {
             iconOnlyProc.themeName = job.iconTheme || "";
             iconOnlyProc.running = true;
@@ -223,6 +275,7 @@ Singleton {
             root._pendingIconTheme = cfg.iconTheme || "";
             root._pendingThemeName = cfg.name || themeLoader.themeId;
             root._pendingGtkPreferDark = root.resolveGtkPreferDark(cfg, root._pendingDarkMode);
+            root._pendingGtkColorScheme = root.resolveGtkColorScheme(cfg, root._pendingDarkMode);
 
             const wp = themeLoader.wallpaperOverride;
             if (wp) {
@@ -286,6 +339,7 @@ done
         _pendingSchemeType = cfg.schemeType || "tonal-spot";
         _pendingDarkMode = cfg.darkMode !== undefined ? !!cfg.darkMode : true;
         _pendingGtkPreferDark = root.resolveGtkPreferDark(cfg, _pendingDarkMode);
+        _pendingGtkColorScheme = root.resolveGtkColorScheme(cfg, _pendingDarkMode);
         walPrepProc.running = true;
     }
 
@@ -374,8 +428,7 @@ done
             gtkFinalizeProc.themeName = root._runThemeSideEffects ? (root._pendingGtkTheme || "") : "";
             gtkFinalizeProc.iconTheme = root._runThemeSideEffects ? (root._pendingIconTheme || "") : "";
             gtkFinalizeProc.themeId = root._runThemeSideEffects ? (root._pendingThemeId || "") : "";
-            gtkFinalizeProc.mode = root._pendingDarkMode ? "dark" : "light";
-            gtkFinalizeProc.preferDark = root._pendingGtkPreferDark || root.resolveGtkPreferFromName(root._pendingGtkTheme, root._pendingDarkMode);
+            gtkFinalizeProc.colorScheme = root._runThemeSideEffects ? (root._pendingGtkColorScheme || "") : "";
             gtkFinalizeProc.running = true;
         }
     }
@@ -391,40 +444,35 @@ done
         property string themeName: ""
         property string iconTheme: ""
         property string themeId: ""
-        property string mode: "dark"
-        property string preferDark: "true"
+        property string colorScheme: ""
         command: ["bash", "-c", `
 set -euo pipefail
-prefer="\${DOTS_GTK_PREFER:-}"
-if [[ -z "\$prefer" ]]; then
-  prefer=$([[ "\${DOTS_MODE}" == "light" ]] && echo false || echo true)
-fi
+policy="\${DOTS_GTK_COLOR_SCHEME:-}"
 if [[ -n "\${DOTS_THEME_ID:-}" && ( -z "\${DOTS_GTK_THEME:-}" || "\${DOTS_GTK_THEME}" == "auto" ) ]]; then
   dots-gtk-theme -q theme "\${DOTS_THEME_ID}" || true
-  if [[ "\$prefer" == "false" ]]; then
-    dots-gtk-theme -q color-scheme light || true
+  if [[ -n "\$policy" ]]; then
+    dots-gtk-theme -q color-scheme "\$policy" || true
   else
-    dots-gtk-theme -q color-scheme dark || true
+    dots-gtk-theme -q sync-color-scheme || true
   fi
 elif [[ -n "\${DOTS_GTK_THEME:-}" && "\${DOTS_GTK_THEME}" != "auto" ]]; then
-  if [[ -n "\${DOTS_ICON_THEME:-}" ]]; then
-    dots-gtk-theme -q apply "\${DOTS_GTK_THEME}" "\${DOTS_ICON_THEME}" "\$prefer" || true
+  if [[ -n "\$policy" ]]; then
+    dots-gtk-theme -q apply "\${DOTS_GTK_THEME}" "\${DOTS_ICON_THEME:-}" "\$policy" || true
   else
-    # Omit icon: dots-gtk-theme apply resolves the live icon theme.
-    dots-gtk-theme -q apply "\${DOTS_GTK_THEME}" "" "\$prefer" || true
+    dots-gtk-theme -q apply "\${DOTS_GTK_THEME}" "\${DOTS_ICON_THEME:-}" || true
   fi
 elif [[ -n "\${DOTS_ICON_THEME:-}" ]]; then
   dots-gtk-theme -q set-icons "\${DOTS_ICON_THEME}" || true
-  if [[ "\$prefer" == "false" ]]; then
-    dots-gtk-theme -q color-scheme light || true
+  if [[ -n "\$policy" ]]; then
+    dots-gtk-theme -q color-scheme "\$policy" || true
   else
-    dots-gtk-theme -q color-scheme dark || true
+    dots-gtk-theme -q sync-color-scheme || true
   fi
 else
-  if [[ "\$prefer" == "false" ]]; then
-    dots-gtk-theme -q color-scheme light || true
+  if [[ -n "\$policy" ]]; then
+    dots-gtk-theme -q color-scheme "\$policy" || true
   else
-    dots-gtk-theme -q color-scheme dark || true
+    dots-gtk-theme -q sync-color-scheme || true
   fi
 fi
 `]
@@ -432,36 +480,29 @@ fi
             "DOTS_GTK_THEME": gtkFinalizeProc.themeName,
             "DOTS_ICON_THEME": gtkFinalizeProc.iconTheme,
             "DOTS_THEME_ID": gtkFinalizeProc.themeId,
-            "DOTS_MODE": gtkFinalizeProc.mode,
-            "DOTS_GTK_PREFER": gtkFinalizeProc.preferDark
+            "DOTS_GTK_COLOR_SCHEME": gtkFinalizeProc.colorScheme
         })
         onExited: (exitCode, exitStatus) => {
             root._finishJob(true, "");
         }
     }
 
-    // Queued GTK override through dots-gtk-theme.
+    // Queued GTK override through dots-gtk-theme. Preserves live gtkColorScheme.
     Process {
         id: gtkStandaloneProc
         property string themeName: ""
-        property string mode: "dark"
-        property string preferDark: "true"
-        command: ["bash", "-c", `
-set -euo pipefail
-prefer="\${DOTS_GTK_PREFER:-}"
-if [[ -z "\$prefer" ]]; then
-  prefer=$([[ "\${DOTS_MODE}" == "light" ]] && echo false || echo true)
-fi
-# Omit icon: dots-gtk-theme apply resolves the live icon theme.
-dots-gtk-theme -q apply "\${DOTS_GTK_THEME}" "" "\$prefer"
-`]
-        environment: ({
-            "DOTS_GTK_THEME": gtkStandaloneProc.themeName,
-            "DOTS_MODE": gtkStandaloneProc.mode,
-            "DOTS_GTK_PREFER": gtkStandaloneProc.preferDark
-        })
+        command: ["dots-gtk-theme", "-q", "apply", gtkStandaloneProc.themeName]
         onExited: (exitCode, exitStatus) => {
             root._finishJob(exitCode === 0, exitCode === 0 ? "" : `setGtk failed (exit ${exitCode})`);
+        }
+    }
+
+    Process {
+        id: gtkColorSchemeProc
+        property string policy: "follow"
+        command: ["dots-gtk-theme", "-q", "color-scheme", gtkColorSchemeProc.policy]
+        onExited: (exitCode, exitStatus) => {
+            root._finishJob(exitCode === 0, exitCode === 0 ? "" : `setGtkColorScheme failed (exit ${exitCode})`);
         }
     }
 
@@ -534,6 +575,10 @@ dots-gtk-theme -q apply "\${DOTS_GTK_THEME}" "" "\$prefer"
 
         function setGtk(theme: string): void {
             root.setGtk(theme);
+        }
+
+        function setGtkColorScheme(policy: string): void {
+            root.setGtkColorScheme(policy);
         }
 
         function setIcons(theme: string): void {

--- a/home/dot_local/bin/executable_dots-appearance
+++ b/home/dot_local/bin/executable_dots-appearance
@@ -14,428 +14,428 @@ cmd="${1:-}"
 shift 2>/dev/null || true
 
 json_escape() {
-  python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1"
+	python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1"
 }
 
 _wait_appearance_ipc() {
-  local _i busy="" last_error
-  for _i in $(seq 1 120); do
-    if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
-      echo "Error: failed to poll appearance isBusy via Quickshell IPC" >&2
-      return 1
-    fi
-    busy="${busy//$'\r'/}"
-    busy="${busy//$'\n'/}"
-    [[ $busy == "1" ]] || break
-    sleep 0.5
-  done
-  if [[ $busy == "1" ]]; then
-    echo "Error: appearance apply timed out waiting for Quickshell" >&2
-    return 1
-  fi
-  last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
-  last_error="${last_error//$'\r'/}"
-  last_error="${last_error//$'\n'/}"
-  if [[ -n $last_error ]]; then
-    echo "Error: appearance apply failed: $last_error" >&2
-    return 1
-  fi
-  return 0
+	local _i busy="" last_error
+	for _i in $(seq 1 120); do
+		if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
+			echo "Error: failed to poll appearance isBusy via Quickshell IPC" >&2
+			return 1
+		fi
+		busy="${busy//$'\r'/}"
+		busy="${busy//$'\n'/}"
+		[[ $busy == "1" ]] || break
+		sleep 0.5
+	done
+	if [[ $busy == "1" ]]; then
+		echo "Error: appearance apply timed out waiting for Quickshell" >&2
+		return 1
+	fi
+	last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
+	last_error="${last_error//$'\r'/}"
+	last_error="${last_error//$'\n'/}"
+	if [[ -n $last_error ]]; then
+		echo "Error: appearance apply failed: $last_error" >&2
+		return 1
+	fi
+	return 0
 }
 
 cmd_theme_list() {
-  local script="${HOME}/.local/lib/dots/list-themes.py"
-  if [[ -f $script ]]; then
-    python3 "$script" "$THEMES_DIR"
-  else
-    echo "[]"
-  fi
+	local script="${HOME}/.local/lib/dots/list-themes.py"
+	if [[ -f $script ]]; then
+		python3 "$script" "$THEMES_DIR"
+	else
+		echo "[]"
+	fi
 }
 
 cmd_theme_show() {
-  local id="${1:-}"
-  [[ -n $id ]] || {
-    echo "Usage: dots-appearance theme show <id>" >&2
-    exit 1
-  }
-  local path="${THEMES_DIR}/${id}/theme.json"
-  [[ -f $path ]] || {
-    echo "Theme not found: $id" >&2
-    exit 1
-  }
-  cat "$path"
+	local id="${1:-}"
+	[[ -n $id ]] || {
+		echo "Usage: dots-appearance theme show <id>" >&2
+		exit 1
+	}
+	local path="${THEMES_DIR}/${id}/theme.json"
+	[[ -f $path ]] || {
+		echo "Theme not found: $id" >&2
+		exit 1
+	}
+	cat "$path"
 }
 
 _shell_theme_apply() {
-  local id="$1"
-  local wallpaper="${2:-}"
-  # shellcheck source=/dev/null
-  source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
-  # shellcheck source=/dev/null
-  source "$HOME/.local/lib/dots/apply-appearance.sh"
-  dots_apply_theme "$id" "$wallpaper"
+	local id="$1"
+	local wallpaper="${2:-}"
+	# shellcheck source=/dev/null
+	source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
+	# shellcheck source=/dev/null
+	source "$HOME/.local/lib/dots/apply-appearance.sh"
+	dots_apply_theme "$id" "$wallpaper"
 }
 
 cmd_theme_apply() {
-  local id="${1:-}"
-  local wallpaper=""
-  shift 2>/dev/null || true
-  while [[ $# -gt 0 ]]; do
-    case "${1:-}" in
-      --wallpaper)
-        [[ -n ${2:-} ]] || {
-          echo "dots-appearance theme apply: --wallpaper requires a path" >&2
-          exit 1
-        }
-        wallpaper="$2"
-        shift 2
-        ;;
-      *)
-        echo "dots-appearance theme apply: unknown argument: $1" >&2
-        exit 1
-        ;;
-    esac
-  done
+	local id="${1:-}"
+	local wallpaper=""
+	shift 2>/dev/null || true
+	while [[ $# -gt 0 ]]; do
+		case "${1:-}" in
+		--wallpaper)
+			[[ -n ${2:-} ]] || {
+				echo "dots-appearance theme apply: --wallpaper requires a path" >&2
+				exit 1
+			}
+			wallpaper="$2"
+			shift 2
+			;;
+		*)
+			echo "dots-appearance theme apply: unknown argument: $1" >&2
+			exit 1
+			;;
+		esac
+	done
 
-  [[ -n $id ]] || {
-    echo "Usage: dots-appearance theme apply <id> [--wallpaper <path>]" >&2
-    exit 1
-  }
+	[[ -n $id ]] || {
+		echo "Usage: dots-appearance theme apply <id> [--wallpaper <path>]" >&2
+		exit 1
+	}
 
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    local ipc_out=""
-    if ipc_out="$(quickshell ipc call appearance applyTheme "$id" "${wallpaper:-}" 2>&1)"; then
-      case "$ipc_out" in
-        "Target not found."* | *"Target not found"*)
-          echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
-          ;;
-        *)
-          _wait_appearance_ipc || exit 1
-          exit 0
-          ;;
-      esac
-    else
-      echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
-    fi
-  fi
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		local ipc_out=""
+		if ipc_out="$(quickshell ipc call appearance applyTheme "$id" "${wallpaper:-}" 2>&1)"; then
+			case "$ipc_out" in
+			"Target not found."* | *"Target not found"*)
+				echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
+				;;
+			*)
+				_wait_appearance_ipc || exit 1
+				exit 0
+				;;
+			esac
+		else
+			echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
+		fi
+	fi
 
-  _shell_theme_apply "$id" "$wallpaper"
+	_shell_theme_apply "$id" "$wallpaper"
 }
 
 cmd_theme() {
-  local sub="${1:-}"
-  shift 2>/dev/null || true
-  case "$sub" in
-    list) cmd_theme_list ;;
-    show) cmd_theme_show "${1:-}" ;;
-    apply) cmd_theme_apply "$@" ;;
-    *)
-      cat <<'EOF' >&2
+	local sub="${1:-}"
+	shift 2>/dev/null || true
+	case "$sub" in
+	list) cmd_theme_list ;;
+	show) cmd_theme_show "${1:-}" ;;
+	apply) cmd_theme_apply "$@" ;;
+	*)
+		cat <<'EOF' >&2
 Usage: dots-appearance theme <list|show|apply> …
 
   theme list
   theme show <id>
   theme apply <id> [--wallpaper <path>]
 EOF
-      exit 1
-      ;;
-  esac
+		exit 1
+		;;
+	esac
 }
 
 cmd_status() {
-  local wallpaper="" mode="" flavour="" gtk_theme="" icon_theme="" gtk_color_scheme=""
-  if command -v dots-wallpaper-current >/dev/null 2>&1; then
-    wallpaper="$(dots-wallpaper-current 2>/dev/null || true)"
-  fi
-  local state_file="${HOME}/.local/state/dots/scheme/state.json"
-  if [[ -f $state_file ]]; then
-    flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
-    mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
-    gtk_color_scheme="$(python3 -c "import json;print(json.load(open('$state_file')).get('gtkColorScheme','') or 'follow')" 2>/dev/null || true)"
-  fi
-  [[ -n $gtk_color_scheme ]] || gtk_color_scheme="follow"
-  if [[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini ]]; then
-    gtk_theme="$(grep -E '^gtk-theme-name=' "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-  fi
-  if command -v gsettings >/dev/null 2>&1; then
-    icon_theme="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'\"" || true)"
-  fi
+	local wallpaper="" mode="" flavour="" gtk_theme="" icon_theme="" gtk_color_scheme=""
+	if command -v dots-wallpaper-current >/dev/null 2>&1; then
+		wallpaper="$(dots-wallpaper-current 2>/dev/null || true)"
+	fi
+	local state_file="${HOME}/.local/state/dots/scheme/state.json"
+	if [[ -f $state_file ]]; then
+		flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
+		mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
+		gtk_color_scheme="$(python3 -c "import json;print(json.load(open('$state_file')).get('gtkColorScheme','') or 'follow')" 2>/dev/null || true)"
+	fi
+	[[ -n $gtk_color_scheme ]] || gtk_color_scheme="follow"
+	if [[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini ]]; then
+		gtk_theme="$(grep -E '^gtk-theme-name=' "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+	fi
+	if command -v gsettings >/dev/null 2>&1; then
+		icon_theme="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'\"" || true)"
+	fi
 
-  if [[ ${1:-} == "--json" ]]; then
-    printf '{"wallpaper":%s,"mode":%s,"flavour":%s,"gtkTheme":%s,"iconTheme":%s,"gtkColorScheme":%s}\n' \
-      "$(json_escape "${wallpaper:-}")" \
-      "$(json_escape "${mode:-}")" \
-      "$(json_escape "${flavour:-}")" \
-      "$(json_escape "${gtk_theme:-}")" \
-      "$(json_escape "${icon_theme:-}")" \
-      "$(json_escape "${gtk_color_scheme:-}")"
-  else
-    echo "wallpaper      : ${wallpaper:-}"
-    echo "mode           : ${mode:-}"
-    echo "flavour        : ${flavour:-}"
-    echo "gtkTheme       : ${gtk_theme:-}"
-    echo "iconTheme      : ${icon_theme:-}"
-    echo "gtkColorScheme : ${gtk_color_scheme:-}"
-  fi
+	if [[ ${1:-} == "--json" ]]; then
+		printf '{"wallpaper":%s,"mode":%s,"flavour":%s,"gtkTheme":%s,"iconTheme":%s,"gtkColorScheme":%s}\n' \
+			"$(json_escape "${wallpaper:-}")" \
+			"$(json_escape "${mode:-}")" \
+			"$(json_escape "${flavour:-}")" \
+			"$(json_escape "${gtk_theme:-}")" \
+			"$(json_escape "${icon_theme:-}")" \
+			"$(json_escape "${gtk_color_scheme:-}")"
+	else
+		echo "wallpaper      : ${wallpaper:-}"
+		echo "mode           : ${mode:-}"
+		echo "flavour        : ${flavour:-}"
+		echo "gtkTheme       : ${gtk_theme:-}"
+		echo "iconTheme      : ${icon_theme:-}"
+		echo "gtkColorScheme : ${gtk_color_scheme:-}"
+	fi
 }
 
 cmd_set_wallpaper() {
-  local wallpaper="${1:-}"
-  [[ -n $wallpaper ]] || {
-    echo "Usage: dots-appearance set-wallpaper <path>" >&2
-    exit 1
-  }
-  dots-wallpaper-set "$wallpaper"
+	local wallpaper="${1:-}"
+	[[ -n $wallpaper ]] || {
+		echo "Usage: dots-appearance set-wallpaper <path>" >&2
+		exit 1
+	}
+	dots-wallpaper-set "$wallpaper"
 }
 
 cmd_set_variant() {
-  dots-color-scheme variant "${1:-}"
+	dots-color-scheme variant "${1:-}"
 }
 
 cmd_set_mode() {
-  dots-color-scheme mode "${1:-}"
+	dots-color-scheme mode "${1:-}"
 }
 
 cmd_set_gtk() {
-  local theme="${1:-}"
-  [[ -n $theme ]] || {
-    echo "Usage: dots-appearance set-gtk <theme>" >&2
-    exit 1
-  }
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    if quickshell ipc call appearance setGtk "$theme" >/dev/null 2>&1; then
-      _wait_appearance_ipc || exit 1
-      exit 0
-    fi
-  fi
-  local icon
-  icon="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'" || true)"
-  [[ -n $icon ]] || icon="Numix-Circle"
-  # Omit color-scheme so live gtkColorScheme policy is preserved.
-  dots-gtk-theme -q apply "$theme" "$icon"
+	local theme="${1:-}"
+	[[ -n $theme ]] || {
+		echo "Usage: dots-appearance set-gtk <theme>" >&2
+		exit 1
+	}
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		if quickshell ipc call appearance setGtk "$theme" >/dev/null 2>&1; then
+			_wait_appearance_ipc || exit 1
+			exit 0
+		fi
+	fi
+	local icon
+	icon="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'" || true)"
+	[[ -n $icon ]] || icon="Numix-Circle"
+	# Omit color-scheme so live gtkColorScheme policy is preserved.
+	dots-gtk-theme -q apply "$theme" "$icon"
 }
 
 cmd_set_gtk_color_scheme() {
-  local policy="${1:-}"
-  [[ -n $policy ]] || {
-    echo "Usage: dots-appearance set-gtk-color-scheme <follow|default|prefer-light|prefer-dark>" >&2
-    exit 1
-  }
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    if quickshell ipc call appearance setGtkColorScheme "$policy" >/dev/null 2>&1; then
-      _wait_appearance_ipc || exit 1
-      exit 0
-    fi
-  fi
-  dots-gtk-theme -q color-scheme "$policy"
+	local policy="${1:-}"
+	[[ -n $policy ]] || {
+		echo "Usage: dots-appearance set-gtk-color-scheme <follow|default|prefer-light|prefer-dark>" >&2
+		exit 1
+	}
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		if quickshell ipc call appearance setGtkColorScheme "$policy" >/dev/null 2>&1; then
+			_wait_appearance_ipc || exit 1
+			exit 0
+		fi
+	fi
+	dots-gtk-theme -q color-scheme "$policy"
 }
 
 cmd_set_icons() {
-  local theme="${1:-}"
-  [[ -n $theme ]] || {
-    echo "Usage: dots-appearance set-icons <theme>" >&2
-    exit 1
-  }
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    if quickshell ipc call appearance setIcons "$theme" >/dev/null 2>&1; then
-      _wait_appearance_ipc || exit 1
-      exit 0
-    fi
-  fi
-  dots-gtk-theme -q set-icons "$theme"
+	local theme="${1:-}"
+	[[ -n $theme ]] || {
+		echo "Usage: dots-appearance set-icons <theme>" >&2
+		exit 1
+	}
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		if quickshell ipc call appearance setIcons "$theme" >/dev/null 2>&1; then
+			_wait_appearance_ipc || exit 1
+			exit 0
+		fi
+	fi
+	dots-gtk-theme -q set-icons "$theme"
 }
 
 cmd_sync() {
-  if pgrep -x quickshell >/dev/null 2>&1; then
-    if quickshell ipc call appearance reload >/dev/null 2>&1; then
-      _wait_appearance_ipc || exit 1
-    fi
-  fi
-  dots-color-scheme sync-state >/dev/null 2>&1 || true
+	if pgrep -x quickshell >/dev/null 2>&1; then
+		if quickshell ipc call appearance reload >/dev/null 2>&1; then
+			_wait_appearance_ipc || exit 1
+		fi
+	fi
+	dots-color-scheme sync-state >/dev/null 2>&1 || true
 }
 
 cmd_doctor() {
-  local ok=0
-  local scheme_flavour="" state_flavour="" scheme_mode="" state_mode=""
-  local pointer="" resolved="" wal_target=""
+	local ok=0
+	local scheme_flavour="" state_flavour="" scheme_mode="" state_mode=""
+	local pointer="" resolved="" wal_target=""
 
-  # One-time purge of removed rice state / legacy pointers.
-  rm -f "$HOME/.local/share/dots/rices/.current_rice" \
-    "$HOME/.cache/dots/current_rice" \
-    "$HOME/.local/state/dots/rice/current" 2>/dev/null || true
-  rmdir "$HOME/.local/state/dots/rice" 2>/dev/null || true
+	# One-time purge of removed rice state / legacy pointers.
+	rm -f "$HOME/.local/share/dots/rices/.current_rice" \
+		"$HOME/.cache/dots/current_rice" \
+		"$HOME/.local/state/dots/rice/current" 2>/dev/null || true
+	rmdir "$HOME/.local/state/dots/rice" 2>/dev/null || true
 
-  local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
-  local state_file="${HOME}/.local/state/dots/scheme/state.json"
-  if [[ -f $scheme_file ]]; then
-    scheme_flavour="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('flavour',''))" 2>/dev/null || true)"
-    scheme_mode="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('mode',''))" 2>/dev/null || true)"
-  fi
-  if [[ -f $state_file ]]; then
-    state_flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
-    state_mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
-  fi
+	local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
+	local state_file="${HOME}/.local/state/dots/scheme/state.json"
+	if [[ -f $scheme_file ]]; then
+		scheme_flavour="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('flavour',''))" 2>/dev/null || true)"
+		scheme_mode="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('mode',''))" 2>/dev/null || true)"
+	fi
+	if [[ -f $state_file ]]; then
+		state_flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
+		state_mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
+	fi
 
-  pointer="${DOTS_WALLPAPER_POINTER_FILE:-$HOME/.local/state/dots/wallpaper/path}"
-  local pointer_val=""
-  [[ -f $pointer ]] && pointer_val="$(head -n 1 "$pointer" | tr -d '\r')"
-  if command -v dots-wallpaper-current >/dev/null 2>&1; then
-    resolved="$(dots-wallpaper-current 2>/dev/null || true)"
-  fi
-  if [[ -L $HOME/.cache/wal/wal ]]; then
-    wal_target="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
-  elif [[ -f $HOME/.cache/wal/wal ]]; then
-    wal_target="$(head -n 1 "$HOME/.cache/wal/wal" | tr -d '\r')"
-    wal_target="$(readlink -f "$wal_target" 2>/dev/null || true)"
-  fi
+	pointer="${DOTS_WALLPAPER_POINTER_FILE:-$HOME/.local/state/dots/wallpaper/path}"
+	local pointer_val=""
+	[[ -f $pointer ]] && pointer_val="$(head -n 1 "$pointer" | tr -d '\r')"
+	if command -v dots-wallpaper-current >/dev/null 2>&1; then
+		resolved="$(dots-wallpaper-current 2>/dev/null || true)"
+	fi
+	if [[ -L $HOME/.cache/wal/wal ]]; then
+		wal_target="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
+	elif [[ -f $HOME/.cache/wal/wal ]]; then
+		wal_target="$(head -n 1 "$HOME/.cache/wal/wal" | tr -d '\r')"
+		wal_target="$(readlink -f "$wal_target" 2>/dev/null || true)"
+	fi
 
-  echo "=== dots-appearance doctor ==="
-  echo "scheme.flavour : ${scheme_flavour:-"(missing)"}"
-  echo "state.flavour  : ${state_flavour:-"(missing)"}"
-  echo "scheme.mode    : ${scheme_mode:-"(missing)"}"
-  echo "state.mode     : ${state_mode:-"(missing)"}"
-  local hyprlock_conf="${HOME}/.cache/dots/smart-colors/colors-hyprlock.conf"
-  local hyprlock_bytes=0
-  [[ -f $hyprlock_conf ]] && hyprlock_bytes="$(wc -c <"$hyprlock_conf" | tr -d ' ')"
-  local gtk_theme_ini="" gtk_prefer_dark="" gtk_color_scheme="" gtk_color_policy=""
-  if [[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini ]]; then
-    gtk_theme_ini="$(grep -E '^gtk-theme-name=' "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-    gtk_prefer_dark="$(grep -E '^gtk-application-prefer-dark-theme=' "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-  fi
-  if command -v gsettings >/dev/null 2>&1; then
-    gtk_color_scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'\"" || true)"
-  fi
-  if [[ -f $state_file ]]; then
-    gtk_color_policy="$(python3 -c "import json;print(json.load(open('$state_file')).get('gtkColorScheme','') or 'follow')" 2>/dev/null || true)"
-  fi
-  [[ -n $gtk_color_policy ]] || gtk_color_policy="follow"
+	echo "=== dots-appearance doctor ==="
+	echo "scheme.flavour : ${scheme_flavour:-"(missing)"}"
+	echo "state.flavour  : ${state_flavour:-"(missing)"}"
+	echo "scheme.mode    : ${scheme_mode:-"(missing)"}"
+	echo "state.mode     : ${state_mode:-"(missing)"}"
+	local hyprlock_conf="${HOME}/.cache/dots/smart-colors/colors-hyprlock.conf"
+	local hyprlock_bytes=0
+	[[ -f $hyprlock_conf ]] && hyprlock_bytes="$(wc -c <"$hyprlock_conf" | tr -d ' ')"
+	local gtk_theme_ini="" gtk_prefer_dark="" gtk_color_scheme="" gtk_color_policy=""
+	if [[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini ]]; then
+		gtk_theme_ini="$(grep -E '^gtk-theme-name=' "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+		gtk_prefer_dark="$(grep -E '^gtk-application-prefer-dark-theme=' "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+	fi
+	if command -v gsettings >/dev/null 2>&1; then
+		gtk_color_scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'\"" || true)"
+	fi
+	if [[ -f $state_file ]]; then
+		gtk_color_policy="$(python3 -c "import json;print(json.load(open('$state_file')).get('gtkColorScheme','') or 'follow')" 2>/dev/null || true)"
+	fi
+	[[ -n $gtk_color_policy ]] || gtk_color_policy="follow"
 
-  echo "wallpaper.ptr  : ${pointer_val:-"(missing)"}"
-  echo "wallpaper.res  : ${resolved:-"(missing)"}"
-  echo "wal.target     : ${wal_target:-"(missing)"}"
-  echo "hyprlock.conf  : ${hyprlock_bytes} bytes"
-  echo "gtk.theme.ini  : ${gtk_theme_ini:-"(missing)"}"
-  echo "gtk.preferDark : ${gtk_prefer_dark:-"(missing)"}"
-  echo "gtk.colorPolicy: ${gtk_color_policy}"
-  echo "gtk.colorScheme: ${gtk_color_scheme:-"(missing)"}"
+	echo "wallpaper.ptr  : ${pointer_val:-"(missing)"}"
+	echo "wallpaper.res  : ${resolved:-"(missing)"}"
+	echo "wal.target     : ${wal_target:-"(missing)"}"
+	echo "hyprlock.conf  : ${hyprlock_bytes} bytes"
+	echo "gtk.theme.ini  : ${gtk_theme_ini:-"(missing)"}"
+	echo "gtk.preferDark : ${gtk_prefer_dark:-"(missing)"}"
+	echo "gtk.colorPolicy: ${gtk_color_policy}"
+	echo "gtk.colorScheme: ${gtk_color_scheme:-"(missing)"}"
 
-  if [[ -e $HOME/.local/share/dots/rices/.current_rice || -e $HOME/.cache/dots/current_rice || -e $HOME/.local/state/dots/rice/current ]]; then
-    echo "FAIL: legacy rice pointer still present" >&2
-    ok=1
-  fi
-  if [[ -n $scheme_flavour && -n $state_flavour && $scheme_flavour != "$state_flavour" ]]; then
-    echo "FAIL: scheme flavour != state flavour ($scheme_flavour vs $state_flavour)" >&2
-    ok=1
-  fi
-  if [[ -n $scheme_mode && -n $state_mode && $scheme_mode != "$state_mode" ]]; then
-    echo "FAIL: scheme mode != state mode ($scheme_mode vs $state_mode)" >&2
-    ok=1
-  fi
-  if [[ -z $pointer_val ]]; then
-    echo "FAIL: wallpaper pointer missing" >&2
-    ok=1
-  elif [[ ! -f $pointer_val ]]; then
-    echo "FAIL: wallpaper pointer does not exist: $pointer_val" >&2
-    ok=1
-  fi
-  if [[ -n $pointer_val && -n $resolved && $pointer_val != "$resolved" ]]; then
-    local ptr_real res_real
-    ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
-    res_real="$(readlink -f "$resolved" 2>/dev/null || true)"
-    if [[ -n $ptr_real && -n $res_real && $ptr_real != "$res_real" ]]; then
-      echo "FAIL: pointer != dots-wallpaper-current ($pointer_val vs $resolved)" >&2
-      ok=1
-    fi
-  fi
-  if [[ -n $pointer_val && -f $pointer_val ]]; then
-    local ptr_real wal_real
-    ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
-    if [[ -L $HOME/.cache/wal/wal ]]; then
-      wal_real="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
-    elif [[ -f $HOME/.cache/wal/wal ]]; then
-      wal_real="$(head -n 1 "$HOME/.cache/wal/wal" | tr -d '\r')"
-      wal_real="$(readlink -f "$wal_real" 2>/dev/null || true)"
-    fi
-    if [[ -z ${wal_real:-} ]]; then
-      echo "FAIL: ~/.cache/wal/wal missing or broken" >&2
-      ok=1
-    elif [[ -n $ptr_real && $ptr_real != "$wal_real" ]]; then
-      echo "FAIL: wal target != wallpaper pointer ($wal_real vs $ptr_real)" >&2
-      ok=1
-    fi
-  fi
-  if [[ ! -f $hyprlock_conf || ${hyprlock_bytes:-0} -eq 0 ]]; then
-    echo "FAIL: colors-hyprlock.conf missing or empty" >&2
-    ok=1
-  fi
-  # shellcheck source=/dev/null
-  source "${HOME}/.local/lib/dots/python-m3.sh" 2>/dev/null || true
-  local m3_py=""
-  if declare -f dots_python_m3 >/dev/null 2>&1; then
-    m3_py="$(dots_python_m3 2>/dev/null || true)"
-  fi
-  echo "m3.python      : ${m3_py:-"(missing)"}"
-  if [[ -z $m3_py ]]; then
-    echo "FAIL: no Python with materialyoucolor (install python-materialyoucolor; pyenv shims alone are not enough)" >&2
-    ok=1
-  fi
-  if [[ -f ${HOME}/.local/state/dots/wallpaper/path.txt ]]; then
-    echo "FAIL: orphan wallpaper/path.txt present (use wallpaper/path)" >&2
-    ok=1
-  fi
-  if [[ -f ${HOME}/.cache/dots/smart-colors/wallpaper ]]; then
-    echo "FAIL: orphan smart-colors/wallpaper cache present" >&2
-    ok=1
-  fi
-  # GTK color-scheme is independent of shell mode unless policy is follow.
-  # Light GTK + dark palette is intentional for many theme packs.
-  if [[ $gtk_color_policy == "follow" ]]; then
-    if [[ -n $state_mode && -n $gtk_prefer_dark ]]; then
-      if [[ $state_mode == "dark" && $gtk_prefer_dark == "false" ]]; then
-        echo "WARN: GTK prefer-dark=false while follow-policy mode is dark" >&2
-      elif [[ $state_mode == "light" && $gtk_prefer_dark == "true" ]]; then
-        echo "WARN: GTK prefer-dark=true while follow-policy mode is light" >&2
-      fi
-    fi
-    if [[ -n $state_mode && -n $gtk_color_scheme ]]; then
-      if [[ $state_mode == "dark" && $gtk_color_scheme != "prefer-dark" ]]; then
-        echo "WARN: gsettings color-scheme=$gtk_color_scheme while follow-policy mode is dark" >&2
-      elif [[ $state_mode == "light" && $gtk_color_scheme != "prefer-light" ]]; then
-        echo "WARN: gsettings color-scheme=$gtk_color_scheme while follow-policy mode is light" >&2
-      fi
-    fi
-  fi
-  if [[ -n $wal_target && -f $wal_target ]]; then
-    if ! file -b --mime-type "$wal_target" 2>/dev/null | grep -q '^image/'; then
-      echo "WARN: wal target is not an image: $wal_target" >&2
-    fi
-  fi
+	if [[ -e $HOME/.local/share/dots/rices/.current_rice || -e $HOME/.cache/dots/current_rice || -e $HOME/.local/state/dots/rice/current ]]; then
+		echo "FAIL: legacy rice pointer still present" >&2
+		ok=1
+	fi
+	if [[ -n $scheme_flavour && -n $state_flavour && $scheme_flavour != "$state_flavour" ]]; then
+		echo "FAIL: scheme flavour != state flavour ($scheme_flavour vs $state_flavour)" >&2
+		ok=1
+	fi
+	if [[ -n $scheme_mode && -n $state_mode && $scheme_mode != "$state_mode" ]]; then
+		echo "FAIL: scheme mode != state mode ($scheme_mode vs $state_mode)" >&2
+		ok=1
+	fi
+	if [[ -z $pointer_val ]]; then
+		echo "FAIL: wallpaper pointer missing" >&2
+		ok=1
+	elif [[ ! -f $pointer_val ]]; then
+		echo "FAIL: wallpaper pointer does not exist: $pointer_val" >&2
+		ok=1
+	fi
+	if [[ -n $pointer_val && -n $resolved && $pointer_val != "$resolved" ]]; then
+		local ptr_real res_real
+		ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
+		res_real="$(readlink -f "$resolved" 2>/dev/null || true)"
+		if [[ -n $ptr_real && -n $res_real && $ptr_real != "$res_real" ]]; then
+			echo "FAIL: pointer != dots-wallpaper-current ($pointer_val vs $resolved)" >&2
+			ok=1
+		fi
+	fi
+	if [[ -n $pointer_val && -f $pointer_val ]]; then
+		local ptr_real wal_real
+		ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
+		if [[ -L $HOME/.cache/wal/wal ]]; then
+			wal_real="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
+		elif [[ -f $HOME/.cache/wal/wal ]]; then
+			wal_real="$(head -n 1 "$HOME/.cache/wal/wal" | tr -d '\r')"
+			wal_real="$(readlink -f "$wal_real" 2>/dev/null || true)"
+		fi
+		if [[ -z ${wal_real:-} ]]; then
+			echo "FAIL: ~/.cache/wal/wal missing or broken" >&2
+			ok=1
+		elif [[ -n $ptr_real && $ptr_real != "$wal_real" ]]; then
+			echo "FAIL: wal target != wallpaper pointer ($wal_real vs $ptr_real)" >&2
+			ok=1
+		fi
+	fi
+	if [[ ! -f $hyprlock_conf || ${hyprlock_bytes:-0} -eq 0 ]]; then
+		echo "FAIL: colors-hyprlock.conf missing or empty" >&2
+		ok=1
+	fi
+	# shellcheck source=/dev/null
+	source "${HOME}/.local/lib/dots/python-m3.sh" 2>/dev/null || true
+	local m3_py=""
+	if declare -f dots_python_m3 >/dev/null 2>&1; then
+		m3_py="$(dots_python_m3 2>/dev/null || true)"
+	fi
+	echo "m3.python      : ${m3_py:-"(missing)"}"
+	if [[ -z $m3_py ]]; then
+		echo "FAIL: no Python with materialyoucolor (install python-materialyoucolor; pyenv shims alone are not enough)" >&2
+		ok=1
+	fi
+	if [[ -f ${HOME}/.local/state/dots/wallpaper/path.txt ]]; then
+		echo "FAIL: orphan wallpaper/path.txt present (use wallpaper/path)" >&2
+		ok=1
+	fi
+	if [[ -f ${HOME}/.cache/dots/smart-colors/wallpaper ]]; then
+		echo "FAIL: orphan smart-colors/wallpaper cache present" >&2
+		ok=1
+	fi
+	# GTK color-scheme is independent of shell mode unless policy is follow.
+	# Light GTK + dark palette is intentional for many theme packs.
+	if [[ $gtk_color_policy == "follow" ]]; then
+		if [[ -n $state_mode && -n $gtk_prefer_dark ]]; then
+			if [[ $state_mode == "dark" && $gtk_prefer_dark == "false" ]]; then
+				echo "WARN: GTK prefer-dark=false while follow-policy mode is dark" >&2
+			elif [[ $state_mode == "light" && $gtk_prefer_dark == "true" ]]; then
+				echo "WARN: GTK prefer-dark=true while follow-policy mode is light" >&2
+			fi
+		fi
+		if [[ -n $state_mode && -n $gtk_color_scheme ]]; then
+			if [[ $state_mode == "dark" && $gtk_color_scheme != "prefer-dark" ]]; then
+				echo "WARN: gsettings color-scheme=$gtk_color_scheme while follow-policy mode is dark" >&2
+			elif [[ $state_mode == "light" && $gtk_color_scheme != "prefer-light" ]]; then
+				echo "WARN: gsettings color-scheme=$gtk_color_scheme while follow-policy mode is light" >&2
+			fi
+		fi
+	fi
+	if [[ -n $wal_target && -f $wal_target ]]; then
+		if ! file -b --mime-type "$wal_target" 2>/dev/null | grep -q '^image/'; then
+			echo "WARN: wal target is not an image: $wal_target" >&2
+		fi
+	fi
 
-  if [[ $ok -eq 0 ]]; then
-    echo "OK: appearance state is consistent"
-  else
-    echo "DONE: inconsistencies detected (exit $ok)"
-  fi
-  return "$ok"
+	if [[ $ok -eq 0 ]]; then
+		echo "OK: appearance state is consistent"
+	else
+		echo "DONE: inconsistencies detected (exit $ok)"
+	fi
+	return "$ok"
 }
 
 case "${cmd:-}" in
-  theme) cmd_theme "$@" ;;
-  status) cmd_status "${1:-}" ;;
-  set-variant) cmd_set_variant "${1:-}" ;;
-  set-mode) cmd_set_mode "${1:-}" ;;
-  set-wallpaper) cmd_set_wallpaper "${1:-}" ;;
-  set-gtk) cmd_set_gtk "${1:-}" ;;
-  set-gtk-color-scheme) cmd_set_gtk_color_scheme "${1:-}" ;;
-  set-icons) cmd_set_icons "${1:-}" ;;
-  sync) cmd_sync ;;
-  doctor) cmd_doctor ;;
-  # Back-compat shims during transition
-  list) cmd_theme_list ;;
-  apply) cmd_theme_apply "$@" ;;
-  preview) cmd_theme_show "${1:-}" ;;
-  *)
-    cat <<'EOF' >&2
+theme) cmd_theme "$@" ;;
+status) cmd_status "${1:-}" ;;
+set-variant) cmd_set_variant "${1:-}" ;;
+set-mode) cmd_set_mode "${1:-}" ;;
+set-wallpaper) cmd_set_wallpaper "${1:-}" ;;
+set-gtk) cmd_set_gtk "${1:-}" ;;
+set-gtk-color-scheme) cmd_set_gtk_color_scheme "${1:-}" ;;
+set-icons) cmd_set_icons "${1:-}" ;;
+sync) cmd_sync ;;
+doctor) cmd_doctor ;;
+# Back-compat shims during transition
+list) cmd_theme_list ;;
+apply) cmd_theme_apply "$@" ;;
+preview) cmd_theme_show "${1:-}" ;;
+*)
+	cat <<'EOF' >&2
 Usage: dots-appearance <command> [args]
 
 Commands:
@@ -450,6 +450,6 @@ Commands:
   sync
   doctor
 EOF
-    exit 1
-    ;;
+	exit 1
+	;;
 esac

--- a/home/dot_local/bin/executable_dots-appearance
+++ b/home/dot_local/bin/executable_dots-appearance
@@ -14,407 +14,428 @@ cmd="${1:-}"
 shift 2>/dev/null || true
 
 json_escape() {
-	python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1"
+  python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$1"
 }
 
 _wait_appearance_ipc() {
-	local _i busy="" last_error
-	for _i in $(seq 1 120); do
-		if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
-			echo "Error: failed to poll appearance isBusy via Quickshell IPC" >&2
-			return 1
-		fi
-		busy="${busy//$'\r'/}"
-		busy="${busy//$'\n'/}"
-		[[ $busy == "1" ]] || break
-		sleep 0.5
-	done
-	if [[ $busy == "1" ]]; then
-		echo "Error: appearance apply timed out waiting for Quickshell" >&2
-		return 1
-	fi
-	last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
-	last_error="${last_error//$'\r'/}"
-	last_error="${last_error//$'\n'/}"
-	if [[ -n $last_error ]]; then
-		echo "Error: appearance apply failed: $last_error" >&2
-		return 1
-	fi
-	return 0
+  local _i busy="" last_error
+  for _i in $(seq 1 120); do
+    if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
+      echo "Error: failed to poll appearance isBusy via Quickshell IPC" >&2
+      return 1
+    fi
+    busy="${busy//$'\r'/}"
+    busy="${busy//$'\n'/}"
+    [[ $busy == "1" ]] || break
+    sleep 0.5
+  done
+  if [[ $busy == "1" ]]; then
+    echo "Error: appearance apply timed out waiting for Quickshell" >&2
+    return 1
+  fi
+  last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
+  last_error="${last_error//$'\r'/}"
+  last_error="${last_error//$'\n'/}"
+  if [[ -n $last_error ]]; then
+    echo "Error: appearance apply failed: $last_error" >&2
+    return 1
+  fi
+  return 0
 }
 
 cmd_theme_list() {
-	local script="${HOME}/.local/lib/dots/list-themes.py"
-	if [[ -f $script ]]; then
-		python3 "$script" "$THEMES_DIR"
-	else
-		echo "[]"
-	fi
+  local script="${HOME}/.local/lib/dots/list-themes.py"
+  if [[ -f $script ]]; then
+    python3 "$script" "$THEMES_DIR"
+  else
+    echo "[]"
+  fi
 }
 
 cmd_theme_show() {
-	local id="${1:-}"
-	[[ -n $id ]] || {
-		echo "Usage: dots-appearance theme show <id>" >&2
-		exit 1
-	}
-	local path="${THEMES_DIR}/${id}/theme.json"
-	[[ -f $path ]] || {
-		echo "Theme not found: $id" >&2
-		exit 1
-	}
-	cat "$path"
+  local id="${1:-}"
+  [[ -n $id ]] || {
+    echo "Usage: dots-appearance theme show <id>" >&2
+    exit 1
+  }
+  local path="${THEMES_DIR}/${id}/theme.json"
+  [[ -f $path ]] || {
+    echo "Theme not found: $id" >&2
+    exit 1
+  }
+  cat "$path"
 }
 
 _shell_theme_apply() {
-	local id="$1"
-	local wallpaper="${2:-}"
-	# shellcheck source=/dev/null
-	source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
-	# shellcheck source=/dev/null
-	source "$HOME/.local/lib/dots/apply-appearance.sh"
-	dots_apply_theme "$id" "$wallpaper"
+  local id="$1"
+  local wallpaper="${2:-}"
+  # shellcheck source=/dev/null
+  source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
+  # shellcheck source=/dev/null
+  source "$HOME/.local/lib/dots/apply-appearance.sh"
+  dots_apply_theme "$id" "$wallpaper"
 }
 
 cmd_theme_apply() {
-	local id="${1:-}"
-	local wallpaper=""
-	shift 2>/dev/null || true
-	while [[ $# -gt 0 ]]; do
-		case "${1:-}" in
-		--wallpaper)
-			[[ -n ${2:-} ]] || {
-				echo "dots-appearance theme apply: --wallpaper requires a path" >&2
-				exit 1
-			}
-			wallpaper="$2"
-			shift 2
-			;;
-		*)
-			echo "dots-appearance theme apply: unknown argument: $1" >&2
-			exit 1
-			;;
-		esac
-	done
+  local id="${1:-}"
+  local wallpaper=""
+  shift 2>/dev/null || true
+  while [[ $# -gt 0 ]]; do
+    case "${1:-}" in
+      --wallpaper)
+        [[ -n ${2:-} ]] || {
+          echo "dots-appearance theme apply: --wallpaper requires a path" >&2
+          exit 1
+        }
+        wallpaper="$2"
+        shift 2
+        ;;
+      *)
+        echo "dots-appearance theme apply: unknown argument: $1" >&2
+        exit 1
+        ;;
+    esac
+  done
 
-	[[ -n $id ]] || {
-		echo "Usage: dots-appearance theme apply <id> [--wallpaper <path>]" >&2
-		exit 1
-	}
+  [[ -n $id ]] || {
+    echo "Usage: dots-appearance theme apply <id> [--wallpaper <path>]" >&2
+    exit 1
+  }
 
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		local ipc_out=""
-		if ipc_out="$(quickshell ipc call appearance applyTheme "$id" "${wallpaper:-}" 2>&1)"; then
-			case "$ipc_out" in
-			"Target not found."* | *"Target not found"*)
-				echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
-				;;
-			*)
-				_wait_appearance_ipc || exit 1
-				exit 0
-				;;
-			esac
-		else
-			echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
-		fi
-	fi
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    local ipc_out=""
+    if ipc_out="$(quickshell ipc call appearance applyTheme "$id" "${wallpaper:-}" 2>&1)"; then
+      case "$ipc_out" in
+        "Target not found."* | *"Target not found"*)
+          echo "Warning: Quickshell IPC unavailable ($ipc_out); falling back to shell apply" >&2
+          ;;
+        *)
+          _wait_appearance_ipc || exit 1
+          exit 0
+          ;;
+      esac
+    else
+      echo "Warning: Quickshell IPC failed; falling back to shell apply" >&2
+    fi
+  fi
 
-	_shell_theme_apply "$id" "$wallpaper"
+  _shell_theme_apply "$id" "$wallpaper"
 }
 
 cmd_theme() {
-	local sub="${1:-}"
-	shift 2>/dev/null || true
-	case "$sub" in
-	list) cmd_theme_list ;;
-	show) cmd_theme_show "${1:-}" ;;
-	apply) cmd_theme_apply "$@" ;;
-	*)
-		cat <<'EOF' >&2
+  local sub="${1:-}"
+  shift 2>/dev/null || true
+  case "$sub" in
+    list) cmd_theme_list ;;
+    show) cmd_theme_show "${1:-}" ;;
+    apply) cmd_theme_apply "$@" ;;
+    *)
+      cat <<'EOF' >&2
 Usage: dots-appearance theme <list|show|apply> …
 
   theme list
   theme show <id>
   theme apply <id> [--wallpaper <path>]
 EOF
-		exit 1
-		;;
-	esac
+      exit 1
+      ;;
+  esac
 }
 
 cmd_status() {
-	local wallpaper="" mode="" flavour="" gtk_theme="" icon_theme=""
-	if command -v dots-wallpaper-current >/dev/null 2>&1; then
-		wallpaper="$(dots-wallpaper-current 2>/dev/null || true)"
-	fi
-	local state_file="${HOME}/.local/state/dots/scheme/state.json"
-	if [[ -f $state_file ]]; then
-		flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
-		mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
-	fi
-	if [[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini ]]; then
-		gtk_theme="$(grep -E '^gtk-theme-name=' "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-	fi
-	if command -v gsettings >/dev/null 2>&1; then
-		icon_theme="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'\"" || true)"
-	fi
+  local wallpaper="" mode="" flavour="" gtk_theme="" icon_theme="" gtk_color_scheme=""
+  if command -v dots-wallpaper-current >/dev/null 2>&1; then
+    wallpaper="$(dots-wallpaper-current 2>/dev/null || true)"
+  fi
+  local state_file="${HOME}/.local/state/dots/scheme/state.json"
+  if [[ -f $state_file ]]; then
+    flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
+    mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
+    gtk_color_scheme="$(python3 -c "import json;print(json.load(open('$state_file')).get('gtkColorScheme','') or 'follow')" 2>/dev/null || true)"
+  fi
+  [[ -n $gtk_color_scheme ]] || gtk_color_scheme="follow"
+  if [[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini ]]; then
+    gtk_theme="$(grep -E '^gtk-theme-name=' "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+  fi
+  if command -v gsettings >/dev/null 2>&1; then
+    icon_theme="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'\"" || true)"
+  fi
 
-	if [[ ${1:-} == "--json" ]]; then
-		printf '{"wallpaper":%s,"mode":%s,"flavour":%s,"gtkTheme":%s,"iconTheme":%s}\n' \
-			"$(json_escape "${wallpaper:-}")" \
-			"$(json_escape "${mode:-}")" \
-			"$(json_escape "${flavour:-}")" \
-			"$(json_escape "${gtk_theme:-}")" \
-			"$(json_escape "${icon_theme:-}")"
-	else
-		echo "wallpaper : ${wallpaper:-}"
-		echo "mode      : ${mode:-}"
-		echo "flavour   : ${flavour:-}"
-		echo "gtkTheme  : ${gtk_theme:-}"
-		echo "iconTheme : ${icon_theme:-}"
-	fi
+  if [[ ${1:-} == "--json" ]]; then
+    printf '{"wallpaper":%s,"mode":%s,"flavour":%s,"gtkTheme":%s,"iconTheme":%s,"gtkColorScheme":%s}\n' \
+      "$(json_escape "${wallpaper:-}")" \
+      "$(json_escape "${mode:-}")" \
+      "$(json_escape "${flavour:-}")" \
+      "$(json_escape "${gtk_theme:-}")" \
+      "$(json_escape "${icon_theme:-}")" \
+      "$(json_escape "${gtk_color_scheme:-}")"
+  else
+    echo "wallpaper      : ${wallpaper:-}"
+    echo "mode           : ${mode:-}"
+    echo "flavour        : ${flavour:-}"
+    echo "gtkTheme       : ${gtk_theme:-}"
+    echo "iconTheme      : ${icon_theme:-}"
+    echo "gtkColorScheme : ${gtk_color_scheme:-}"
+  fi
 }
 
 cmd_set_wallpaper() {
-	local wallpaper="${1:-}"
-	[[ -n $wallpaper ]] || {
-		echo "Usage: dots-appearance set-wallpaper <path>" >&2
-		exit 1
-	}
-	dots-wallpaper-set "$wallpaper"
+  local wallpaper="${1:-}"
+  [[ -n $wallpaper ]] || {
+    echo "Usage: dots-appearance set-wallpaper <path>" >&2
+    exit 1
+  }
+  dots-wallpaper-set "$wallpaper"
 }
 
 cmd_set_variant() {
-	dots-color-scheme variant "${1:-}"
+  dots-color-scheme variant "${1:-}"
 }
 
 cmd_set_mode() {
-	dots-color-scheme mode "${1:-}"
+  dots-color-scheme mode "${1:-}"
 }
 
 cmd_set_gtk() {
-	local theme="${1:-}"
-	[[ -n $theme ]] || {
-		echo "Usage: dots-appearance set-gtk <theme>" >&2
-		exit 1
-	}
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		if quickshell ipc call appearance setGtk "$theme" >/dev/null 2>&1; then
-			_wait_appearance_ipc || exit 1
-			exit 0
-		fi
-	fi
-	local prefer="true" mode="dark"
-	local state_json="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
-	if [[ -f $state_json ]]; then
-		mode="$(python3 -c "import json;print(json.load(open('$state_json')).get('mode','dark'))" 2>/dev/null || echo dark)"
-	fi
-	prefer=$([[ $mode == "light" ]] && echo false || echo true)
-	local icon
-	icon="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'" || true)"
-	[[ -n $icon ]] || icon="Numix-Circle"
-	dots-gtk-theme -q apply "$theme" "$icon" "$prefer"
+  local theme="${1:-}"
+  [[ -n $theme ]] || {
+    echo "Usage: dots-appearance set-gtk <theme>" >&2
+    exit 1
+  }
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    if quickshell ipc call appearance setGtk "$theme" >/dev/null 2>&1; then
+      _wait_appearance_ipc || exit 1
+      exit 0
+    fi
+  fi
+  local icon
+  icon="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'" || true)"
+  [[ -n $icon ]] || icon="Numix-Circle"
+  # Omit color-scheme so live gtkColorScheme policy is preserved.
+  dots-gtk-theme -q apply "$theme" "$icon"
+}
+
+cmd_set_gtk_color_scheme() {
+  local policy="${1:-}"
+  [[ -n $policy ]] || {
+    echo "Usage: dots-appearance set-gtk-color-scheme <follow|default|prefer-light|prefer-dark>" >&2
+    exit 1
+  }
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    if quickshell ipc call appearance setGtkColorScheme "$policy" >/dev/null 2>&1; then
+      _wait_appearance_ipc || exit 1
+      exit 0
+    fi
+  fi
+  dots-gtk-theme -q color-scheme "$policy"
 }
 
 cmd_set_icons() {
-	local theme="${1:-}"
-	[[ -n $theme ]] || {
-		echo "Usage: dots-appearance set-icons <theme>" >&2
-		exit 1
-	}
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		if quickshell ipc call appearance setIcons "$theme" >/dev/null 2>&1; then
-			_wait_appearance_ipc || exit 1
-			exit 0
-		fi
-	fi
-	dots-gtk-theme -q set-icons "$theme"
+  local theme="${1:-}"
+  [[ -n $theme ]] || {
+    echo "Usage: dots-appearance set-icons <theme>" >&2
+    exit 1
+  }
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    if quickshell ipc call appearance setIcons "$theme" >/dev/null 2>&1; then
+      _wait_appearance_ipc || exit 1
+      exit 0
+    fi
+  fi
+  dots-gtk-theme -q set-icons "$theme"
 }
 
 cmd_sync() {
-	if pgrep -x quickshell >/dev/null 2>&1; then
-		if quickshell ipc call appearance reload >/dev/null 2>&1; then
-			_wait_appearance_ipc || exit 1
-		fi
-	fi
-	dots-color-scheme sync-state >/dev/null 2>&1 || true
+  if pgrep -x quickshell >/dev/null 2>&1; then
+    if quickshell ipc call appearance reload >/dev/null 2>&1; then
+      _wait_appearance_ipc || exit 1
+    fi
+  fi
+  dots-color-scheme sync-state >/dev/null 2>&1 || true
 }
 
 cmd_doctor() {
-	local ok=0
-	local scheme_flavour="" state_flavour="" scheme_mode="" state_mode=""
-	local pointer="" resolved="" wal_target=""
+  local ok=0
+  local scheme_flavour="" state_flavour="" scheme_mode="" state_mode=""
+  local pointer="" resolved="" wal_target=""
 
-	# One-time purge of removed rice state / legacy pointers.
-	rm -f "$HOME/.local/share/dots/rices/.current_rice" \
-		"$HOME/.cache/dots/current_rice" \
-		"$HOME/.local/state/dots/rice/current" 2>/dev/null || true
-	rmdir "$HOME/.local/state/dots/rice" 2>/dev/null || true
+  # One-time purge of removed rice state / legacy pointers.
+  rm -f "$HOME/.local/share/dots/rices/.current_rice" \
+    "$HOME/.cache/dots/current_rice" \
+    "$HOME/.local/state/dots/rice/current" 2>/dev/null || true
+  rmdir "$HOME/.local/state/dots/rice" 2>/dev/null || true
 
-	local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
-	local state_file="${HOME}/.local/state/dots/scheme/state.json"
-	if [[ -f $scheme_file ]]; then
-		scheme_flavour="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('flavour',''))" 2>/dev/null || true)"
-		scheme_mode="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('mode',''))" 2>/dev/null || true)"
-	fi
-	if [[ -f $state_file ]]; then
-		state_flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
-		state_mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
-	fi
+  local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
+  local state_file="${HOME}/.local/state/dots/scheme/state.json"
+  if [[ -f $scheme_file ]]; then
+    scheme_flavour="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('flavour',''))" 2>/dev/null || true)"
+    scheme_mode="$(python3 -c "import json;print(json.load(open('$scheme_file')).get('mode',''))" 2>/dev/null || true)"
+  fi
+  if [[ -f $state_file ]]; then
+    state_flavour="$(python3 -c "import json;print(json.load(open('$state_file')).get('flavour',''))" 2>/dev/null || true)"
+    state_mode="$(python3 -c "import json;print(json.load(open('$state_file')).get('mode',''))" 2>/dev/null || true)"
+  fi
 
-	pointer="${DOTS_WALLPAPER_POINTER_FILE:-$HOME/.local/state/dots/wallpaper/path}"
-	local pointer_val=""
-	[[ -f $pointer ]] && pointer_val="$(head -n 1 "$pointer" | tr -d '\r')"
-	if command -v dots-wallpaper-current >/dev/null 2>&1; then
-		resolved="$(dots-wallpaper-current 2>/dev/null || true)"
-	fi
-	if [[ -L $HOME/.cache/wal/wal ]]; then
-		wal_target="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
-	elif [[ -f $HOME/.cache/wal/wal ]]; then
-		wal_target="$(head -n 1 "$HOME/.cache/wal/wal" | tr -d '\r')"
-		wal_target="$(readlink -f "$wal_target" 2>/dev/null || true)"
-	fi
+  pointer="${DOTS_WALLPAPER_POINTER_FILE:-$HOME/.local/state/dots/wallpaper/path}"
+  local pointer_val=""
+  [[ -f $pointer ]] && pointer_val="$(head -n 1 "$pointer" | tr -d '\r')"
+  if command -v dots-wallpaper-current >/dev/null 2>&1; then
+    resolved="$(dots-wallpaper-current 2>/dev/null || true)"
+  fi
+  if [[ -L $HOME/.cache/wal/wal ]]; then
+    wal_target="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
+  elif [[ -f $HOME/.cache/wal/wal ]]; then
+    wal_target="$(head -n 1 "$HOME/.cache/wal/wal" | tr -d '\r')"
+    wal_target="$(readlink -f "$wal_target" 2>/dev/null || true)"
+  fi
 
-	echo "=== dots-appearance doctor ==="
-	echo "scheme.flavour : ${scheme_flavour:-"(missing)"}"
-	echo "state.flavour  : ${state_flavour:-"(missing)"}"
-	echo "scheme.mode    : ${scheme_mode:-"(missing)"}"
-	echo "state.mode     : ${state_mode:-"(missing)"}"
-	local hyprlock_conf="${HOME}/.cache/dots/smart-colors/colors-hyprlock.conf"
-	local hyprlock_bytes=0
-	[[ -f $hyprlock_conf ]] && hyprlock_bytes="$(wc -c <"$hyprlock_conf" | tr -d ' ')"
-	local gtk_theme_ini="" gtk_prefer_dark="" gtk_color_scheme=""
-	if [[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini ]]; then
-		gtk_theme_ini="$(grep -E '^gtk-theme-name=' "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-		gtk_prefer_dark="$(grep -E '^gtk-application-prefer-dark-theme=' "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
-	fi
-	if command -v gsettings >/dev/null 2>&1; then
-		gtk_color_scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'\"" || true)"
-	fi
+  echo "=== dots-appearance doctor ==="
+  echo "scheme.flavour : ${scheme_flavour:-"(missing)"}"
+  echo "state.flavour  : ${state_flavour:-"(missing)"}"
+  echo "scheme.mode    : ${scheme_mode:-"(missing)"}"
+  echo "state.mode     : ${state_mode:-"(missing)"}"
+  local hyprlock_conf="${HOME}/.cache/dots/smart-colors/colors-hyprlock.conf"
+  local hyprlock_bytes=0
+  [[ -f $hyprlock_conf ]] && hyprlock_bytes="$(wc -c <"$hyprlock_conf" | tr -d ' ')"
+  local gtk_theme_ini="" gtk_prefer_dark="" gtk_color_scheme="" gtk_color_policy=""
+  if [[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini ]]; then
+    gtk_theme_ini="$(grep -E '^gtk-theme-name=' "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+    gtk_prefer_dark="$(grep -E '^gtk-application-prefer-dark-theme=' "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" 2>/dev/null | head -n1 | cut -d= -f2- || true)"
+  fi
+  if command -v gsettings >/dev/null 2>&1; then
+    gtk_color_scheme="$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'\"" || true)"
+  fi
+  if [[ -f $state_file ]]; then
+    gtk_color_policy="$(python3 -c "import json;print(json.load(open('$state_file')).get('gtkColorScheme','') or 'follow')" 2>/dev/null || true)"
+  fi
+  [[ -n $gtk_color_policy ]] || gtk_color_policy="follow"
 
-	echo "wallpaper.ptr  : ${pointer_val:-"(missing)"}"
-	echo "wallpaper.res  : ${resolved:-"(missing)"}"
-	echo "wal.target     : ${wal_target:-"(missing)"}"
-	echo "hyprlock.conf  : ${hyprlock_bytes} bytes"
-	echo "gtk.theme.ini  : ${gtk_theme_ini:-"(missing)"}"
-	echo "gtk.preferDark : ${gtk_prefer_dark:-"(missing)"}"
-	echo "gtk.colorScheme: ${gtk_color_scheme:-"(missing)"}"
+  echo "wallpaper.ptr  : ${pointer_val:-"(missing)"}"
+  echo "wallpaper.res  : ${resolved:-"(missing)"}"
+  echo "wal.target     : ${wal_target:-"(missing)"}"
+  echo "hyprlock.conf  : ${hyprlock_bytes} bytes"
+  echo "gtk.theme.ini  : ${gtk_theme_ini:-"(missing)"}"
+  echo "gtk.preferDark : ${gtk_prefer_dark:-"(missing)"}"
+  echo "gtk.colorPolicy: ${gtk_color_policy}"
+  echo "gtk.colorScheme: ${gtk_color_scheme:-"(missing)"}"
 
-	if [[ -e $HOME/.local/share/dots/rices/.current_rice || -e $HOME/.cache/dots/current_rice || -e $HOME/.local/state/dots/rice/current ]]; then
-		echo "FAIL: legacy rice pointer still present" >&2
-		ok=1
-	fi
-	if [[ -n $scheme_flavour && -n $state_flavour && $scheme_flavour != "$state_flavour" ]]; then
-		echo "FAIL: scheme flavour != state flavour ($scheme_flavour vs $state_flavour)" >&2
-		ok=1
-	fi
-	if [[ -n $scheme_mode && -n $state_mode && $scheme_mode != "$state_mode" ]]; then
-		echo "FAIL: scheme mode != state mode ($scheme_mode vs $state_mode)" >&2
-		ok=1
-	fi
-	if [[ -z $pointer_val ]]; then
-		echo "FAIL: wallpaper pointer missing" >&2
-		ok=1
-	elif [[ ! -f $pointer_val ]]; then
-		echo "FAIL: wallpaper pointer does not exist: $pointer_val" >&2
-		ok=1
-	fi
-	if [[ -n $pointer_val && -n $resolved && $pointer_val != "$resolved" ]]; then
-		local ptr_real res_real
-		ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
-		res_real="$(readlink -f "$resolved" 2>/dev/null || true)"
-		if [[ -n $ptr_real && -n $res_real && $ptr_real != "$res_real" ]]; then
-			echo "FAIL: pointer != dots-wallpaper-current ($pointer_val vs $resolved)" >&2
-			ok=1
-		fi
-	fi
-	if [[ -n $pointer_val && -f $pointer_val ]]; then
-		local ptr_real wal_real
-		ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
-		if [[ -L $HOME/.cache/wal/wal ]]; then
-			wal_real="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
-		elif [[ -f $HOME/.cache/wal/wal ]]; then
-			wal_real="$(head -n 1 "$HOME/.cache/wal/wal" | tr -d '\r')"
-			wal_real="$(readlink -f "$wal_real" 2>/dev/null || true)"
-		fi
-		if [[ -z ${wal_real:-} ]]; then
-			echo "FAIL: ~/.cache/wal/wal missing or broken" >&2
-			ok=1
-		elif [[ -n $ptr_real && $ptr_real != "$wal_real" ]]; then
-			echo "FAIL: wal target != wallpaper pointer ($wal_real vs $ptr_real)" >&2
-			ok=1
-		fi
-	fi
-	if [[ ! -f $hyprlock_conf || ${hyprlock_bytes:-0} -eq 0 ]]; then
-		echo "FAIL: colors-hyprlock.conf missing or empty" >&2
-		ok=1
-	fi
-	# shellcheck source=/dev/null
-	source "${HOME}/.local/lib/dots/python-m3.sh" 2>/dev/null || true
-	local m3_py=""
-	if declare -f dots_python_m3 >/dev/null 2>&1; then
-		m3_py="$(dots_python_m3 2>/dev/null || true)"
-	fi
-	echo "m3.python      : ${m3_py:-"(missing)"}"
-	if [[ -z $m3_py ]]; then
-		echo "FAIL: no Python with materialyoucolor (install python-materialyoucolor; pyenv shims alone are not enough)" >&2
-		ok=1
-	fi
-	if [[ -f ${HOME}/.local/state/dots/wallpaper/path.txt ]]; then
-		echo "FAIL: orphan wallpaper/path.txt present (use wallpaper/path)" >&2
-		ok=1
-	fi
-	if [[ -f ${HOME}/.cache/dots/smart-colors/wallpaper ]]; then
-		echo "FAIL: orphan smart-colors/wallpaper cache present" >&2
-		ok=1
-	fi
-	# GTK light with dark mode is intentional for many theme packs
-	# (e.g. gruvbox darkMode=true + gtkPreferDark=false → Orchis-Light-Compact).
-	# Downgrade to WARN so user light preference + dark wal does not fail doctor.
-	if [[ -n $state_mode && -n $gtk_prefer_dark ]]; then
-		if [[ $state_mode == "dark" && $gtk_prefer_dark == "false" ]]; then
-			echo "WARN: GTK prefer-dark=false while live mode is dark (light GTK + dark palette — intentional if theme sets gtkPreferDark=false or you prefer light GTK)" >&2
-		elif [[ $state_mode == "light" && $gtk_prefer_dark == "true" ]]; then
-			echo "WARN: GTK prefer-dark=true while live mode is light (dark GTK + light palette — check theme gtkPreferDark)" >&2
-		fi
-	fi
-	if [[ -n $state_mode && -n $gtk_color_scheme ]]; then
-		if [[ $state_mode == "dark" && $gtk_color_scheme != "prefer-dark" ]]; then
-			echo "WARN: gsettings color-scheme=$gtk_color_scheme while live mode is dark (mismatch — was GTK manually set to light?)" >&2
-		elif [[ $state_mode == "light" && $gtk_color_scheme != "prefer-light" ]]; then
-			echo "WARN: gsettings color-scheme=$gtk_color_scheme while live mode is light (mismatch — was GTK manually set to dark?)" >&2
-		fi
-	fi
-	if [[ -n $wal_target && -f $wal_target ]]; then
-		if ! file -b --mime-type "$wal_target" 2>/dev/null | grep -q '^image/'; then
-			echo "WARN: wal target is not an image: $wal_target" >&2
-		fi
-	fi
+  if [[ -e $HOME/.local/share/dots/rices/.current_rice || -e $HOME/.cache/dots/current_rice || -e $HOME/.local/state/dots/rice/current ]]; then
+    echo "FAIL: legacy rice pointer still present" >&2
+    ok=1
+  fi
+  if [[ -n $scheme_flavour && -n $state_flavour && $scheme_flavour != "$state_flavour" ]]; then
+    echo "FAIL: scheme flavour != state flavour ($scheme_flavour vs $state_flavour)" >&2
+    ok=1
+  fi
+  if [[ -n $scheme_mode && -n $state_mode && $scheme_mode != "$state_mode" ]]; then
+    echo "FAIL: scheme mode != state mode ($scheme_mode vs $state_mode)" >&2
+    ok=1
+  fi
+  if [[ -z $pointer_val ]]; then
+    echo "FAIL: wallpaper pointer missing" >&2
+    ok=1
+  elif [[ ! -f $pointer_val ]]; then
+    echo "FAIL: wallpaper pointer does not exist: $pointer_val" >&2
+    ok=1
+  fi
+  if [[ -n $pointer_val && -n $resolved && $pointer_val != "$resolved" ]]; then
+    local ptr_real res_real
+    ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
+    res_real="$(readlink -f "$resolved" 2>/dev/null || true)"
+    if [[ -n $ptr_real && -n $res_real && $ptr_real != "$res_real" ]]; then
+      echo "FAIL: pointer != dots-wallpaper-current ($pointer_val vs $resolved)" >&2
+      ok=1
+    fi
+  fi
+  if [[ -n $pointer_val && -f $pointer_val ]]; then
+    local ptr_real wal_real
+    ptr_real="$(readlink -f "$pointer_val" 2>/dev/null || true)"
+    if [[ -L $HOME/.cache/wal/wal ]]; then
+      wal_real="$(readlink -f "$HOME/.cache/wal/wal" 2>/dev/null || true)"
+    elif [[ -f $HOME/.cache/wal/wal ]]; then
+      wal_real="$(head -n 1 "$HOME/.cache/wal/wal" | tr -d '\r')"
+      wal_real="$(readlink -f "$wal_real" 2>/dev/null || true)"
+    fi
+    if [[ -z ${wal_real:-} ]]; then
+      echo "FAIL: ~/.cache/wal/wal missing or broken" >&2
+      ok=1
+    elif [[ -n $ptr_real && $ptr_real != "$wal_real" ]]; then
+      echo "FAIL: wal target != wallpaper pointer ($wal_real vs $ptr_real)" >&2
+      ok=1
+    fi
+  fi
+  if [[ ! -f $hyprlock_conf || ${hyprlock_bytes:-0} -eq 0 ]]; then
+    echo "FAIL: colors-hyprlock.conf missing or empty" >&2
+    ok=1
+  fi
+  # shellcheck source=/dev/null
+  source "${HOME}/.local/lib/dots/python-m3.sh" 2>/dev/null || true
+  local m3_py=""
+  if declare -f dots_python_m3 >/dev/null 2>&1; then
+    m3_py="$(dots_python_m3 2>/dev/null || true)"
+  fi
+  echo "m3.python      : ${m3_py:-"(missing)"}"
+  if [[ -z $m3_py ]]; then
+    echo "FAIL: no Python with materialyoucolor (install python-materialyoucolor; pyenv shims alone are not enough)" >&2
+    ok=1
+  fi
+  if [[ -f ${HOME}/.local/state/dots/wallpaper/path.txt ]]; then
+    echo "FAIL: orphan wallpaper/path.txt present (use wallpaper/path)" >&2
+    ok=1
+  fi
+  if [[ -f ${HOME}/.cache/dots/smart-colors/wallpaper ]]; then
+    echo "FAIL: orphan smart-colors/wallpaper cache present" >&2
+    ok=1
+  fi
+  # GTK color-scheme is independent of shell mode unless policy is follow.
+  # Light GTK + dark palette is intentional for many theme packs.
+  if [[ $gtk_color_policy == "follow" ]]; then
+    if [[ -n $state_mode && -n $gtk_prefer_dark ]]; then
+      if [[ $state_mode == "dark" && $gtk_prefer_dark == "false" ]]; then
+        echo "WARN: GTK prefer-dark=false while follow-policy mode is dark" >&2
+      elif [[ $state_mode == "light" && $gtk_prefer_dark == "true" ]]; then
+        echo "WARN: GTK prefer-dark=true while follow-policy mode is light" >&2
+      fi
+    fi
+    if [[ -n $state_mode && -n $gtk_color_scheme ]]; then
+      if [[ $state_mode == "dark" && $gtk_color_scheme != "prefer-dark" ]]; then
+        echo "WARN: gsettings color-scheme=$gtk_color_scheme while follow-policy mode is dark" >&2
+      elif [[ $state_mode == "light" && $gtk_color_scheme != "prefer-light" ]]; then
+        echo "WARN: gsettings color-scheme=$gtk_color_scheme while follow-policy mode is light" >&2
+      fi
+    fi
+  fi
+  if [[ -n $wal_target && -f $wal_target ]]; then
+    if ! file -b --mime-type "$wal_target" 2>/dev/null | grep -q '^image/'; then
+      echo "WARN: wal target is not an image: $wal_target" >&2
+    fi
+  fi
 
-	if [[ $ok -eq 0 ]]; then
-		echo "OK: appearance state is consistent"
-	else
-		echo "DONE: inconsistencies detected (exit $ok)"
-	fi
-	return "$ok"
+  if [[ $ok -eq 0 ]]; then
+    echo "OK: appearance state is consistent"
+  else
+    echo "DONE: inconsistencies detected (exit $ok)"
+  fi
+  return "$ok"
 }
 
 case "${cmd:-}" in
-theme) cmd_theme "$@" ;;
-status) cmd_status "${1:-}" ;;
-set-variant) cmd_set_variant "${1:-}" ;;
-set-mode) cmd_set_mode "${1:-}" ;;
-set-wallpaper) cmd_set_wallpaper "${1:-}" ;;
-set-gtk) cmd_set_gtk "${1:-}" ;;
-set-icons) cmd_set_icons "${1:-}" ;;
-sync) cmd_sync ;;
-doctor) cmd_doctor ;;
-# Back-compat shims during transition
-list) cmd_theme_list ;;
-apply) cmd_theme_apply "$@" ;;
-preview) cmd_theme_show "${1:-}" ;;
-*)
-	cat <<'EOF' >&2
+  theme) cmd_theme "$@" ;;
+  status) cmd_status "${1:-}" ;;
+  set-variant) cmd_set_variant "${1:-}" ;;
+  set-mode) cmd_set_mode "${1:-}" ;;
+  set-wallpaper) cmd_set_wallpaper "${1:-}" ;;
+  set-gtk) cmd_set_gtk "${1:-}" ;;
+  set-gtk-color-scheme) cmd_set_gtk_color_scheme "${1:-}" ;;
+  set-icons) cmd_set_icons "${1:-}" ;;
+  sync) cmd_sync ;;
+  doctor) cmd_doctor ;;
+  # Back-compat shims during transition
+  list) cmd_theme_list ;;
+  apply) cmd_theme_apply "$@" ;;
+  preview) cmd_theme_show "${1:-}" ;;
+  *)
+    cat <<'EOF' >&2
 Usage: dots-appearance <command> [args]
 
 Commands:
@@ -424,10 +445,11 @@ Commands:
   set-mode <dark|light>
   set-wallpaper <path>
   set-gtk <theme>
+  set-gtk-color-scheme <follow|default|prefer-light|prefer-dark>
   set-icons <theme>
   sync
   doctor
 EOF
-	exit 1
-	;;
+    exit 1
+    ;;
 esac

--- a/home/dot_local/bin/executable_dots-color-scheme
+++ b/home/dot_local/bin/executable_dots-color-scheme
@@ -8,8 +8,8 @@
 set -euo pipefail
 
 if [[ -r "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-	# shellcheck source=/dev/null
-	source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
+  # shellcheck source=/dev/null
+  source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
 fi
 
 SCHEME_FILE="${HOME}/.cache/dots/smart-colors/scheme.json"
@@ -25,79 +25,79 @@ cmd="${1:-}"
 shift 2>/dev/null || true
 
 normalize_scheme_type() {
-	local raw="${1:-tonal-spot}"
-	local normalized
-	normalized=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
-	case "$normalized" in
-	vibrant) echo "vibrant" ;;
-	tonalspot | tonal-spot) echo "tonal-spot" ;;
-	expressive) echo "expressive" ;;
-	fidelity) echo "fidelity" ;;
-	content) echo "content" ;;
-	neutral) echo "neutral" ;;
-	monochrome) echo "monochrome" ;;
-	fruitsalad | rainbow) echo "expressive" ;;
-	auto | *) echo "tonal-spot" ;;
-	esac
+  local raw="${1:-tonal-spot}"
+  local normalized
+  normalized=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
+  case "$normalized" in
+    vibrant) echo "vibrant" ;;
+    tonalspot | tonal-spot) echo "tonal-spot" ;;
+    expressive) echo "expressive" ;;
+    fidelity) echo "fidelity" ;;
+    content) echo "content" ;;
+    neutral) echo "neutral" ;;
+    monochrome) echo "monochrome" ;;
+    fruitsalad | rainbow) echo "expressive" ;;
+    auto | *) echo "tonal-spot" ;;
+  esac
 }
 
 normalize_variant() {
-	local raw="${1:-tonalspot}"
-	local normalized
-	normalized=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
-	case "$normalized" in
-	tonal-spot | tonalspot) echo "tonalspot" ;;
-	vibrant | expressive | fidelity | content | neutral | monochrome | fruitsalad | rainbow) echo "$normalized" ;;
-	*) echo "tonalspot" ;;
-	esac
+  local raw="${1:-tonalspot}"
+  local normalized
+  normalized=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
+  case "$normalized" in
+    tonal-spot | tonalspot) echo "tonalspot" ;;
+    vibrant | expressive | fidelity | content | neutral | monochrome | fruitsalad | rainbow) echo "$normalized" ;;
+    *) echo "tonalspot" ;;
+  esac
 }
 
 variant_to_scheme_type() {
-	local variant
-	variant=$(normalize_variant "${1:-}")
-	case "$variant" in
-	tonalspot) echo "tonal-spot" ;;
-	fruitsalad | rainbow) echo "expressive" ;;
-	*) echo "$variant" ;;
-	esac
+  local variant
+  variant=$(normalize_variant "${1:-}")
+  case "$variant" in
+    tonalspot) echo "tonal-spot" ;;
+    fruitsalad | rainbow) echo "expressive" ;;
+    *) echo "$variant" ;;
+  esac
 }
 
 resolve_wallpaper() {
-	if declare -f dots_current_wallpaper >/dev/null 2>&1; then
-		local unified=""
-		unified="$(dots_current_wallpaper 2>/dev/null || true)"
-		if [[ -n ${unified:-} && -f $unified ]]; then
-			printf '%s\n' "$unified"
-			return 0
-		fi
-	fi
+  if declare -f dots_current_wallpaper >/dev/null 2>&1; then
+    local unified=""
+    unified="$(dots_current_wallpaper 2>/dev/null || true)"
+    if [[ -n ${unified:-} && -f $unified ]]; then
+      printf '%s\n' "$unified"
+      return 0
+    fi
+  fi
 
-	local wall=""
-	if [[ -f $CURRENT_WALL_CACHE ]]; then
-		wall="$(head -n 1 "$CURRENT_WALL_CACHE" 2>/dev/null | tr -d '\r' || true)"
-	elif [[ -L $WAL_WALL_LINK ]]; then
-		# Legacy pywal image symlink
-		wall="$(readlink -f "$WAL_WALL_LINK" 2>/dev/null || true)"
-	elif [[ -f $WAL_WALL_LINK ]]; then
-		# Canonical: text path file (never treat the wal file itself as the image)
-		wall="$(head -n 1 "$WAL_WALL_LINK" 2>/dev/null | tr -d '\r' || true)"
-	fi
+  local wall=""
+  if [[ -f $CURRENT_WALL_CACHE ]]; then
+    wall="$(head -n 1 "$CURRENT_WALL_CACHE" 2>/dev/null | tr -d '\r' || true)"
+  elif [[ -L $WAL_WALL_LINK ]]; then
+    # Legacy pywal image symlink
+    wall="$(readlink -f "$WAL_WALL_LINK" 2>/dev/null || true)"
+  elif [[ -f $WAL_WALL_LINK ]]; then
+    # Canonical: text path file (never treat the wal file itself as the image)
+    wall="$(head -n 1 "$WAL_WALL_LINK" 2>/dev/null | tr -d '\r' || true)"
+  fi
 
-	if [[ -n ${wall:-} && -f $wall ]]; then
-		printf '%s\n' "$wall"
-		return 0
-	fi
-	return 1
+  if [[ -n ${wall:-} && -f $wall ]]; then
+    printf '%s\n' "$wall"
+    return 0
+  fi
+  return 1
 }
 
 ensure_state_dir() {
-	mkdir -p "$STATE_DIR"
+  mkdir -p "$STATE_DIR"
 }
 
 read_scheme_meta() {
-	local field="${1:-}"
-	[[ -f $SCHEME_FILE ]] || return 1
-	python3 - "$SCHEME_FILE" "$field" <<'PY'
+  local field="${1:-}"
+  [[ -f $SCHEME_FILE ]] || return 1
+  python3 - "$SCHEME_FILE" "$field" <<'PY'
 import json
 import sys
 path, field = sys.argv[1], sys.argv[2]
@@ -108,53 +108,60 @@ PY
 }
 
 write_state() {
-	local name="$1"
-	local flavour="$2"
-	local mode="$3"
-	local variant="$4"
-	ensure_state_dir
-	python3 - "$STATE_FILE" "$name" "$flavour" "$mode" "$variant" <<'PY'
+  local name="$1"
+  local flavour="$2"
+  local mode="$3"
+  local variant="$4"
+  ensure_state_dir
+  python3 - "$STATE_FILE" "$name" "$flavour" "$mode" "$variant" <<'PY'
 import json
 import pathlib
 import sys
 path = pathlib.Path(sys.argv[1])
 name, flavour, mode, variant = sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5]
-state = {
-    "name": name,
-    "flavour": flavour,
-    "mode": mode,
-    "variant": variant,
-}
+state = {}
+if path.is_file():
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(loaded, dict):
+            state = loaded
+    except Exception:
+        state = {}
+state["name"] = name
+state["flavour"] = flavour
+state["mode"] = mode
+state["variant"] = variant
+# gtkColorScheme is independent of shell mode — never clobber it here.
 path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
 PY
 }
 
 ensure_state() {
-	ensure_state_dir
-	if [[ -f $STATE_FILE ]]; then
-		return 0
-	fi
+  ensure_state_dir
+  if [[ -f $STATE_FILE ]]; then
+    return 0
+  fi
 
-	local flavour="tonal-spot"
-	local mode="dark"
-	local variant="tonalspot"
+  local flavour="tonal-spot"
+  local mode="dark"
+  local variant="tonalspot"
 
-	if [[ -f $SCHEME_FILE ]]; then
-		local f m
-		f="$(read_scheme_meta flavour || true)"
-		m="$(read_scheme_meta mode || true)"
-		[[ -n ${f:-} ]] && flavour="$(normalize_scheme_type "$f")"
-		[[ $m == "light" || $m == "dark" ]] && mode="$m"
-		variant="$(normalize_variant "$flavour")"
-	fi
+  if [[ -f $SCHEME_FILE ]]; then
+    local f m
+    f="$(read_scheme_meta flavour || true)"
+    m="$(read_scheme_meta mode || true)"
+    [[ -n ${f:-} ]] && flavour="$(normalize_scheme_type "$f")"
+    [[ $m == "light" || $m == "dark" ]] && mode="$m"
+    variant="$(normalize_variant "$flavour")"
+  fi
 
-	write_state "dynamic" "$flavour" "$mode" "$variant"
+  write_state "dynamic" "$flavour" "$mode" "$variant"
 }
 
 read_state_field() {
-	local field="$1"
-	ensure_state
-	python3 - "$STATE_FILE" "$field" <<'PY'
+  local field="$1"
+  ensure_state
+  python3 - "$STATE_FILE" "$field" <<'PY'
 import json
 import sys
 path, field = sys.argv[1], sys.argv[2]
@@ -165,77 +172,77 @@ PY
 }
 
 ensure_scheme_file() {
-	if [[ -f $SCHEME_FILE ]]; then
-		return 0
-	fi
-	regenerate_scheme >/dev/null 2>&1 || true
+  if [[ -f $SCHEME_FILE ]]; then
+    return 0
+  fi
+  regenerate_scheme >/dev/null 2>&1 || true
 }
 
 regenerate_scheme() {
-	ensure_state
-	[[ -f $M3_SCRIPT ]] || return 1
+  ensure_state
+  [[ -f $M3_SCRIPT ]] || return 1
 
-	local wallpaper
-	wallpaper="$(resolve_wallpaper)" || return 1
+  local wallpaper
+  wallpaper="$(resolve_wallpaper)" || return 1
 
-	local flavour mode
-	flavour="$(read_state_field flavour)"
-	mode="$(read_state_field mode)"
-	flavour="$(normalize_scheme_type "$flavour")"
-	[[ $mode == "light" || $mode == "dark" ]] || mode="dark"
+  local flavour mode
+  flavour="$(read_state_field flavour)"
+  mode="$(read_state_field mode)"
+  flavour="$(normalize_scheme_type "$flavour")"
+  [[ $mode == "light" || $mode == "dark" ]] || mode="dark"
 
-	mkdir -p "$(dirname "$SCHEME_FILE")"
-	local accent_args=()
-	local accent_override="${XDG_CACHE_HOME:-${HOME}/.cache}/dots/smart-colors/accent-override"
-	if [[ -f $accent_override ]]; then
-		local accent_hex
-		accent_hex="$(cat "$accent_override")"
-		[[ -n $accent_hex ]] && accent_args=(--source-color "$accent_hex")
-	fi
+  mkdir -p "$(dirname "$SCHEME_FILE")"
+  local accent_args=()
+  local accent_override="${XDG_CACHE_HOME:-${HOME}/.cache}/dots/smart-colors/accent-override"
+  if [[ -f $accent_override ]]; then
+    local accent_hex
+    accent_hex="$(cat "$accent_override")"
+    [[ -n $accent_hex ]] && accent_args=(--source-color "$accent_hex")
+  fi
 
-	# Prefer system Python with materialyoucolor over pyenv shims on PATH.
-	# shellcheck source=/dev/null
-	source "${HOME}/.local/lib/dots/python-m3.sh" 2>/dev/null || true
-	if declare -f dots_run_m3_colors >/dev/null 2>&1; then
-		dots_run_m3_colors \
-			--image "$wallpaper" \
-			--output "$SCHEME_FILE" \
-			--mode "$mode" \
-			--scheme-type "$flavour" \
-			"${accent_args[@]}" >/dev/null 2>&1 || return 1
-	elif command -v dots-m3-colors >/dev/null 2>&1; then
-		dots-m3-colors \
-			--image "$wallpaper" \
-			--output "$SCHEME_FILE" \
-			--mode "$mode" \
-			--scheme-type "$flavour" \
-			"${accent_args[@]}" >/dev/null 2>&1 || return 1
-	elif command -v python3 >/dev/null 2>&1; then
-		python3 "$M3_SCRIPT" \
-			--image "$wallpaper" \
-			--output "$SCHEME_FILE" \
-			--mode "$mode" \
-			--scheme-type "$flavour" \
-			"${accent_args[@]}" >/dev/null 2>&1 || return 1
-	else
-		return 1
-	fi
+  # Prefer system Python with materialyoucolor over pyenv shims on PATH.
+  # shellcheck source=/dev/null
+  source "${HOME}/.local/lib/dots/python-m3.sh" 2>/dev/null || true
+  if declare -f dots_run_m3_colors >/dev/null 2>&1; then
+    dots_run_m3_colors \
+      --image "$wallpaper" \
+      --output "$SCHEME_FILE" \
+      --mode "$mode" \
+      --scheme-type "$flavour" \
+      "${accent_args[@]}" >/dev/null 2>&1 || return 1
+  elif command -v dots-m3-colors >/dev/null 2>&1; then
+    dots-m3-colors \
+      --image "$wallpaper" \
+      --output "$SCHEME_FILE" \
+      --mode "$mode" \
+      --scheme-type "$flavour" \
+      "${accent_args[@]}" >/dev/null 2>&1 || return 1
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 "$M3_SCRIPT" \
+      --image "$wallpaper" \
+      --output "$SCHEME_FILE" \
+      --mode "$mode" \
+      --scheme-type "$flavour" \
+      "${accent_args[@]}" >/dev/null 2>&1 || return 1
+  else
+    return 1
+  fi
 
-	# Regenerate hyprlock theme colors from the new scheme
-	if command -v dots-hyprlock-theme >/dev/null 2>&1; then
-		dots-hyprlock-theme >/dev/null 2>&1 || true
-	fi
+  # Regenerate hyprlock theme colors from the new scheme
+  if command -v dots-hyprlock-theme >/dev/null 2>&1; then
+    dots-hyprlock-theme >/dev/null 2>&1 || true
+  fi
 
-	if pgrep -x quickshell >/dev/null 2>&1 && command -v dots-quickshell >/dev/null 2>&1; then
-		dots-quickshell ipc colours reload >/dev/null 2>&1 || true
-	fi
+  if pgrep -x quickshell >/dev/null 2>&1 && command -v dots-quickshell >/dev/null 2>&1; then
+    dots-quickshell ipc colours reload >/dev/null 2>&1 || true
+  fi
 }
 
 cmd_list() {
-	ensure_state
-	ensure_scheme_file
+  ensure_state
+  ensure_scheme_file
 
-	python3 - "$SCHEME_FILE" "${SCHEME_TYPES[@]}" <<'PY'
+  python3 - "$SCHEME_FILE" "${SCHEME_TYPES[@]}" <<'PY'
 import json
 import pathlib
 import sys
@@ -257,119 +264,124 @@ PY
 }
 
 cmd_current() {
-	ensure_state
-	local name flavour variant
-	name="$(read_state_field name)"
-	flavour="$(read_state_field flavour)"
-	variant="$(read_state_field variant)"
-	[[ -n $name ]] || name="dynamic"
-	[[ -n $flavour ]] || flavour="tonal-spot"
-	[[ -n $variant ]] || variant="tonalspot"
-	printf '%s\n' "$name"
-	printf '%s\n' "$flavour"
-	printf '%s\n' "$variant"
+  ensure_state
+  local name flavour variant
+  name="$(read_state_field name)"
+  flavour="$(read_state_field flavour)"
+  variant="$(read_state_field variant)"
+  [[ -n $name ]] || name="dynamic"
+  [[ -n $flavour ]] || flavour="tonal-spot"
+  [[ -n $variant ]] || variant="tonalspot"
+  printf '%s\n' "$name"
+  printf '%s\n' "$flavour"
+  printf '%s\n' "$variant"
 }
 
 cmd_set() {
-	ensure_state
-	local name flavour mode variant
-	name="$(read_state_field name)"
-	flavour="$(read_state_field flavour)"
-	mode="$(read_state_field mode)"
-	variant="$(read_state_field variant)"
+  ensure_state
+  local name flavour mode variant
+  name="$(read_state_field name)"
+  flavour="$(read_state_field flavour)"
+  mode="$(read_state_field mode)"
+  variant="$(read_state_field variant)"
 
-	while [[ $# -gt 0 ]]; do
-		case "$1" in
-		-n | --name)
-			name="${2:-$name}"
-			shift 2
-			;;
-		-f | --flavour | --flavor)
-			flavour="$(normalize_scheme_type "${2:-$flavour}")"
-			variant="$(normalize_variant "$flavour")"
-			shift 2
-			;;
-		*)
-			shift
-			;;
-		esac
-	done
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -n | --name)
+        name="${2:-$name}"
+        shift 2
+        ;;
+      -f | --flavour | --flavor)
+        flavour="$(normalize_scheme_type "${2:-$flavour}")"
+        variant="$(normalize_variant "$flavour")"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
 
-	write_state "$name" "$flavour" "$mode" "$variant"
-	regenerate_scheme || true
+  write_state "$name" "$flavour" "$mode" "$variant"
+  regenerate_scheme || true
 }
 
 cmd_variant() {
-	ensure_state
-	local variant_in="${1:-tonalspot}"
-	local variant flavour name mode
-	variant="$(normalize_variant "$variant_in")"
-	flavour="$(variant_to_scheme_type "$variant")"
-	name="$(read_state_field name)"
-	mode="$(read_state_field mode)"
-	write_state "${name:-dynamic}" "$flavour" "${mode:-dark}" "$variant"
-	regenerate_scheme || true
+  ensure_state
+  local variant_in="${1:-tonalspot}"
+  local variant flavour name mode
+  variant="$(normalize_variant "$variant_in")"
+  flavour="$(variant_to_scheme_type "$variant")"
+  name="$(read_state_field name)"
+  mode="$(read_state_field mode)"
+  write_state "${name:-dynamic}" "$flavour" "${mode:-dark}" "$variant"
+  regenerate_scheme || true
 }
 
 cmd_mode() {
-	ensure_state
-	local mode="${1:-}"
-	if [[ $mode != "light" && $mode != "dark" ]]; then
-		echo "Usage: dots-color-scheme mode {light|dark}" >&2
-		exit 1
-	fi
-	local name flavour variant
-	name="$(read_state_field name)"
-	flavour="$(normalize_scheme_type "$(read_state_field flavour)")"
-	variant="$(read_state_field variant)"
-	write_state "${name:-dynamic}" "$flavour" "$mode" "${variant:-tonalspot}"
-	regenerate_scheme || true
-	# Keep GTK/libadwaita color-scheme aligned with live appearance mode.
-	if command -v dots-gtk-theme >/dev/null 2>&1; then
-		dots-gtk-theme -q color-scheme "$mode" >/dev/null 2>&1 || true
-	elif [[ -f ${HOME}/.local/lib/dots/gtk-theme-manager.sh ]]; then
-		# shellcheck source=/dev/null
-		source "${HOME}/.local/lib/dots/gtk-theme-manager.sh"
-		if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
-			apply_gtk_color_scheme "$mode" || true
-		fi
-	fi
+  ensure_state
+  local mode="${1:-}"
+  if [[ $mode != "light" && $mode != "dark" ]]; then
+    echo "Usage: dots-color-scheme mode {light|dark}" >&2
+    exit 1
+  fi
+  local name flavour variant
+  name="$(read_state_field name)"
+  flavour="$(normalize_scheme_type "$(read_state_field flavour)")"
+  variant="$(read_state_field variant)"
+  write_state "${name:-dynamic}" "$flavour" "$mode" "${variant:-tonalspot}"
+  regenerate_scheme || true
+  # Only push GTK when policy is follow (missing key = follow for legacy boots).
+  local gtk_policy="follow"
+  gtk_policy="$(read_state_field gtkColorScheme 2>/dev/null || true)"
+  [[ -n $gtk_policy ]] || gtk_policy="follow"
+  if [[ $gtk_policy == "follow" ]]; then
+    if command -v dots-gtk-theme >/dev/null 2>&1; then
+      dots-gtk-theme -q color-scheme follow >/dev/null 2>&1 || true
+    elif [[ -f ${HOME}/.local/lib/dots/gtk-theme-manager.sh ]]; then
+      # shellcheck source=/dev/null
+      source "${HOME}/.local/lib/dots/gtk-theme-manager.sh"
+      if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
+        apply_gtk_color_scheme follow || true
+      fi
+    fi
+  fi
 }
 
 cmd_regenerate() {
-	# Force a full M3 rewrite from the current wallpaper + state flavour/mode.
-	# ensure_scheme_file alone is a no-op when scheme.json already exists.
-	regenerate_scheme
+  # Force a full M3 rewrite from the current wallpaper + state flavour/mode.
+  # ensure_scheme_file alone is a no-op when scheme.json already exists.
+  regenerate_scheme
 }
 
 # Sync state.json from the meta already present in scheme.json (no regenerate).
 # Used by ThemePipeline.qml / apply-appearance.sh after a successful M3 write so boot
 # regenerate cannot fight the live schemeType/mode.
 cmd_sync_state() {
-	[[ -f $SCHEME_FILE ]] || {
-		echo "dots-color-scheme sync-state: scheme.json missing" >&2
-		return 1
-	}
-	local flavour mode name variant
-	flavour="$(normalize_scheme_type "$(read_scheme_meta flavour || true)")"
-	mode="$(read_scheme_meta mode || true)"
-	[[ $mode == "light" || $mode == "dark" ]] || mode="dark"
-	name="$(read_scheme_meta name || true)"
-	[[ -n $name ]] || name="dynamic"
-	variant="$(normalize_variant "$flavour")"
-	write_state "$name" "$flavour" "$mode" "$variant"
+  [[ -f $SCHEME_FILE ]] || {
+    echo "dots-color-scheme sync-state: scheme.json missing" >&2
+    return 1
+  }
+  local flavour mode name variant
+  flavour="$(normalize_scheme_type "$(read_scheme_meta flavour || true)")"
+  mode="$(read_scheme_meta mode || true)"
+  [[ $mode == "light" || $mode == "dark" ]] || mode="dark"
+  name="$(read_scheme_meta name || true)"
+  [[ -n $name ]] || name="dynamic"
+  variant="$(normalize_variant "$flavour")"
+  write_state "$name" "$flavour" "$mode" "$variant"
 }
 
 case "$cmd" in
-list) cmd_list ;;
-current) cmd_current ;;
-set) cmd_set "$@" ;;
-variant) cmd_variant "${1:-}" ;;
-mode) cmd_mode "${1:-}" ;;
-regenerate) cmd_regenerate ;;
-sync-state) cmd_sync_state ;;
-*)
-	echo "Usage: dots-color-scheme {list|current|set|variant|mode|regenerate|sync-state}" >&2
-	exit 1
-	;;
+  list) cmd_list ;;
+  current) cmd_current ;;
+  set) cmd_set "$@" ;;
+  variant) cmd_variant "${1:-}" ;;
+  mode) cmd_mode "${1:-}" ;;
+  regenerate) cmd_regenerate ;;
+  sync-state) cmd_sync_state ;;
+  *)
+    echo "Usage: dots-color-scheme {list|current|set|variant|mode|regenerate|sync-state}" >&2
+    exit 1
+    ;;
 esac

--- a/home/dot_local/bin/executable_dots-color-scheme
+++ b/home/dot_local/bin/executable_dots-color-scheme
@@ -8,8 +8,8 @@
 set -euo pipefail
 
 if [[ -r "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-  # shellcheck source=/dev/null
-  source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
+	# shellcheck source=/dev/null
+	source "$HOME/.local/lib/dots/wallpaper-resolver.sh" 2>/dev/null || true
 fi
 
 SCHEME_FILE="${HOME}/.cache/dots/smart-colors/scheme.json"
@@ -25,79 +25,79 @@ cmd="${1:-}"
 shift 2>/dev/null || true
 
 normalize_scheme_type() {
-  local raw="${1:-tonal-spot}"
-  local normalized
-  normalized=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
-  case "$normalized" in
-    vibrant) echo "vibrant" ;;
-    tonalspot | tonal-spot) echo "tonal-spot" ;;
-    expressive) echo "expressive" ;;
-    fidelity) echo "fidelity" ;;
-    content) echo "content" ;;
-    neutral) echo "neutral" ;;
-    monochrome) echo "monochrome" ;;
-    fruitsalad | rainbow) echo "expressive" ;;
-    auto | *) echo "tonal-spot" ;;
-  esac
+	local raw="${1:-tonal-spot}"
+	local normalized
+	normalized=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
+	case "$normalized" in
+	vibrant) echo "vibrant" ;;
+	tonalspot | tonal-spot) echo "tonal-spot" ;;
+	expressive) echo "expressive" ;;
+	fidelity) echo "fidelity" ;;
+	content) echo "content" ;;
+	neutral) echo "neutral" ;;
+	monochrome) echo "monochrome" ;;
+	fruitsalad | rainbow) echo "expressive" ;;
+	auto | *) echo "tonal-spot" ;;
+	esac
 }
 
 normalize_variant() {
-  local raw="${1:-tonalspot}"
-  local normalized
-  normalized=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
-  case "$normalized" in
-    tonal-spot | tonalspot) echo "tonalspot" ;;
-    vibrant | expressive | fidelity | content | neutral | monochrome | fruitsalad | rainbow) echo "$normalized" ;;
-    *) echo "tonalspot" ;;
-  esac
+	local raw="${1:-tonalspot}"
+	local normalized
+	normalized=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
+	case "$normalized" in
+	tonal-spot | tonalspot) echo "tonalspot" ;;
+	vibrant | expressive | fidelity | content | neutral | monochrome | fruitsalad | rainbow) echo "$normalized" ;;
+	*) echo "tonalspot" ;;
+	esac
 }
 
 variant_to_scheme_type() {
-  local variant
-  variant=$(normalize_variant "${1:-}")
-  case "$variant" in
-    tonalspot) echo "tonal-spot" ;;
-    fruitsalad | rainbow) echo "expressive" ;;
-    *) echo "$variant" ;;
-  esac
+	local variant
+	variant=$(normalize_variant "${1:-}")
+	case "$variant" in
+	tonalspot) echo "tonal-spot" ;;
+	fruitsalad | rainbow) echo "expressive" ;;
+	*) echo "$variant" ;;
+	esac
 }
 
 resolve_wallpaper() {
-  if declare -f dots_current_wallpaper >/dev/null 2>&1; then
-    local unified=""
-    unified="$(dots_current_wallpaper 2>/dev/null || true)"
-    if [[ -n ${unified:-} && -f $unified ]]; then
-      printf '%s\n' "$unified"
-      return 0
-    fi
-  fi
+	if declare -f dots_current_wallpaper >/dev/null 2>&1; then
+		local unified=""
+		unified="$(dots_current_wallpaper 2>/dev/null || true)"
+		if [[ -n ${unified:-} && -f $unified ]]; then
+			printf '%s\n' "$unified"
+			return 0
+		fi
+	fi
 
-  local wall=""
-  if [[ -f $CURRENT_WALL_CACHE ]]; then
-    wall="$(head -n 1 "$CURRENT_WALL_CACHE" 2>/dev/null | tr -d '\r' || true)"
-  elif [[ -L $WAL_WALL_LINK ]]; then
-    # Legacy pywal image symlink
-    wall="$(readlink -f "$WAL_WALL_LINK" 2>/dev/null || true)"
-  elif [[ -f $WAL_WALL_LINK ]]; then
-    # Canonical: text path file (never treat the wal file itself as the image)
-    wall="$(head -n 1 "$WAL_WALL_LINK" 2>/dev/null | tr -d '\r' || true)"
-  fi
+	local wall=""
+	if [[ -f $CURRENT_WALL_CACHE ]]; then
+		wall="$(head -n 1 "$CURRENT_WALL_CACHE" 2>/dev/null | tr -d '\r' || true)"
+	elif [[ -L $WAL_WALL_LINK ]]; then
+		# Legacy pywal image symlink
+		wall="$(readlink -f "$WAL_WALL_LINK" 2>/dev/null || true)"
+	elif [[ -f $WAL_WALL_LINK ]]; then
+		# Canonical: text path file (never treat the wal file itself as the image)
+		wall="$(head -n 1 "$WAL_WALL_LINK" 2>/dev/null | tr -d '\r' || true)"
+	fi
 
-  if [[ -n ${wall:-} && -f $wall ]]; then
-    printf '%s\n' "$wall"
-    return 0
-  fi
-  return 1
+	if [[ -n ${wall:-} && -f $wall ]]; then
+		printf '%s\n' "$wall"
+		return 0
+	fi
+	return 1
 }
 
 ensure_state_dir() {
-  mkdir -p "$STATE_DIR"
+	mkdir -p "$STATE_DIR"
 }
 
 read_scheme_meta() {
-  local field="${1:-}"
-  [[ -f $SCHEME_FILE ]] || return 1
-  python3 - "$SCHEME_FILE" "$field" <<'PY'
+	local field="${1:-}"
+	[[ -f $SCHEME_FILE ]] || return 1
+	python3 - "$SCHEME_FILE" "$field" <<'PY'
 import json
 import sys
 path, field = sys.argv[1], sys.argv[2]
@@ -108,12 +108,12 @@ PY
 }
 
 write_state() {
-  local name="$1"
-  local flavour="$2"
-  local mode="$3"
-  local variant="$4"
-  ensure_state_dir
-  python3 - "$STATE_FILE" "$name" "$flavour" "$mode" "$variant" <<'PY'
+	local name="$1"
+	local flavour="$2"
+	local mode="$3"
+	local variant="$4"
+	ensure_state_dir
+	python3 - "$STATE_FILE" "$name" "$flavour" "$mode" "$variant" <<'PY'
 import json
 import pathlib
 import sys
@@ -137,31 +137,31 @@ PY
 }
 
 ensure_state() {
-  ensure_state_dir
-  if [[ -f $STATE_FILE ]]; then
-    return 0
-  fi
+	ensure_state_dir
+	if [[ -f $STATE_FILE ]]; then
+		return 0
+	fi
 
-  local flavour="tonal-spot"
-  local mode="dark"
-  local variant="tonalspot"
+	local flavour="tonal-spot"
+	local mode="dark"
+	local variant="tonalspot"
 
-  if [[ -f $SCHEME_FILE ]]; then
-    local f m
-    f="$(read_scheme_meta flavour || true)"
-    m="$(read_scheme_meta mode || true)"
-    [[ -n ${f:-} ]] && flavour="$(normalize_scheme_type "$f")"
-    [[ $m == "light" || $m == "dark" ]] && mode="$m"
-    variant="$(normalize_variant "$flavour")"
-  fi
+	if [[ -f $SCHEME_FILE ]]; then
+		local f m
+		f="$(read_scheme_meta flavour || true)"
+		m="$(read_scheme_meta mode || true)"
+		[[ -n ${f:-} ]] && flavour="$(normalize_scheme_type "$f")"
+		[[ $m == "light" || $m == "dark" ]] && mode="$m"
+		variant="$(normalize_variant "$flavour")"
+	fi
 
-  write_state "dynamic" "$flavour" "$mode" "$variant"
+	write_state "dynamic" "$flavour" "$mode" "$variant"
 }
 
 read_state_field() {
-  local field="$1"
-  ensure_state
-  python3 - "$STATE_FILE" "$field" <<'PY'
+	local field="$1"
+	ensure_state
+	python3 - "$STATE_FILE" "$field" <<'PY'
 import json
 import sys
 path, field = sys.argv[1], sys.argv[2]
@@ -172,77 +172,77 @@ PY
 }
 
 ensure_scheme_file() {
-  if [[ -f $SCHEME_FILE ]]; then
-    return 0
-  fi
-  regenerate_scheme >/dev/null 2>&1 || true
+	if [[ -f $SCHEME_FILE ]]; then
+		return 0
+	fi
+	regenerate_scheme >/dev/null 2>&1 || true
 }
 
 regenerate_scheme() {
-  ensure_state
-  [[ -f $M3_SCRIPT ]] || return 1
+	ensure_state
+	[[ -f $M3_SCRIPT ]] || return 1
 
-  local wallpaper
-  wallpaper="$(resolve_wallpaper)" || return 1
+	local wallpaper
+	wallpaper="$(resolve_wallpaper)" || return 1
 
-  local flavour mode
-  flavour="$(read_state_field flavour)"
-  mode="$(read_state_field mode)"
-  flavour="$(normalize_scheme_type "$flavour")"
-  [[ $mode == "light" || $mode == "dark" ]] || mode="dark"
+	local flavour mode
+	flavour="$(read_state_field flavour)"
+	mode="$(read_state_field mode)"
+	flavour="$(normalize_scheme_type "$flavour")"
+	[[ $mode == "light" || $mode == "dark" ]] || mode="dark"
 
-  mkdir -p "$(dirname "$SCHEME_FILE")"
-  local accent_args=()
-  local accent_override="${XDG_CACHE_HOME:-${HOME}/.cache}/dots/smart-colors/accent-override"
-  if [[ -f $accent_override ]]; then
-    local accent_hex
-    accent_hex="$(cat "$accent_override")"
-    [[ -n $accent_hex ]] && accent_args=(--source-color "$accent_hex")
-  fi
+	mkdir -p "$(dirname "$SCHEME_FILE")"
+	local accent_args=()
+	local accent_override="${XDG_CACHE_HOME:-${HOME}/.cache}/dots/smart-colors/accent-override"
+	if [[ -f $accent_override ]]; then
+		local accent_hex
+		accent_hex="$(cat "$accent_override")"
+		[[ -n $accent_hex ]] && accent_args=(--source-color "$accent_hex")
+	fi
 
-  # Prefer system Python with materialyoucolor over pyenv shims on PATH.
-  # shellcheck source=/dev/null
-  source "${HOME}/.local/lib/dots/python-m3.sh" 2>/dev/null || true
-  if declare -f dots_run_m3_colors >/dev/null 2>&1; then
-    dots_run_m3_colors \
-      --image "$wallpaper" \
-      --output "$SCHEME_FILE" \
-      --mode "$mode" \
-      --scheme-type "$flavour" \
-      "${accent_args[@]}" >/dev/null 2>&1 || return 1
-  elif command -v dots-m3-colors >/dev/null 2>&1; then
-    dots-m3-colors \
-      --image "$wallpaper" \
-      --output "$SCHEME_FILE" \
-      --mode "$mode" \
-      --scheme-type "$flavour" \
-      "${accent_args[@]}" >/dev/null 2>&1 || return 1
-  elif command -v python3 >/dev/null 2>&1; then
-    python3 "$M3_SCRIPT" \
-      --image "$wallpaper" \
-      --output "$SCHEME_FILE" \
-      --mode "$mode" \
-      --scheme-type "$flavour" \
-      "${accent_args[@]}" >/dev/null 2>&1 || return 1
-  else
-    return 1
-  fi
+	# Prefer system Python with materialyoucolor over pyenv shims on PATH.
+	# shellcheck source=/dev/null
+	source "${HOME}/.local/lib/dots/python-m3.sh" 2>/dev/null || true
+	if declare -f dots_run_m3_colors >/dev/null 2>&1; then
+		dots_run_m3_colors \
+			--image "$wallpaper" \
+			--output "$SCHEME_FILE" \
+			--mode "$mode" \
+			--scheme-type "$flavour" \
+			"${accent_args[@]}" >/dev/null 2>&1 || return 1
+	elif command -v dots-m3-colors >/dev/null 2>&1; then
+		dots-m3-colors \
+			--image "$wallpaper" \
+			--output "$SCHEME_FILE" \
+			--mode "$mode" \
+			--scheme-type "$flavour" \
+			"${accent_args[@]}" >/dev/null 2>&1 || return 1
+	elif command -v python3 >/dev/null 2>&1; then
+		python3 "$M3_SCRIPT" \
+			--image "$wallpaper" \
+			--output "$SCHEME_FILE" \
+			--mode "$mode" \
+			--scheme-type "$flavour" \
+			"${accent_args[@]}" >/dev/null 2>&1 || return 1
+	else
+		return 1
+	fi
 
-  # Regenerate hyprlock theme colors from the new scheme
-  if command -v dots-hyprlock-theme >/dev/null 2>&1; then
-    dots-hyprlock-theme >/dev/null 2>&1 || true
-  fi
+	# Regenerate hyprlock theme colors from the new scheme
+	if command -v dots-hyprlock-theme >/dev/null 2>&1; then
+		dots-hyprlock-theme >/dev/null 2>&1 || true
+	fi
 
-  if pgrep -x quickshell >/dev/null 2>&1 && command -v dots-quickshell >/dev/null 2>&1; then
-    dots-quickshell ipc colours reload >/dev/null 2>&1 || true
-  fi
+	if pgrep -x quickshell >/dev/null 2>&1 && command -v dots-quickshell >/dev/null 2>&1; then
+		dots-quickshell ipc colours reload >/dev/null 2>&1 || true
+	fi
 }
 
 cmd_list() {
-  ensure_state
-  ensure_scheme_file
+	ensure_state
+	ensure_scheme_file
 
-  python3 - "$SCHEME_FILE" "${SCHEME_TYPES[@]}" <<'PY'
+	python3 - "$SCHEME_FILE" "${SCHEME_TYPES[@]}" <<'PY'
 import json
 import pathlib
 import sys
@@ -264,124 +264,124 @@ PY
 }
 
 cmd_current() {
-  ensure_state
-  local name flavour variant
-  name="$(read_state_field name)"
-  flavour="$(read_state_field flavour)"
-  variant="$(read_state_field variant)"
-  [[ -n $name ]] || name="dynamic"
-  [[ -n $flavour ]] || flavour="tonal-spot"
-  [[ -n $variant ]] || variant="tonalspot"
-  printf '%s\n' "$name"
-  printf '%s\n' "$flavour"
-  printf '%s\n' "$variant"
+	ensure_state
+	local name flavour variant
+	name="$(read_state_field name)"
+	flavour="$(read_state_field flavour)"
+	variant="$(read_state_field variant)"
+	[[ -n $name ]] || name="dynamic"
+	[[ -n $flavour ]] || flavour="tonal-spot"
+	[[ -n $variant ]] || variant="tonalspot"
+	printf '%s\n' "$name"
+	printf '%s\n' "$flavour"
+	printf '%s\n' "$variant"
 }
 
 cmd_set() {
-  ensure_state
-  local name flavour mode variant
-  name="$(read_state_field name)"
-  flavour="$(read_state_field flavour)"
-  mode="$(read_state_field mode)"
-  variant="$(read_state_field variant)"
+	ensure_state
+	local name flavour mode variant
+	name="$(read_state_field name)"
+	flavour="$(read_state_field flavour)"
+	mode="$(read_state_field mode)"
+	variant="$(read_state_field variant)"
 
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      -n | --name)
-        name="${2:-$name}"
-        shift 2
-        ;;
-      -f | --flavour | --flavor)
-        flavour="$(normalize_scheme_type "${2:-$flavour}")"
-        variant="$(normalize_variant "$flavour")"
-        shift 2
-        ;;
-      *)
-        shift
-        ;;
-    esac
-  done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		-n | --name)
+			name="${2:-$name}"
+			shift 2
+			;;
+		-f | --flavour | --flavor)
+			flavour="$(normalize_scheme_type "${2:-$flavour}")"
+			variant="$(normalize_variant "$flavour")"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
 
-  write_state "$name" "$flavour" "$mode" "$variant"
-  regenerate_scheme || true
+	write_state "$name" "$flavour" "$mode" "$variant"
+	regenerate_scheme || true
 }
 
 cmd_variant() {
-  ensure_state
-  local variant_in="${1:-tonalspot}"
-  local variant flavour name mode
-  variant="$(normalize_variant "$variant_in")"
-  flavour="$(variant_to_scheme_type "$variant")"
-  name="$(read_state_field name)"
-  mode="$(read_state_field mode)"
-  write_state "${name:-dynamic}" "$flavour" "${mode:-dark}" "$variant"
-  regenerate_scheme || true
+	ensure_state
+	local variant_in="${1:-tonalspot}"
+	local variant flavour name mode
+	variant="$(normalize_variant "$variant_in")"
+	flavour="$(variant_to_scheme_type "$variant")"
+	name="$(read_state_field name)"
+	mode="$(read_state_field mode)"
+	write_state "${name:-dynamic}" "$flavour" "${mode:-dark}" "$variant"
+	regenerate_scheme || true
 }
 
 cmd_mode() {
-  ensure_state
-  local mode="${1:-}"
-  if [[ $mode != "light" && $mode != "dark" ]]; then
-    echo "Usage: dots-color-scheme mode {light|dark}" >&2
-    exit 1
-  fi
-  local name flavour variant
-  name="$(read_state_field name)"
-  flavour="$(normalize_scheme_type "$(read_state_field flavour)")"
-  variant="$(read_state_field variant)"
-  write_state "${name:-dynamic}" "$flavour" "$mode" "${variant:-tonalspot}"
-  regenerate_scheme || true
-  # Only push GTK when policy is follow (missing key = follow for legacy boots).
-  local gtk_policy="follow"
-  gtk_policy="$(read_state_field gtkColorScheme 2>/dev/null || true)"
-  [[ -n $gtk_policy ]] || gtk_policy="follow"
-  if [[ $gtk_policy == "follow" ]]; then
-    if command -v dots-gtk-theme >/dev/null 2>&1; then
-      dots-gtk-theme -q color-scheme follow >/dev/null 2>&1 || true
-    elif [[ -f ${HOME}/.local/lib/dots/gtk-theme-manager.sh ]]; then
-      # shellcheck source=/dev/null
-      source "${HOME}/.local/lib/dots/gtk-theme-manager.sh"
-      if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
-        apply_gtk_color_scheme follow || true
-      fi
-    fi
-  fi
+	ensure_state
+	local mode="${1:-}"
+	if [[ $mode != "light" && $mode != "dark" ]]; then
+		echo "Usage: dots-color-scheme mode {light|dark}" >&2
+		exit 1
+	fi
+	local name flavour variant
+	name="$(read_state_field name)"
+	flavour="$(normalize_scheme_type "$(read_state_field flavour)")"
+	variant="$(read_state_field variant)"
+	write_state "${name:-dynamic}" "$flavour" "$mode" "${variant:-tonalspot}"
+	regenerate_scheme || true
+	# Only push GTK when policy is follow (missing key = follow for legacy boots).
+	local gtk_policy="follow"
+	gtk_policy="$(read_state_field gtkColorScheme 2>/dev/null || true)"
+	[[ -n $gtk_policy ]] || gtk_policy="follow"
+	if [[ $gtk_policy == "follow" ]]; then
+		if command -v dots-gtk-theme >/dev/null 2>&1; then
+			dots-gtk-theme -q color-scheme follow >/dev/null 2>&1 || true
+		elif [[ -f ${HOME}/.local/lib/dots/gtk-theme-manager.sh ]]; then
+			# shellcheck source=/dev/null
+			source "${HOME}/.local/lib/dots/gtk-theme-manager.sh"
+			if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
+				apply_gtk_color_scheme follow || true
+			fi
+		fi
+	fi
 }
 
 cmd_regenerate() {
-  # Force a full M3 rewrite from the current wallpaper + state flavour/mode.
-  # ensure_scheme_file alone is a no-op when scheme.json already exists.
-  regenerate_scheme
+	# Force a full M3 rewrite from the current wallpaper + state flavour/mode.
+	# ensure_scheme_file alone is a no-op when scheme.json already exists.
+	regenerate_scheme
 }
 
 # Sync state.json from the meta already present in scheme.json (no regenerate).
 # Used by ThemePipeline.qml / apply-appearance.sh after a successful M3 write so boot
 # regenerate cannot fight the live schemeType/mode.
 cmd_sync_state() {
-  [[ -f $SCHEME_FILE ]] || {
-    echo "dots-color-scheme sync-state: scheme.json missing" >&2
-    return 1
-  }
-  local flavour mode name variant
-  flavour="$(normalize_scheme_type "$(read_scheme_meta flavour || true)")"
-  mode="$(read_scheme_meta mode || true)"
-  [[ $mode == "light" || $mode == "dark" ]] || mode="dark"
-  name="$(read_scheme_meta name || true)"
-  [[ -n $name ]] || name="dynamic"
-  variant="$(normalize_variant "$flavour")"
-  write_state "$name" "$flavour" "$mode" "$variant"
+	[[ -f $SCHEME_FILE ]] || {
+		echo "dots-color-scheme sync-state: scheme.json missing" >&2
+		return 1
+	}
+	local flavour mode name variant
+	flavour="$(normalize_scheme_type "$(read_scheme_meta flavour || true)")"
+	mode="$(read_scheme_meta mode || true)"
+	[[ $mode == "light" || $mode == "dark" ]] || mode="dark"
+	name="$(read_scheme_meta name || true)"
+	[[ -n $name ]] || name="dynamic"
+	variant="$(normalize_variant "$flavour")"
+	write_state "$name" "$flavour" "$mode" "$variant"
 }
 
 case "$cmd" in
-  list) cmd_list ;;
-  current) cmd_current ;;
-  set) cmd_set "$@" ;;
-  variant) cmd_variant "${1:-}" ;;
-  mode) cmd_mode "${1:-}" ;;
-  regenerate) cmd_regenerate ;;
-  sync-state) cmd_sync_state ;;
-  *)
-    echo "Usage: dots-color-scheme {list|current|set|variant|mode|regenerate|sync-state}" >&2
-    exit 1
-    ;;
+list) cmd_list ;;
+current) cmd_current ;;
+set) cmd_set "$@" ;;
+variant) cmd_variant "${1:-}" ;;
+mode) cmd_mode "${1:-}" ;;
+regenerate) cmd_regenerate ;;
+sync-state) cmd_sync_state ;;
+*)
+	echo "Usage: dots-color-scheme {list|current|set|variant|mode|regenerate|sync-state}" >&2
+	exit 1
+	;;
 esac

--- a/home/dot_local/bin/executable_dots-gtk-theme
+++ b/home/dot_local/bin/executable_dots-gtk-theme
@@ -58,23 +58,23 @@ source ~/.local/lib/dots/easy-options/easyoptions.sh || exit
 
 # Source the GTK theme manager - try multiple locations
 gtk_theme_manager_paths=(
-  "$HOME/.local/lib/dots/gtk-theme-manager.sh"
-  "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../lib/dots/gtk-theme-manager.sh"
+	"$HOME/.local/lib/dots/gtk-theme-manager.sh"
+	"$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../lib/dots/gtk-theme-manager.sh"
 )
 
 gtk_theme_manager_found=false
 for path in "${gtk_theme_manager_paths[@]}"; do
-  if [[ -f $path ]]; then
-    source "$path"
-    gtk_theme_manager_found=true
-    break
-  fi
+	if [[ -f $path ]]; then
+		source "$path"
+		gtk_theme_manager_found=true
+		break
+	fi
 done
 
 if [[ $gtk_theme_manager_found != "true" ]]; then
-  echo "Error: GTK theme manager not found in any of these locations:" >&2
-  printf '  %s\n' "${gtk_theme_manager_paths[@]}" >&2
-  exit 1
+	echo "Error: GTK theme manager not found in any of these locations:" >&2
+	printf '  %s\n' "${gtk_theme_manager_paths[@]}" >&2
+	exit 1
 fi
 
 # Color definitions for output
@@ -88,478 +88,478 @@ readonly NC='\033[0m' # No Color
 
 # Function to log messages with verbosity control
 log() {
-  local level="$1"
-  shift
-  local message="$*"
+	local level="$1"
+	shift
+	local message="$*"
 
-  if [[ ${quiet:-} == "yes" ]] && [[ $level != "ERROR" ]]; then
-    return 0
-  fi
+	if [[ ${quiet:-} == "yes" ]] && [[ $level != "ERROR" ]]; then
+		return 0
+	fi
 
-  local timestamp
-  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+	local timestamp
+	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-  case "$level" in
-    "ERROR")
-      echo -e "${RED}❌ [ERROR] $message${NC}" >&2
-      ;;
-    "WARN")
-      echo -e "${YELLOW}⚠️  [WARN] $message${NC}" >&2
-      ;;
-    "INFO")
-      if [[ ${verbose:-} == "yes" ]]; then
-        echo -e "${BLUE}ℹ️  [INFO] $message${NC}"
-      fi
-      ;;
-    "DEBUG")
-      if [[ ${debug:-} == "yes" ]]; then
-        echo -e "${PURPLE}🐛 [DEBUG] [$timestamp] $message${NC}" >&2
-      fi
-      ;;
-    *)
-      echo -e "$message"
-      ;;
-  esac
+	case "$level" in
+	"ERROR")
+		echo -e "${RED}❌ [ERROR] $message${NC}" >&2
+		;;
+	"WARN")
+		echo -e "${YELLOW}⚠️  [WARN] $message${NC}" >&2
+		;;
+	"INFO")
+		if [[ ${verbose:-} == "yes" ]]; then
+			echo -e "${BLUE}ℹ️  [INFO] $message${NC}"
+		fi
+		;;
+	"DEBUG")
+		if [[ ${debug:-} == "yes" ]]; then
+			echo -e "${PURPLE}🐛 [DEBUG] [$timestamp] $message${NC}" >&2
+		fi
+		;;
+	*)
+		echo -e "$message"
+		;;
+	esac
 }
 
 # Function to list installed GTK themes
 cmd_list() {
-  local use_plain=false
-  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+	local use_plain=false
+	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-  local themes
-  themes=$(list_installed_gtk_themes)
+	local themes
+	themes=$(list_installed_gtk_themes)
 
-  if [[ -z $themes ]]; then
-    [[ $use_plain == true ]] || log "WARN" "No GTK themes found"
-    return 1
-  fi
+	if [[ -z $themes ]]; then
+		[[ $use_plain == true ]] || log "WARN" "No GTK themes found"
+		return 1
+	fi
 
-  if [[ $use_plain == true ]]; then
-    printf '%s\n' "$themes"
-    return 0
-  fi
+	if [[ $use_plain == true ]]; then
+		printf '%s\n' "$themes"
+		return 0
+	fi
 
-  log "" "${BLUE}📋 Installed GTK themes:${NC}"
-  log "" ""
+	log "" "${BLUE}📋 Installed GTK themes:${NC}"
+	log "" ""
 
-  local current_theme
-  current_theme=$(get_current_gtk_theme)
-  log "DEBUG" "Current theme: $current_theme"
+	local current_theme
+	current_theme=$(get_current_gtk_theme)
+	log "DEBUG" "Current theme: $current_theme"
 
-  while IFS= read -r theme; do
-    if [[ $theme == "$current_theme" ]]; then
-      log "" "  ${GREEN}✓${NC} $theme ${CYAN}(current)${NC}"
-    else
-      log "" "    $theme"
-    fi
-  done <<<"$themes"
+	while IFS= read -r theme; do
+		if [[ $theme == "$current_theme" ]]; then
+			log "" "  ${GREEN}✓${NC} $theme ${CYAN}(current)${NC}"
+		else
+			log "" "    $theme"
+		fi
+	done <<<"$themes"
 
-  log "" ""
-  log "" "${CYAN}💡 Tip:${NC} Use 'dots gtk-theme apply <theme>' to apply a theme"
+	log "" ""
+	log "" "${CYAN}💡 Tip:${NC} Use 'dots gtk-theme apply <theme>' to apply a theme"
 }
 
 # Function to show current theme
 cmd_current() {
-  local use_plain=false
-  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+	local use_plain=false
+	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-  local current_theme
-  current_theme=$(get_current_gtk_theme)
+	local current_theme
+	current_theme=$(get_current_gtk_theme)
 
-  if [[ $use_plain == true ]]; then
-    printf '%s\n' "$current_theme"
-    return 0
-  fi
+	if [[ $use_plain == true ]]; then
+		printf '%s\n' "$current_theme"
+		return 0
+	fi
 
-  log "" "${BLUE}🎨 Current GTK Theme:${NC} $current_theme"
+	log "" "${BLUE}🎨 Current GTK Theme:${NC} $current_theme"
 
-  # Show additional info
-  if [[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" ]]; then
-    local icon_theme
-    icon_theme=$(grep "^gtk-icon-theme-name=" "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" | cut -d'=' -f2)
-    log "" "${BLUE}🎯 Icon Theme:${NC} $icon_theme"
+	# Show additional info
+	if [[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" ]]; then
+		local icon_theme
+		icon_theme=$(grep "^gtk-icon-theme-name=" "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" | cut -d'=' -f2)
+		log "" "${BLUE}🎯 Icon Theme:${NC} $icon_theme"
 
-    local dark_pref
-    dark_pref=$(grep "^gtk-application-prefer-dark-theme=" "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" | cut -d'=' -f2)
-    log "" "${BLUE}🌙 Dark Theme Preference:${NC} $dark_pref"
-  fi
+		local dark_pref
+		dark_pref=$(grep "^gtk-application-prefer-dark-theme=" "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" | cut -d'=' -f2)
+		log "" "${BLUE}🌙 Dark Theme Preference:${NC} $dark_pref"
+	fi
 }
 
 # Function to show current icon theme
 cmd_current_icon() {
-  local use_plain=false
-  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+	local use_plain=false
+	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-  local current_icon
-  current_icon="$(get_current_icon_theme 2>/dev/null || true)"
-  [[ -n $current_icon ]] || current_icon="Unknown"
+	local current_icon
+	current_icon="$(get_current_icon_theme 2>/dev/null || true)"
+	[[ -n $current_icon ]] || current_icon="Unknown"
 
-  if [[ $use_plain == true ]]; then
-    printf '%s\n' "$current_icon"
-    return 0
-  fi
+	if [[ $use_plain == true ]]; then
+		printf '%s\n' "$current_icon"
+		return 0
+	fi
 
-  log "" "${BLUE}🎯 Current Icon Theme:${NC} $current_icon"
+	log "" "${BLUE}🎯 Current Icon Theme:${NC} $current_icon"
 }
 
 # Function to apply specific theme
 cmd_apply() {
-  local theme_name="$1"
-  local icon_theme="${2:-}"
-  local color_scheme="${3:-}"
+	local theme_name="$1"
+	local icon_theme="${2:-}"
+	local color_scheme="${3:-}"
 
-  if [[ -z $icon_theme ]]; then
-    icon_theme="$(get_current_icon_theme 2>/dev/null || true)"
-    [[ -n $icon_theme ]] || icon_theme="Numix-Circle"
-  fi
+	if [[ -z $icon_theme ]]; then
+		icon_theme="$(get_current_icon_theme 2>/dev/null || true)"
+		[[ -n $icon_theme ]] || icon_theme="Numix-Circle"
+	fi
 
-  log "" "${BLUE}🎨 Applying GTK Theme:${NC} $theme_name"
-  log "DEBUG" "Icon theme: $icon_theme, color-scheme: ${color_scheme:-live-policy}"
+	log "" "${BLUE}🎨 Applying GTK Theme:${NC} $theme_name"
+	log "DEBUG" "Icon theme: $icon_theme, color-scheme: ${color_scheme:-live-policy}"
 
-  if [[ -n $color_scheme ]]; then
-    if apply_gtk_theme "$theme_name" "$icon_theme" "$color_scheme"; then
-      log "" "${GREEN}✅ Theme applied successfully${NC}"
-    else
-      log "ERROR" "Failed to apply theme"
-      return 1
-    fi
-  else
-    if apply_gtk_theme "$theme_name" "$icon_theme"; then
-      log "" "${GREEN}✅ Theme applied successfully${NC}"
-    else
-      log "ERROR" "Failed to apply theme"
-      return 1
-    fi
-  fi
+	if [[ -n $color_scheme ]]; then
+		if apply_gtk_theme "$theme_name" "$icon_theme" "$color_scheme"; then
+			log "" "${GREEN}✅ Theme applied successfully${NC}"
+		else
+			log "ERROR" "Failed to apply theme"
+			return 1
+		fi
+	else
+		if apply_gtk_theme "$theme_name" "$icon_theme"; then
+			log "" "${GREEN}✅ Theme applied successfully${NC}"
+		else
+			log "ERROR" "Failed to apply theme"
+			return 1
+		fi
+	fi
 }
 
 # Update icon theme while preserving the current GTK theme + color-scheme policy.
 cmd_set_icons() {
-  local icon_theme="${1:-}"
-  [[ -n $icon_theme ]] || {
-    log "ERROR" "Icon theme name required"
-    log "" "Usage: $(basename "$0") set-icons <icon-theme>"
-    return 1
-  }
+	local icon_theme="${1:-}"
+	[[ -n $icon_theme ]] || {
+		log "ERROR" "Icon theme name required"
+		log "" "Usage: $(basename "$0") set-icons <icon-theme>"
+		return 1
+	}
 
-  local gtk_theme
-  gtk_theme="$(get_current_gtk_theme)"
+	local gtk_theme
+	gtk_theme="$(get_current_gtk_theme)"
 
-  log "" "${BLUE}🎯 Applying icon theme:${NC} $icon_theme (gtk=$gtk_theme)"
-  if apply_gtk_theme "$gtk_theme" "$icon_theme"; then
-    log "" "${GREEN}✅ Icon theme applied successfully${NC}"
-  else
-    log "ERROR" "Failed to apply icon theme"
-    return 1
-  fi
+	log "" "${BLUE}🎯 Applying icon theme:${NC} $icon_theme (gtk=$gtk_theme)"
+	if apply_gtk_theme "$gtk_theme" "$icon_theme"; then
+		log "" "${GREEN}✅ Icon theme applied successfully${NC}"
+	else
+		log "ERROR" "Failed to apply icon theme"
+		return 1
+	fi
 }
 
 cmd_current_color_scheme() {
-  local use_plain=false
-  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+	local use_plain=false
+	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-  local policy
-  policy="$(get_current_gtk_color_scheme)"
+	local policy
+	policy="$(get_current_gtk_color_scheme)"
 
-  if [[ $use_plain == true ]]; then
-    printf '%s\n' "$policy"
-    return 0
-  fi
+	if [[ $use_plain == true ]]; then
+		printf '%s\n' "$policy"
+		return 0
+	fi
 
-  log "" "${BLUE}🎨 GTK color-scheme policy:${NC} $policy"
+	log "" "${BLUE}🎨 GTK color-scheme policy:${NC} $policy"
 }
 
 # Set GTK color-scheme policy. Never writes shell `mode`.
 cmd_color_scheme() {
-  local requested="${1:-}"
-  local policy
-  policy="$(normalize_gtk_color_scheme "$requested")"
-  [[ $policy != "invalid" && -n $requested ]] || {
-    log "ERROR" "Policy must be follow|default|prefer-light|prefer-dark|light|dark"
-    log "" "Usage: $(basename "$0") color-scheme <follow|default|prefer-light|prefer-dark|light|dark>"
-    return 1
-  }
-  if apply_gtk_color_scheme "$policy"; then
-    log "" "${GREEN}✅ GTK color-scheme policy:${NC} $policy"
-  else
-    log "ERROR" "Failed to sync GTK color-scheme"
-    return 1
-  fi
+	local requested="${1:-}"
+	local policy
+	policy="$(normalize_gtk_color_scheme "$requested")"
+	[[ $policy != "invalid" && -n $requested ]] || {
+		log "ERROR" "Policy must be follow|default|prefer-light|prefer-dark|light|dark"
+		log "" "Usage: $(basename "$0") color-scheme <follow|default|prefer-light|prefer-dark|light|dark>"
+		return 1
+	}
+	if apply_gtk_color_scheme "$policy"; then
+		log "" "${GREEN}✅ GTK color-scheme policy:${NC} $policy"
+	else
+		log "ERROR" "Failed to sync GTK color-scheme"
+		return 1
+	fi
 }
 
 cmd_sync_color_scheme() {
-  if sync_gtk_color_scheme; then
-    log "" "${GREEN}✅ GTK color-scheme re-applied:${NC} $(get_current_gtk_color_scheme)"
-  else
-    log "ERROR" "Failed to re-apply GTK color-scheme"
-    return 1
-  fi
+	if sync_gtk_color_scheme; then
+		log "" "${GREEN}✅ GTK color-scheme re-applied:${NC} $(get_current_gtk_color_scheme)"
+	else
+		log "ERROR" "Failed to re-apply GTK color-scheme"
+		return 1
+	fi
 }
 
 # Function to detect optimal theme
 cmd_detect() {
-  local wallpaper_path="${1:-}"
+	local wallpaper_path="${1:-}"
 
-  if [[ -z $wallpaper_path ]]; then
-    if [[ -f $HOME/.local/lib/dots/wallpaper-resolver.sh ]]; then
-      # shellcheck source=/dev/null
-      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-      wallpaper_path="$(dots_current_wallpaper 2>/dev/null || true)"
-    fi
-    if [[ -z ${wallpaper_path:-} ]]; then
-      echo -e "${RED}❌ No wallpaper specified and no current wallpaper found${NC}"
-      return 1
-    fi
-  fi
+	if [[ -z $wallpaper_path ]]; then
+		if [[ -f $HOME/.local/lib/dots/wallpaper-resolver.sh ]]; then
+			# shellcheck source=/dev/null
+			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+			wallpaper_path="$(dots_current_wallpaper 2>/dev/null || true)"
+		fi
+		if [[ -z ${wallpaper_path:-} ]]; then
+			echo -e "${RED}❌ No wallpaper specified and no current wallpaper found${NC}"
+			return 1
+		fi
+	fi
 
-  if [[ ! -f $wallpaper_path ]]; then
-    echo -e "${RED}❌ Wallpaper file not found: $wallpaper_path${NC}"
-    return 1
-  fi
+	if [[ ! -f $wallpaper_path ]]; then
+		echo -e "${RED}❌ Wallpaper file not found: $wallpaper_path${NC}"
+		return 1
+	fi
 
-  echo -e "${BLUE}🔍 Analyzing wallpaper:${NC} $(basename "$wallpaper_path")"
+	echo -e "${BLUE}🔍 Analyzing wallpaper:${NC} $(basename "$wallpaper_path")"
 
-  local theme_info
-  theme_info=$(detect_optimal_gtk_theme "$wallpaper_path")
-  local detected_theme="${theme_info%:*}"
-  local prefer_dark="${theme_info#*:}"
+	local theme_info
+	theme_info=$(detect_optimal_gtk_theme "$wallpaper_path")
+	local detected_theme="${theme_info%:*}"
+	local prefer_dark="${theme_info#*:}"
 
-  echo -e "${GREEN}🎯 Detected optimal theme:${NC} $detected_theme"
-  echo -e "${GREEN}🌙 Dark preference:${NC} $prefer_dark"
+	echo -e "${GREEN}🎯 Detected optimal theme:${NC} $detected_theme"
+	echo -e "${GREEN}🌙 Dark preference:${NC} $prefer_dark"
 
-  # Ask if user wants to apply
-  read -p "Apply this theme? (y/N): " -n 1 -r
-  echo
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
-    cmd_apply "$detected_theme" "Numix-Circle" "$prefer_dark"
-  fi
+	# Ask if user wants to apply
+	read -p "Apply this theme? (y/N): " -n 1 -r
+	echo
+	if [[ $REPLY =~ ^[Yy]$ ]]; then
+		cmd_apply "$detected_theme" "Numix-Circle" "$prefer_dark"
+	fi
 }
 
 # Function to apply theme-pack GTK settings
 cmd_theme_pack() {
-  local theme_id="${1:-}"
+	local theme_id="${1:-}"
 
-  echo -e "${BLUE}🎨 Applying GTK theme from theme pack:${NC} ${theme_id:-auto-detect}"
+	echo -e "${BLUE}🎨 Applying GTK theme from theme pack:${NC} ${theme_id:-auto-detect}"
 
-  if apply_theme_gtk_theme "$theme_id"; then
-    echo -e "${GREEN}✅ Theme pack GTK theme applied successfully${NC}"
-  else
-    echo -e "${RED}❌ Failed to apply theme pack GTK theme${NC}"
-    return 1
-  fi
+	if apply_theme_gtk_theme "$theme_id"; then
+		echo -e "${GREEN}✅ Theme pack GTK theme applied successfully${NC}"
+	else
+		echo -e "${RED}❌ Failed to apply theme pack GTK theme${NC}"
+		return 1
+	fi
 }
 
 # Function to auto-detect and apply
 cmd_auto() {
-  echo -e "${BLUE}🤖 Auto-detecting optimal GTK theme...${NC}"
-  cmd_theme_pack ""
+	echo -e "${BLUE}🤖 Auto-detecting optimal GTK theme...${NC}"
+	cmd_theme_pack ""
 }
 
 # Function to list icon themes
 cmd_icons() {
-  local use_plain=false
-  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+	local use_plain=false
+	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-  local icon_dirs=(
-    "/usr/share/icons"
-    "/usr/local/share/icons"
-    "$HOME/.icons"
-    "${XDG_DATA_HOME:-$HOME/.local/share}/icons"
-  )
+	local icon_dirs=(
+		"/usr/share/icons"
+		"/usr/local/share/icons"
+		"$HOME/.icons"
+		"${XDG_DATA_HOME:-$HOME/.local/share}/icons"
+	)
 
-  local icons=()
-  for icon_dir in "${icon_dirs[@]}"; do
-    if [[ -d $icon_dir ]]; then
-      while IFS= read -r -d '' icon_path; do
-        local icon_name
-        icon_name=$(basename "$icon_path")
-        case "$icon_name" in
-          default | hicolor) continue ;;
-        esac
-        if [[ -f "$icon_path/index.theme" ]]; then
-          icons+=("$icon_name")
-        fi
-      done < <(find "$icon_dir" -maxdepth 1 -mindepth 1 -type d -print0 2>/dev/null)
-    fi
-  done
+	local icons=()
+	for icon_dir in "${icon_dirs[@]}"; do
+		if [[ -d $icon_dir ]]; then
+			while IFS= read -r -d '' icon_path; do
+				local icon_name
+				icon_name=$(basename "$icon_path")
+				case "$icon_name" in
+				default | hicolor) continue ;;
+				esac
+				if [[ -f "$icon_path/index.theme" ]]; then
+					icons+=("$icon_name")
+				fi
+			done < <(find "$icon_dir" -maxdepth 1 -mindepth 1 -type d -print0 2>/dev/null)
+		fi
+	done
 
-  if ((${#icons[@]} == 0)); then
-    if [[ $use_plain == true ]]; then
-      return 1
-    fi
-    echo -e "${YELLOW}⚠️  No icon themes found${NC}"
-    return 1
-  fi
+	if ((${#icons[@]} == 0)); then
+		if [[ $use_plain == true ]]; then
+			return 1
+		fi
+		echo -e "${YELLOW}⚠️  No icon themes found${NC}"
+		return 1
+	fi
 
-  local unique_icons
-  unique_icons=$(printf '%s\n' "${icons[@]}" | sort -u)
+	local unique_icons
+	unique_icons=$(printf '%s\n' "${icons[@]}" | sort -u)
 
-  if [[ $use_plain == true ]]; then
-    printf '%s\n' "$unique_icons"
-    return 0
-  fi
+	if [[ $use_plain == true ]]; then
+		printf '%s\n' "$unique_icons"
+		return 0
+	fi
 
-  echo -e "${BLUE}🎯 Installed Icon Themes:${NC}"
-  echo ""
+	echo -e "${BLUE}🎯 Installed Icon Themes:${NC}"
+	echo ""
 
-  local current_icon=""
-  current_icon="$(get_current_icon_theme 2>/dev/null || true)"
+	local current_icon=""
+	current_icon="$(get_current_icon_theme 2>/dev/null || true)"
 
-  while IFS= read -r icon; do
-    [[ -z $icon ]] && continue
-    if [[ $icon == "$current_icon" ]]; then
-      echo -e "  ${GREEN}✓${NC} $icon ${CYAN}(current)${NC}"
-    else
-      echo -e "    $icon"
-    fi
-  done <<<"$unique_icons"
+	while IFS= read -r icon; do
+		[[ -z $icon ]] && continue
+		if [[ $icon == "$current_icon" ]]; then
+			echo -e "  ${GREEN}✓${NC} $icon ${CYAN}(current)${NC}"
+		else
+			echo -e "    $icon"
+		fi
+	done <<<"$unique_icons"
 }
 
 # Function to show theme information
 cmd_info() {
-  local theme_name="$1"
+	local theme_name="$1"
 
-  echo -e "${BLUE}ℹ️  Theme Information: $theme_name${NC}"
-  echo ""
+	echo -e "${BLUE}ℹ️  Theme Information: $theme_name${NC}"
+	echo ""
 
-  # Find theme directories
-  local theme_dirs=(
-    "/usr/share/themes"
-    "/usr/local/share/themes"
-    "$HOME/.themes"
-    "$HOME/.local/share/themes"
-  )
+	# Find theme directories
+	local theme_dirs=(
+		"/usr/share/themes"
+		"/usr/local/share/themes"
+		"$HOME/.themes"
+		"$HOME/.local/share/themes"
+	)
 
-  local found_path=""
-  for theme_dir in "${theme_dirs[@]}"; do
-    if [[ -d "$theme_dir/$theme_name" ]]; then
-      found_path="$theme_dir/$theme_name"
-      break
-    fi
-  done
+	local found_path=""
+	for theme_dir in "${theme_dirs[@]}"; do
+		if [[ -d "$theme_dir/$theme_name" ]]; then
+			found_path="$theme_dir/$theme_name"
+			break
+		fi
+	done
 
-  if [[ -z $found_path ]]; then
-    echo -e "${RED}❌ Theme not found: $theme_name${NC}"
-    return 1
-  fi
+	if [[ -z $found_path ]]; then
+		echo -e "${RED}❌ Theme not found: $theme_name${NC}"
+		return 1
+	fi
 
-  echo -e "${GREEN}📁 Location:${NC} $found_path"
+	echo -e "${GREEN}📁 Location:${NC} $found_path"
 
-  # Check what components are available
-  echo -e "${GREEN}🧩 Available Components:${NC}"
-  if [[ -d "$found_path/gtk-2.0" ]]; then
-    echo -e "  ✅ GTK2"
-  else
-    echo -e "  ❌ GTK2"
-  fi
+	# Check what components are available
+	echo -e "${GREEN}🧩 Available Components:${NC}"
+	if [[ -d "$found_path/gtk-2.0" ]]; then
+		echo -e "  ✅ GTK2"
+	else
+		echo -e "  ❌ GTK2"
+	fi
 
-  if [[ -d "$found_path/gtk-3.0" ]]; then
-    echo -e "  ✅ GTK3"
-  else
-    echo -e "  ❌ GTK3"
-  fi
+	if [[ -d "$found_path/gtk-3.0" ]]; then
+		echo -e "  ✅ GTK3"
+	else
+		echo -e "  ❌ GTK3"
+	fi
 
-  if [[ -d "$found_path/gtk-4.0" ]]; then
-    echo -e "  ✅ GTK4"
-  else
-    echo -e "  ❌ GTK4"
-  fi
+	if [[ -d "$found_path/gtk-4.0" ]]; then
+		echo -e "  ✅ GTK4"
+	else
+		echo -e "  ❌ GTK4"
+	fi
 
-  # Show index.theme if available
-  if [[ -f "$found_path/index.theme" ]]; then
-    echo ""
-    echo -e "${GREEN}📋 Theme Metadata:${NC}"
-    while IFS= read -r line; do
-      if [[ $line =~ ^Name= ]]; then
-        echo -e "  ${BLUE}Name:${NC} ${line#Name=}"
-      elif [[ $line =~ ^Comment= ]]; then
-        echo -e "  ${BLUE}Description:${NC} ${line#Comment=}"
-      fi
-    done <"$found_path/index.theme"
-  fi
+	# Show index.theme if available
+	if [[ -f "$found_path/index.theme" ]]; then
+		echo ""
+		echo -e "${GREEN}📋 Theme Metadata:${NC}"
+		while IFS= read -r line; do
+			if [[ $line =~ ^Name= ]]; then
+				echo -e "  ${BLUE}Name:${NC} ${line#Name=}"
+			elif [[ $line =~ ^Comment= ]]; then
+				echo -e "  ${BLUE}Description:${NC} ${line#Comment=}"
+			fi
+		done <"$found_path/index.theme"
+	fi
 }
 
 # Main script logic
 main() {
-  log "DEBUG" "Starting GTK theme manager with args: ${arguments[*]}"
+	log "DEBUG" "Starting GTK theme manager with args: ${arguments[*]}"
 
-  if [[ ${#arguments[@]} -eq 0 ]]; then
-    log "ERROR" "No command specified. Use --help for usage information."
-    exit 1
-  fi
+	if [[ ${#arguments[@]} -eq 0 ]]; then
+		log "ERROR" "No command specified. Use --help for usage information."
+		exit 1
+	fi
 
-  local command="${arguments[0]}"
-  local cmd_args=("${arguments[@]:1}")
+	local command="${arguments[0]}"
+	local cmd_args=("${arguments[@]:1}")
 
-  log "DEBUG" "Command: $command, args: ${cmd_args[*]}"
+	log "DEBUG" "Command: $command, args: ${cmd_args[*]}"
 
-  case "$command" in
-    "list" | "ls")
-      cmd_list "${cmd_args[@]}"
-      ;;
-    "current" | "status")
-      cmd_current "${cmd_args[@]}"
-      ;;
-    "current-icon" | "current-icons" | "icon-current")
-      cmd_current_icon "${cmd_args[@]}"
-      ;;
-    "current-color-scheme" | "current-scheme")
-      cmd_current_color_scheme "${cmd_args[@]}"
-      ;;
-    "apply" | "set")
-      if [[ ${#cmd_args[@]} -eq 0 ]]; then
-        log "ERROR" "Theme name required for apply command"
-        log "" "Usage: $(basename "$0") apply <theme-name> [icon-theme] [color-scheme]"
-        exit 1
-      fi
-      cmd_apply "${cmd_args[@]}"
-      ;;
-    "set-icons" | "set-icon")
-      if [[ ${#cmd_args[@]} -eq 0 ]]; then
-        log "ERROR" "Icon theme name required"
-        log "" "Usage: $(basename "$0") set-icons <icon-theme>"
-        exit 1
-      fi
-      cmd_set_icons "${cmd_args[0]}"
-      ;;
-    "color-scheme" | "scheme")
-      if [[ ${#cmd_args[@]} -eq 0 ]]; then
-        log "ERROR" "Policy required (follow|default|prefer-light|prefer-dark|light|dark)"
-        log "" "Usage: $(basename "$0") color-scheme <follow|default|prefer-light|prefer-dark|light|dark>"
-        exit 1
-      fi
-      cmd_color_scheme "${cmd_args[0]}"
-      ;;
-    "sync-color-scheme" | "sync-scheme")
-      cmd_sync_color_scheme
-      ;;
-    "detect" | "analyze")
-      cmd_detect "${cmd_args[@]}"
-      ;;
-    "theme" | "t")
-      cmd_theme_pack "${cmd_args[@]}"
-      ;;
-    "auto" | "automatic")
-      cmd_auto
-      ;;
-    "icons" | "icon")
-      cmd_icons "${cmd_args[@]}"
-      ;;
-    "info" | "show")
-      if [[ ${#cmd_args[@]} -eq 0 ]]; then
-        log "ERROR" "Theme name required for info command"
-        log "" "Usage: $(basename "$0") info <theme-name>"
-        exit 1
-      fi
-      cmd_info "${cmd_args[0]}"
-      ;;
-    *)
-      log "ERROR" "Unknown command '$command'"
-      log "" "Use --help for available commands"
-      exit 1
-      ;;
-  esac
+	case "$command" in
+	"list" | "ls")
+		cmd_list "${cmd_args[@]}"
+		;;
+	"current" | "status")
+		cmd_current "${cmd_args[@]}"
+		;;
+	"current-icon" | "current-icons" | "icon-current")
+		cmd_current_icon "${cmd_args[@]}"
+		;;
+	"current-color-scheme" | "current-scheme")
+		cmd_current_color_scheme "${cmd_args[@]}"
+		;;
+	"apply" | "set")
+		if [[ ${#cmd_args[@]} -eq 0 ]]; then
+			log "ERROR" "Theme name required for apply command"
+			log "" "Usage: $(basename "$0") apply <theme-name> [icon-theme] [color-scheme]"
+			exit 1
+		fi
+		cmd_apply "${cmd_args[@]}"
+		;;
+	"set-icons" | "set-icon")
+		if [[ ${#cmd_args[@]} -eq 0 ]]; then
+			log "ERROR" "Icon theme name required"
+			log "" "Usage: $(basename "$0") set-icons <icon-theme>"
+			exit 1
+		fi
+		cmd_set_icons "${cmd_args[0]}"
+		;;
+	"color-scheme" | "scheme")
+		if [[ ${#cmd_args[@]} -eq 0 ]]; then
+			log "ERROR" "Policy required (follow|default|prefer-light|prefer-dark|light|dark)"
+			log "" "Usage: $(basename "$0") color-scheme <follow|default|prefer-light|prefer-dark|light|dark>"
+			exit 1
+		fi
+		cmd_color_scheme "${cmd_args[0]}"
+		;;
+	"sync-color-scheme" | "sync-scheme")
+		cmd_sync_color_scheme
+		;;
+	"detect" | "analyze")
+		cmd_detect "${cmd_args[@]}"
+		;;
+	"theme" | "t")
+		cmd_theme_pack "${cmd_args[@]}"
+		;;
+	"auto" | "automatic")
+		cmd_auto
+		;;
+	"icons" | "icon")
+		cmd_icons "${cmd_args[@]}"
+		;;
+	"info" | "show")
+		if [[ ${#cmd_args[@]} -eq 0 ]]; then
+			log "ERROR" "Theme name required for info command"
+			log "" "Usage: $(basename "$0") info <theme-name>"
+			exit 1
+		fi
+		cmd_info "${cmd_args[0]}"
+		;;
+	*)
+		log "ERROR" "Unknown command '$command'"
+		log "" "Use --help for available commands"
+		exit 1
+		;;
+	esac
 }
 
 # Run main function

--- a/home/dot_local/bin/executable_dots-gtk-theme
+++ b/home/dot_local/bin/executable_dots-gtk-theme
@@ -24,10 +24,14 @@
 ##     list                    List installed GTK themes
 ##     current                 Show current GTK theme
 ##     current-icon            Show current icon theme
-##     apply <theme> [icon] [prefer-dark]
-##                             Apply GTK theme (prefer-dark: true|false)
-##     set-icons <icon>        Update icon theme (keeps current GTK theme)
-##     color-scheme <mode>     Sync gtk prefer-dark / color-scheme (light|dark)
+##     current-color-scheme    Show persisted GTK color-scheme policy
+##     apply <theme> [icon] [color-scheme]
+##                             Apply GTK theme. Optional color-scheme:
+##                             follow|default|prefer-light|prefer-dark|true|false
+##     set-icons <icon>        Update icon theme (keeps current GTK theme + policy)
+##     color-scheme <policy>   Set GTK color-scheme policy
+##                             (follow|default|prefer-light|prefer-dark|light|dark)
+##     sync-color-scheme       Re-apply persisted GTK color-scheme policy
 ##     detect [wallpaper]      Detect optimal theme for wallpaper
 ##     theme [theme-id]        Apply GTK theme from appearance theme pack
 ##     auto                    Auto-detect and apply optimal theme
@@ -38,9 +42,11 @@
 ##     @script.name -p list
 ##     @script.name -q -p current
 ##     @script.name -q -p current-icon
-##     @script.name apply Orchis-Dark-Compact Numix-Circle true
+##     @script.name -q -p current-color-scheme
+##     @script.name apply Orchis-Dark-Compact Numix-Circle prefer-light
 ##     @script.name set-icons Papirus-Dark
-##     @script.name color-scheme dark
+##     @script.name color-scheme prefer-light
+##     @script.name color-scheme follow
 ##     @script.name theme vapor-dreams
 ##     @script.name detect ~/Pictures/wallpaper.jpg
 ##     @script.name auto
@@ -52,23 +58,23 @@ source ~/.local/lib/dots/easy-options/easyoptions.sh || exit
 
 # Source the GTK theme manager - try multiple locations
 gtk_theme_manager_paths=(
-	"$HOME/.local/lib/dots/gtk-theme-manager.sh"
-	"$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../lib/dots/gtk-theme-manager.sh"
+  "$HOME/.local/lib/dots/gtk-theme-manager.sh"
+  "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../lib/dots/gtk-theme-manager.sh"
 )
 
 gtk_theme_manager_found=false
 for path in "${gtk_theme_manager_paths[@]}"; do
-	if [[ -f $path ]]; then
-		source "$path"
-		gtk_theme_manager_found=true
-		break
-	fi
+  if [[ -f $path ]]; then
+    source "$path"
+    gtk_theme_manager_found=true
+    break
+  fi
 done
 
 if [[ $gtk_theme_manager_found != "true" ]]; then
-	echo "Error: GTK theme manager not found in any of these locations:" >&2
-	printf '  %s\n' "${gtk_theme_manager_paths[@]}" >&2
-	exit 1
+  echo "Error: GTK theme manager not found in any of these locations:" >&2
+  printf '  %s\n' "${gtk_theme_manager_paths[@]}" >&2
+  exit 1
 fi
 
 # Color definitions for output
@@ -82,476 +88,478 @@ readonly NC='\033[0m' # No Color
 
 # Function to log messages with verbosity control
 log() {
-	local level="$1"
-	shift
-	local message="$*"
+  local level="$1"
+  shift
+  local message="$*"
 
-	if [[ ${quiet:-} == "yes" ]] && [[ $level != "ERROR" ]]; then
-		return 0
-	fi
+  if [[ ${quiet:-} == "yes" ]] && [[ $level != "ERROR" ]]; then
+    return 0
+  fi
 
-	local timestamp
-	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+  local timestamp
+  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-	case "$level" in
-	"ERROR")
-		echo -e "${RED}❌ [ERROR] $message${NC}" >&2
-		;;
-	"WARN")
-		echo -e "${YELLOW}⚠️  [WARN] $message${NC}" >&2
-		;;
-	"INFO")
-		if [[ ${verbose:-} == "yes" ]]; then
-			echo -e "${BLUE}ℹ️  [INFO] $message${NC}"
-		fi
-		;;
-	"DEBUG")
-		if [[ ${debug:-} == "yes" ]]; then
-			echo -e "${PURPLE}🐛 [DEBUG] [$timestamp] $message${NC}" >&2
-		fi
-		;;
-	*)
-		echo -e "$message"
-		;;
-	esac
+  case "$level" in
+    "ERROR")
+      echo -e "${RED}❌ [ERROR] $message${NC}" >&2
+      ;;
+    "WARN")
+      echo -e "${YELLOW}⚠️  [WARN] $message${NC}" >&2
+      ;;
+    "INFO")
+      if [[ ${verbose:-} == "yes" ]]; then
+        echo -e "${BLUE}ℹ️  [INFO] $message${NC}"
+      fi
+      ;;
+    "DEBUG")
+      if [[ ${debug:-} == "yes" ]]; then
+        echo -e "${PURPLE}🐛 [DEBUG] [$timestamp] $message${NC}" >&2
+      fi
+      ;;
+    *)
+      echo -e "$message"
+      ;;
+  esac
 }
 
 # Function to list installed GTK themes
 cmd_list() {
-	local use_plain=false
-	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+  local use_plain=false
+  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-	local themes
-	themes=$(list_installed_gtk_themes)
+  local themes
+  themes=$(list_installed_gtk_themes)
 
-	if [[ -z $themes ]]; then
-		[[ $use_plain == true ]] || log "WARN" "No GTK themes found"
-		return 1
-	fi
+  if [[ -z $themes ]]; then
+    [[ $use_plain == true ]] || log "WARN" "No GTK themes found"
+    return 1
+  fi
 
-	if [[ $use_plain == true ]]; then
-		printf '%s\n' "$themes"
-		return 0
-	fi
+  if [[ $use_plain == true ]]; then
+    printf '%s\n' "$themes"
+    return 0
+  fi
 
-	log "" "${BLUE}📋 Installed GTK themes:${NC}"
-	log "" ""
+  log "" "${BLUE}📋 Installed GTK themes:${NC}"
+  log "" ""
 
-	local current_theme
-	current_theme=$(get_current_gtk_theme)
-	log "DEBUG" "Current theme: $current_theme"
+  local current_theme
+  current_theme=$(get_current_gtk_theme)
+  log "DEBUG" "Current theme: $current_theme"
 
-	while IFS= read -r theme; do
-		if [[ $theme == "$current_theme" ]]; then
-			log "" "  ${GREEN}✓${NC} $theme ${CYAN}(current)${NC}"
-		else
-			log "" "    $theme"
-		fi
-	done <<<"$themes"
+  while IFS= read -r theme; do
+    if [[ $theme == "$current_theme" ]]; then
+      log "" "  ${GREEN}✓${NC} $theme ${CYAN}(current)${NC}"
+    else
+      log "" "    $theme"
+    fi
+  done <<<"$themes"
 
-	log "" ""
-	log "" "${CYAN}💡 Tip:${NC} Use 'dots gtk-theme apply <theme>' to apply a theme"
+  log "" ""
+  log "" "${CYAN}💡 Tip:${NC} Use 'dots gtk-theme apply <theme>' to apply a theme"
 }
 
 # Function to show current theme
 cmd_current() {
-	local use_plain=false
-	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+  local use_plain=false
+  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-	local current_theme
-	current_theme=$(get_current_gtk_theme)
+  local current_theme
+  current_theme=$(get_current_gtk_theme)
 
-	if [[ $use_plain == true ]]; then
-		printf '%s\n' "$current_theme"
-		return 0
-	fi
+  if [[ $use_plain == true ]]; then
+    printf '%s\n' "$current_theme"
+    return 0
+  fi
 
-	log "" "${BLUE}🎨 Current GTK Theme:${NC} $current_theme"
+  log "" "${BLUE}🎨 Current GTK Theme:${NC} $current_theme"
 
-	# Show additional info
-	if [[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" ]]; then
-		local icon_theme
-		icon_theme=$(grep "^gtk-icon-theme-name=" "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" | cut -d'=' -f2)
-		log "" "${BLUE}🎯 Icon Theme:${NC} $icon_theme"
+  # Show additional info
+  if [[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" ]]; then
+    local icon_theme
+    icon_theme=$(grep "^gtk-icon-theme-name=" "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" | cut -d'=' -f2)
+    log "" "${BLUE}🎯 Icon Theme:${NC} $icon_theme"
 
-		local dark_pref
-		dark_pref=$(grep "^gtk-application-prefer-dark-theme=" "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" | cut -d'=' -f2)
-		log "" "${BLUE}🌙 Dark Theme Preference:${NC} $dark_pref"
-	fi
+    local dark_pref
+    dark_pref=$(grep "^gtk-application-prefer-dark-theme=" "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" | cut -d'=' -f2)
+    log "" "${BLUE}🌙 Dark Theme Preference:${NC} $dark_pref"
+  fi
 }
 
 # Function to show current icon theme
 cmd_current_icon() {
-	local use_plain=false
-	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+  local use_plain=false
+  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-	local current_icon
-	current_icon="$(get_current_icon_theme 2>/dev/null || true)"
-	[[ -n $current_icon ]] || current_icon="Unknown"
+  local current_icon
+  current_icon="$(get_current_icon_theme 2>/dev/null || true)"
+  [[ -n $current_icon ]] || current_icon="Unknown"
 
-	if [[ $use_plain == true ]]; then
-		printf '%s\n' "$current_icon"
-		return 0
-	fi
+  if [[ $use_plain == true ]]; then
+    printf '%s\n' "$current_icon"
+    return 0
+  fi
 
-	log "" "${BLUE}🎯 Current Icon Theme:${NC} $current_icon"
+  log "" "${BLUE}🎯 Current Icon Theme:${NC} $current_icon"
 }
 
 # Function to apply specific theme
 cmd_apply() {
-	local theme_name="$1"
-	local icon_theme="${2:-}"
-	local prefer_dark="${3:-}"
+  local theme_name="$1"
+  local icon_theme="${2:-}"
+  local color_scheme="${3:-}"
 
-	if [[ -z $icon_theme ]]; then
-		icon_theme="$(get_current_icon_theme 2>/dev/null || true)"
-		[[ -n $icon_theme ]] || icon_theme="Numix-Circle"
-	fi
-	if [[ -z $prefer_dark ]]; then
-		# Derive from live scheme state when callers omit prefer-dark.
-		local mode="dark"
-		local state_json="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
-		if [[ -f $state_json ]]; then
-			mode="$(python3 -c "import json;print(json.load(open('$state_json')).get('mode','dark'))" 2>/dev/null || echo dark)"
-		fi
-		prefer_dark=$([[ $mode == "light" ]] && echo false || echo true)
-	fi
+  if [[ -z $icon_theme ]]; then
+    icon_theme="$(get_current_icon_theme 2>/dev/null || true)"
+    [[ -n $icon_theme ]] || icon_theme="Numix-Circle"
+  fi
 
-	log "" "${BLUE}🎨 Applying GTK Theme:${NC} $theme_name"
-	log "DEBUG" "Icon theme: $icon_theme, prefer dark: $prefer_dark"
+  log "" "${BLUE}🎨 Applying GTK Theme:${NC} $theme_name"
+  log "DEBUG" "Icon theme: $icon_theme, color-scheme: ${color_scheme:-live-policy}"
 
-	if apply_gtk_theme "$theme_name" "$icon_theme" "$prefer_dark"; then
-		log "" "${GREEN}✅ Theme applied successfully${NC}"
-	else
-		log "ERROR" "Failed to apply theme"
-		return 1
-	fi
+  if [[ -n $color_scheme ]]; then
+    if apply_gtk_theme "$theme_name" "$icon_theme" "$color_scheme"; then
+      log "" "${GREEN}✅ Theme applied successfully${NC}"
+    else
+      log "ERROR" "Failed to apply theme"
+      return 1
+    fi
+  else
+    if apply_gtk_theme "$theme_name" "$icon_theme"; then
+      log "" "${GREEN}✅ Theme applied successfully${NC}"
+    else
+      log "ERROR" "Failed to apply theme"
+      return 1
+    fi
+  fi
 }
 
-# Update icon theme while preserving the current GTK theme + prefer-dark.
+# Update icon theme while preserving the current GTK theme + color-scheme policy.
 cmd_set_icons() {
-	local icon_theme="${1:-}"
-	[[ -n $icon_theme ]] || {
-		log "ERROR" "Icon theme name required"
-		log "" "Usage: $(basename "$0") set-icons <icon-theme>"
-		return 1
-	}
+  local icon_theme="${1:-}"
+  [[ -n $icon_theme ]] || {
+    log "ERROR" "Icon theme name required"
+    log "" "Usage: $(basename "$0") set-icons <icon-theme>"
+    return 1
+  }
 
-	local gtk_theme prefer_dark
-	gtk_theme="$(get_current_gtk_theme)"
-	prefer_dark="false"
-	if [[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" ]]; then
-		prefer_dark="$(grep "^gtk-application-prefer-dark-theme=" "${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini" | cut -d'=' -f2 || echo false)"
-	fi
-	[[ $prefer_dark == "1" || $prefer_dark == "true" ]] && prefer_dark="true" || prefer_dark="false"
+  local gtk_theme
+  gtk_theme="$(get_current_gtk_theme)"
 
-	log "" "${BLUE}🎯 Applying icon theme:${NC} $icon_theme (gtk=$gtk_theme)"
-	if apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"; then
-		log "" "${GREEN}✅ Icon theme applied successfully${NC}"
-	else
-		log "ERROR" "Failed to apply icon theme"
-		return 1
-	fi
+  log "" "${BLUE}🎯 Applying icon theme:${NC} $icon_theme (gtk=$gtk_theme)"
+  if apply_gtk_theme "$gtk_theme" "$icon_theme"; then
+    log "" "${GREEN}✅ Icon theme applied successfully${NC}"
+  else
+    log "ERROR" "Failed to apply icon theme"
+    return 1
+  fi
 }
 
-# Sync GTK color-scheme / prefer-dark with live light|dark mode.
-# Persists to live scheme state so next boot and wal-restore respect the
-# user preference (previously this was ephemeral and reverted to state.json
-# mode on every login).
+cmd_current_color_scheme() {
+  local use_plain=false
+  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+
+  local policy
+  policy="$(get_current_gtk_color_scheme)"
+
+  if [[ $use_plain == true ]]; then
+    printf '%s\n' "$policy"
+    return 0
+  fi
+
+  log "" "${BLUE}🎨 GTK color-scheme policy:${NC} $policy"
+}
+
+# Set GTK color-scheme policy. Never writes shell `mode`.
 cmd_color_scheme() {
-	local mode="${1:-}"
-	[[ $mode == "light" || $mode == "dark" ]] || {
-		log "ERROR" "Mode must be light or dark"
-		log "" "Usage: $(basename "$0") color-scheme <light|dark>"
-		return 1
-	}
-	if apply_gtk_color_scheme "$mode"; then
-		# Persist mode to live appearance state (best effort, no hard fail).
-		if command -v python3 >/dev/null 2>&1; then
-			local state_file="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
-			mkdir -p "$(dirname "$state_file")" 2>/dev/null || true
-			python3 - "$state_file" "$mode" 2>/dev/null <<'PY' || true
-import json
-import pathlib
-import sys
-path = pathlib.Path(sys.argv[1])
-mode = sys.argv[2]
-try:
-    data = json.loads(path.read_text(encoding="utf-8"))
-except Exception:
-    data = {}
-data["mode"] = mode
-# Ensure required keys exist so dots-color-scheme doctor stays happy
-data.setdefault("name", "dynamic")
-data.setdefault("flavour", "tonal-spot")
-data.setdefault("variant", "tonalspot")
-path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-PY
-		fi
-		log "" "${GREEN}✅ GTK color-scheme synced:${NC} $mode (persisted to state.json)"
-	else
-		log "ERROR" "Failed to sync GTK color-scheme"
-		return 1
-	fi
+  local requested="${1:-}"
+  local policy
+  policy="$(normalize_gtk_color_scheme "$requested")"
+  [[ $policy != "invalid" && -n $requested ]] || {
+    log "ERROR" "Policy must be follow|default|prefer-light|prefer-dark|light|dark"
+    log "" "Usage: $(basename "$0") color-scheme <follow|default|prefer-light|prefer-dark|light|dark>"
+    return 1
+  }
+  if apply_gtk_color_scheme "$policy"; then
+    log "" "${GREEN}✅ GTK color-scheme policy:${NC} $policy"
+  else
+    log "ERROR" "Failed to sync GTK color-scheme"
+    return 1
+  fi
+}
+
+cmd_sync_color_scheme() {
+  if sync_gtk_color_scheme; then
+    log "" "${GREEN}✅ GTK color-scheme re-applied:${NC} $(get_current_gtk_color_scheme)"
+  else
+    log "ERROR" "Failed to re-apply GTK color-scheme"
+    return 1
+  fi
 }
 
 # Function to detect optimal theme
 cmd_detect() {
-	local wallpaper_path="${1:-}"
+  local wallpaper_path="${1:-}"
 
-	if [[ -z $wallpaper_path ]]; then
-		if [[ -f $HOME/.local/lib/dots/wallpaper-resolver.sh ]]; then
-			# shellcheck source=/dev/null
-			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-			wallpaper_path="$(dots_current_wallpaper 2>/dev/null || true)"
-		fi
-		if [[ -z ${wallpaper_path:-} ]]; then
-			echo -e "${RED}❌ No wallpaper specified and no current wallpaper found${NC}"
-			return 1
-		fi
-	fi
+  if [[ -z $wallpaper_path ]]; then
+    if [[ -f $HOME/.local/lib/dots/wallpaper-resolver.sh ]]; then
+      # shellcheck source=/dev/null
+      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+      wallpaper_path="$(dots_current_wallpaper 2>/dev/null || true)"
+    fi
+    if [[ -z ${wallpaper_path:-} ]]; then
+      echo -e "${RED}❌ No wallpaper specified and no current wallpaper found${NC}"
+      return 1
+    fi
+  fi
 
-	if [[ ! -f $wallpaper_path ]]; then
-		echo -e "${RED}❌ Wallpaper file not found: $wallpaper_path${NC}"
-		return 1
-	fi
+  if [[ ! -f $wallpaper_path ]]; then
+    echo -e "${RED}❌ Wallpaper file not found: $wallpaper_path${NC}"
+    return 1
+  fi
 
-	echo -e "${BLUE}🔍 Analyzing wallpaper:${NC} $(basename "$wallpaper_path")"
+  echo -e "${BLUE}🔍 Analyzing wallpaper:${NC} $(basename "$wallpaper_path")"
 
-	local theme_info
-	theme_info=$(detect_optimal_gtk_theme "$wallpaper_path")
-	local detected_theme="${theme_info%:*}"
-	local prefer_dark="${theme_info#*:}"
+  local theme_info
+  theme_info=$(detect_optimal_gtk_theme "$wallpaper_path")
+  local detected_theme="${theme_info%:*}"
+  local prefer_dark="${theme_info#*:}"
 
-	echo -e "${GREEN}🎯 Detected optimal theme:${NC} $detected_theme"
-	echo -e "${GREEN}🌙 Dark preference:${NC} $prefer_dark"
+  echo -e "${GREEN}🎯 Detected optimal theme:${NC} $detected_theme"
+  echo -e "${GREEN}🌙 Dark preference:${NC} $prefer_dark"
 
-	# Ask if user wants to apply
-	read -p "Apply this theme? (y/N): " -n 1 -r
-	echo
-	if [[ $REPLY =~ ^[Yy]$ ]]; then
-		cmd_apply "$detected_theme" "Numix-Circle" "$prefer_dark"
-	fi
+  # Ask if user wants to apply
+  read -p "Apply this theme? (y/N): " -n 1 -r
+  echo
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    cmd_apply "$detected_theme" "Numix-Circle" "$prefer_dark"
+  fi
 }
 
 # Function to apply theme-pack GTK settings
 cmd_theme_pack() {
-	local theme_id="${1:-}"
+  local theme_id="${1:-}"
 
-	echo -e "${BLUE}🎨 Applying GTK theme from theme pack:${NC} ${theme_id:-auto-detect}"
+  echo -e "${BLUE}🎨 Applying GTK theme from theme pack:${NC} ${theme_id:-auto-detect}"
 
-	if apply_theme_gtk_theme "$theme_id"; then
-		echo -e "${GREEN}✅ Theme pack GTK theme applied successfully${NC}"
-	else
-		echo -e "${RED}❌ Failed to apply theme pack GTK theme${NC}"
-		return 1
-	fi
+  if apply_theme_gtk_theme "$theme_id"; then
+    echo -e "${GREEN}✅ Theme pack GTK theme applied successfully${NC}"
+  else
+    echo -e "${RED}❌ Failed to apply theme pack GTK theme${NC}"
+    return 1
+  fi
 }
 
 # Function to auto-detect and apply
 cmd_auto() {
-	echo -e "${BLUE}🤖 Auto-detecting optimal GTK theme...${NC}"
-	cmd_theme_pack ""
+  echo -e "${BLUE}🤖 Auto-detecting optimal GTK theme...${NC}"
+  cmd_theme_pack ""
 }
 
 # Function to list icon themes
 cmd_icons() {
-	local use_plain=false
-	[[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
+  local use_plain=false
+  [[ ${plain:-} == "yes" || ${1:-} == "--plain" || ${1:-} == "-p" || ${1:-} == "plain" ]] && use_plain=true
 
-	local icon_dirs=(
-		"/usr/share/icons"
-		"/usr/local/share/icons"
-		"$HOME/.icons"
-		"${XDG_DATA_HOME:-$HOME/.local/share}/icons"
-	)
+  local icon_dirs=(
+    "/usr/share/icons"
+    "/usr/local/share/icons"
+    "$HOME/.icons"
+    "${XDG_DATA_HOME:-$HOME/.local/share}/icons"
+  )
 
-	local icons=()
-	for icon_dir in "${icon_dirs[@]}"; do
-		if [[ -d $icon_dir ]]; then
-			while IFS= read -r -d '' icon_path; do
-				local icon_name
-				icon_name=$(basename "$icon_path")
-				case "$icon_name" in
-				default | hicolor) continue ;;
-				esac
-				if [[ -f "$icon_path/index.theme" ]]; then
-					icons+=("$icon_name")
-				fi
-			done < <(find "$icon_dir" -maxdepth 1 -mindepth 1 -type d -print0 2>/dev/null)
-		fi
-	done
+  local icons=()
+  for icon_dir in "${icon_dirs[@]}"; do
+    if [[ -d $icon_dir ]]; then
+      while IFS= read -r -d '' icon_path; do
+        local icon_name
+        icon_name=$(basename "$icon_path")
+        case "$icon_name" in
+          default | hicolor) continue ;;
+        esac
+        if [[ -f "$icon_path/index.theme" ]]; then
+          icons+=("$icon_name")
+        fi
+      done < <(find "$icon_dir" -maxdepth 1 -mindepth 1 -type d -print0 2>/dev/null)
+    fi
+  done
 
-	if ((${#icons[@]} == 0)); then
-		if [[ $use_plain == true ]]; then
-			return 1
-		fi
-		echo -e "${YELLOW}⚠️  No icon themes found${NC}"
-		return 1
-	fi
+  if ((${#icons[@]} == 0)); then
+    if [[ $use_plain == true ]]; then
+      return 1
+    fi
+    echo -e "${YELLOW}⚠️  No icon themes found${NC}"
+    return 1
+  fi
 
-	local unique_icons
-	unique_icons=$(printf '%s\n' "${icons[@]}" | sort -u)
+  local unique_icons
+  unique_icons=$(printf '%s\n' "${icons[@]}" | sort -u)
 
-	if [[ $use_plain == true ]]; then
-		printf '%s\n' "$unique_icons"
-		return 0
-	fi
+  if [[ $use_plain == true ]]; then
+    printf '%s\n' "$unique_icons"
+    return 0
+  fi
 
-	echo -e "${BLUE}🎯 Installed Icon Themes:${NC}"
-	echo ""
+  echo -e "${BLUE}🎯 Installed Icon Themes:${NC}"
+  echo ""
 
-	local current_icon=""
-	current_icon="$(get_current_icon_theme 2>/dev/null || true)"
+  local current_icon=""
+  current_icon="$(get_current_icon_theme 2>/dev/null || true)"
 
-	while IFS= read -r icon; do
-		[[ -z $icon ]] && continue
-		if [[ $icon == "$current_icon" ]]; then
-			echo -e "  ${GREEN}✓${NC} $icon ${CYAN}(current)${NC}"
-		else
-			echo -e "    $icon"
-		fi
-	done <<<"$unique_icons"
+  while IFS= read -r icon; do
+    [[ -z $icon ]] && continue
+    if [[ $icon == "$current_icon" ]]; then
+      echo -e "  ${GREEN}✓${NC} $icon ${CYAN}(current)${NC}"
+    else
+      echo -e "    $icon"
+    fi
+  done <<<"$unique_icons"
 }
 
 # Function to show theme information
 cmd_info() {
-	local theme_name="$1"
+  local theme_name="$1"
 
-	echo -e "${BLUE}ℹ️  Theme Information: $theme_name${NC}"
-	echo ""
+  echo -e "${BLUE}ℹ️  Theme Information: $theme_name${NC}"
+  echo ""
 
-	# Find theme directories
-	local theme_dirs=(
-		"/usr/share/themes"
-		"/usr/local/share/themes"
-		"$HOME/.themes"
-		"$HOME/.local/share/themes"
-	)
+  # Find theme directories
+  local theme_dirs=(
+    "/usr/share/themes"
+    "/usr/local/share/themes"
+    "$HOME/.themes"
+    "$HOME/.local/share/themes"
+  )
 
-	local found_path=""
-	for theme_dir in "${theme_dirs[@]}"; do
-		if [[ -d "$theme_dir/$theme_name" ]]; then
-			found_path="$theme_dir/$theme_name"
-			break
-		fi
-	done
+  local found_path=""
+  for theme_dir in "${theme_dirs[@]}"; do
+    if [[ -d "$theme_dir/$theme_name" ]]; then
+      found_path="$theme_dir/$theme_name"
+      break
+    fi
+  done
 
-	if [[ -z $found_path ]]; then
-		echo -e "${RED}❌ Theme not found: $theme_name${NC}"
-		return 1
-	fi
+  if [[ -z $found_path ]]; then
+    echo -e "${RED}❌ Theme not found: $theme_name${NC}"
+    return 1
+  fi
 
-	echo -e "${GREEN}📁 Location:${NC} $found_path"
+  echo -e "${GREEN}📁 Location:${NC} $found_path"
 
-	# Check what components are available
-	echo -e "${GREEN}🧩 Available Components:${NC}"
-	if [[ -d "$found_path/gtk-2.0" ]]; then
-		echo -e "  ✅ GTK2"
-	else
-		echo -e "  ❌ GTK2"
-	fi
+  # Check what components are available
+  echo -e "${GREEN}🧩 Available Components:${NC}"
+  if [[ -d "$found_path/gtk-2.0" ]]; then
+    echo -e "  ✅ GTK2"
+  else
+    echo -e "  ❌ GTK2"
+  fi
 
-	if [[ -d "$found_path/gtk-3.0" ]]; then
-		echo -e "  ✅ GTK3"
-	else
-		echo -e "  ❌ GTK3"
-	fi
+  if [[ -d "$found_path/gtk-3.0" ]]; then
+    echo -e "  ✅ GTK3"
+  else
+    echo -e "  ❌ GTK3"
+  fi
 
-	if [[ -d "$found_path/gtk-4.0" ]]; then
-		echo -e "  ✅ GTK4"
-	else
-		echo -e "  ❌ GTK4"
-	fi
+  if [[ -d "$found_path/gtk-4.0" ]]; then
+    echo -e "  ✅ GTK4"
+  else
+    echo -e "  ❌ GTK4"
+  fi
 
-	# Show index.theme if available
-	if [[ -f "$found_path/index.theme" ]]; then
-		echo ""
-		echo -e "${GREEN}📋 Theme Metadata:${NC}"
-		while IFS= read -r line; do
-			if [[ $line =~ ^Name= ]]; then
-				echo -e "  ${BLUE}Name:${NC} ${line#Name=}"
-			elif [[ $line =~ ^Comment= ]]; then
-				echo -e "  ${BLUE}Description:${NC} ${line#Comment=}"
-			fi
-		done <"$found_path/index.theme"
-	fi
+  # Show index.theme if available
+  if [[ -f "$found_path/index.theme" ]]; then
+    echo ""
+    echo -e "${GREEN}📋 Theme Metadata:${NC}"
+    while IFS= read -r line; do
+      if [[ $line =~ ^Name= ]]; then
+        echo -e "  ${BLUE}Name:${NC} ${line#Name=}"
+      elif [[ $line =~ ^Comment= ]]; then
+        echo -e "  ${BLUE}Description:${NC} ${line#Comment=}"
+      fi
+    done <"$found_path/index.theme"
+  fi
 }
 
 # Main script logic
 main() {
-	log "DEBUG" "Starting GTK theme manager with args: ${arguments[*]}"
+  log "DEBUG" "Starting GTK theme manager with args: ${arguments[*]}"
 
-	if [[ ${#arguments[@]} -eq 0 ]]; then
-		log "ERROR" "No command specified. Use --help for usage information."
-		exit 1
-	fi
+  if [[ ${#arguments[@]} -eq 0 ]]; then
+    log "ERROR" "No command specified. Use --help for usage information."
+    exit 1
+  fi
 
-	local command="${arguments[0]}"
-	local cmd_args=("${arguments[@]:1}")
+  local command="${arguments[0]}"
+  local cmd_args=("${arguments[@]:1}")
 
-	log "DEBUG" "Command: $command, args: ${cmd_args[*]}"
+  log "DEBUG" "Command: $command, args: ${cmd_args[*]}"
 
-	case "$command" in
-	"list" | "ls")
-		cmd_list "${cmd_args[@]}"
-		;;
-	"current" | "status")
-		cmd_current "${cmd_args[@]}"
-		;;
-	"current-icon" | "current-icons" | "icon-current")
-		cmd_current_icon "${cmd_args[@]}"
-		;;
-	"apply" | "set")
-		if [[ ${#cmd_args[@]} -eq 0 ]]; then
-			log "ERROR" "Theme name required for apply command"
-			log "" "Usage: $(basename "$0") apply <theme-name> [icon-theme] [prefer-dark]"
-			exit 1
-		fi
-		cmd_apply "${cmd_args[@]}"
-		;;
-	"set-icons" | "set-icon")
-		if [[ ${#cmd_args[@]} -eq 0 ]]; then
-			log "ERROR" "Icon theme name required"
-			log "" "Usage: $(basename "$0") set-icons <icon-theme>"
-			exit 1
-		fi
-		cmd_set_icons "${cmd_args[0]}"
-		;;
-	"color-scheme" | "scheme")
-		if [[ ${#cmd_args[@]} -eq 0 ]]; then
-			log "ERROR" "Mode required (light|dark)"
-			log "" "Usage: $(basename "$0") color-scheme <light|dark>"
-			exit 1
-		fi
-		cmd_color_scheme "${cmd_args[0]}"
-		;;
-	"detect" | "analyze")
-		cmd_detect "${cmd_args[@]}"
-		;;
-	"theme" | "t")
-		cmd_theme_pack "${cmd_args[@]}"
-		;;
-	"auto" | "automatic")
-		cmd_auto
-		;;
-	"icons" | "icon")
-		cmd_icons "${cmd_args[@]}"
-		;;
-	"info" | "show")
-		if [[ ${#cmd_args[@]} -eq 0 ]]; then
-			log "ERROR" "Theme name required for info command"
-			log "" "Usage: $(basename "$0") info <theme-name>"
-			exit 1
-		fi
-		cmd_info "${cmd_args[0]}"
-		;;
-	*)
-		log "ERROR" "Unknown command '$command'"
-		log "" "Use --help for available commands"
-		exit 1
-		;;
-	esac
+  case "$command" in
+    "list" | "ls")
+      cmd_list "${cmd_args[@]}"
+      ;;
+    "current" | "status")
+      cmd_current "${cmd_args[@]}"
+      ;;
+    "current-icon" | "current-icons" | "icon-current")
+      cmd_current_icon "${cmd_args[@]}"
+      ;;
+    "current-color-scheme" | "current-scheme")
+      cmd_current_color_scheme "${cmd_args[@]}"
+      ;;
+    "apply" | "set")
+      if [[ ${#cmd_args[@]} -eq 0 ]]; then
+        log "ERROR" "Theme name required for apply command"
+        log "" "Usage: $(basename "$0") apply <theme-name> [icon-theme] [color-scheme]"
+        exit 1
+      fi
+      cmd_apply "${cmd_args[@]}"
+      ;;
+    "set-icons" | "set-icon")
+      if [[ ${#cmd_args[@]} -eq 0 ]]; then
+        log "ERROR" "Icon theme name required"
+        log "" "Usage: $(basename "$0") set-icons <icon-theme>"
+        exit 1
+      fi
+      cmd_set_icons "${cmd_args[0]}"
+      ;;
+    "color-scheme" | "scheme")
+      if [[ ${#cmd_args[@]} -eq 0 ]]; then
+        log "ERROR" "Policy required (follow|default|prefer-light|prefer-dark|light|dark)"
+        log "" "Usage: $(basename "$0") color-scheme <follow|default|prefer-light|prefer-dark|light|dark>"
+        exit 1
+      fi
+      cmd_color_scheme "${cmd_args[0]}"
+      ;;
+    "sync-color-scheme" | "sync-scheme")
+      cmd_sync_color_scheme
+      ;;
+    "detect" | "analyze")
+      cmd_detect "${cmd_args[@]}"
+      ;;
+    "theme" | "t")
+      cmd_theme_pack "${cmd_args[@]}"
+      ;;
+    "auto" | "automatic")
+      cmd_auto
+      ;;
+    "icons" | "icon")
+      cmd_icons "${cmd_args[@]}"
+      ;;
+    "info" | "show")
+      if [[ ${#cmd_args[@]} -eq 0 ]]; then
+        log "ERROR" "Theme name required for info command"
+        log "" "Usage: $(basename "$0") info <theme-name>"
+        exit 1
+      fi
+      cmd_info "${cmd_args[0]}"
+      ;;
+    *)
+      log "ERROR" "Unknown command '$command'"
+      log "" "Use --help for available commands"
+      exit 1
+      ;;
+  esac
 }
 
 # Run main function

--- a/home/dot_local/bin/executable_dots-wal-reload
+++ b/home/dot_local/bin/executable_dots-wal-reload
@@ -14,41 +14,41 @@ set -euo pipefail
 # plus appearance target) before falling back to direct wal -R + GTK.
 # Verifies IPC readiness, not just process presence, so we do not apply
 # state.json mode via the fallback and ignore theme.json gtkPreferDark.
-if [[ -n "${HYPRLAND_INSTANCE_SIGNATURE:-}" ]]; then
-	for _w in $(seq 1 30); do
-		if pgrep -x quickshell >/dev/null 2>&1 && quickshell ipc call appearance isBusy >/dev/null 2>&1; then
-			break
-		fi
-		sleep 0.5
-	done
+if [[ -n ${HYPRLAND_INSTANCE_SIGNATURE:-} ]]; then
+  for _w in $(seq 1 30); do
+    if pgrep -x quickshell >/dev/null 2>&1 && quickshell ipc call appearance isBusy >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.5
+  done
 fi
 
 if pgrep -x quickshell >/dev/null 2>&1; then
-	if quickshell ipc call appearance reload >/dev/null 2>&1; then
-		busy=""
-		for _i in $(seq 1 120); do
-			if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
-				echo "Error: could not read appearance job status via Quickshell IPC" >&2
-				exit 1
-			fi
-			busy="${busy//$'\r'/}"
-			busy="${busy//$'\n'/}"
-			[[ $busy == "1" ]] || break
-			sleep 0.5
-		done
-		if [[ $busy == "1" ]]; then
-			echo "Error: appearance reload timed out" >&2
-			exit 1
-		fi
-		last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
-		last_error="${last_error//$'\r'/}"
-		last_error="${last_error//$'\n'/}"
-		if [[ -n $last_error ]]; then
-			echo "Error: appearance reload failed: $last_error" >&2
-			exit 1
-		fi
-		exit 0
-	fi
+  if quickshell ipc call appearance reload >/dev/null 2>&1; then
+    busy=""
+    for _i in $(seq 1 120); do
+      if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
+        echo "Error: could not read appearance job status via Quickshell IPC" >&2
+        exit 1
+      fi
+      busy="${busy//$'\r'/}"
+      busy="${busy//$'\n'/}"
+      [[ $busy == "1" ]] || break
+      sleep 0.5
+    done
+    if [[ $busy == "1" ]]; then
+      echo "Error: appearance reload timed out" >&2
+      exit 1
+    fi
+    last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
+    last_error="${last_error//$'\r'/}"
+    last_error="${last_error//$'\n'/}"
+    if [[ -n $last_error ]]; then
+      echo "Error: appearance reload failed: $last_error" >&2
+      exit 1
+    fi
+    exit 0
+  fi
 fi
 
 # Fallback: direct wal reload + M3 from live state prefs
@@ -59,65 +59,67 @@ STATE_JSON="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
 
 wallpaper=""
 if [[ -f $WALL_POINTER ]]; then
-	wallpaper="$(head -n 1 "$WALL_POINTER" 2>/dev/null | tr -d '\r' || true)"
+  wallpaper="$(head -n 1 "$WALL_POINTER" 2>/dev/null | tr -d '\r' || true)"
 fi
 
 if command -v wal >/dev/null 2>&1; then
-	wal -R -q 2>/dev/null || true
+  wal -R -q 2>/dev/null || true
 fi
 
 # wal -R may recreate ~/.cache/wal/wal as an image symlink; writers that
 # echo into that path would truncate the wallpaper. Keep a text path file.
 if [[ -n ${wallpaper:-} && -f $wallpaper ]]; then
-	mkdir -p "$HOME/.cache/wal"
-	rm -f "$HOME/.cache/wal/wal"
-	printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
+  mkdir -p "$HOME/.cache/wal"
+  rm -f "$HOME/.cache/wal/wal"
+  printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
 fi
 
 mode="dark"
 flavour="tonal-spot"
 if [[ -f $STATE_JSON ]]; then
-	mode="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('mode','dark'))" 2>/dev/null || echo dark)"
-	flavour="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('flavour','tonal-spot'))" 2>/dev/null || echo tonal-spot)"
+  mode="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('mode','dark'))" 2>/dev/null || echo dark)"
+  flavour="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('flavour','tonal-spot'))" 2>/dev/null || echo tonal-spot)"
 fi
 [[ $mode == "light" || $mode == "dark" ]] || mode="dark"
 
 if [[ -n ${wallpaper:-} && -f $wallpaper && -f $M3_SCRIPT ]]; then
-	# Prefer system Python with materialyoucolor over pyenv shims on PATH.
-	# shellcheck source=/dev/null
-	source "${HOME}/.local/lib/dots/python-m3.sh" 2>/dev/null || true
-	if declare -f dots_run_m3_colors >/dev/null 2>&1; then
-		dots_run_m3_colors \
-			--image "$wallpaper" \
-			--scheme-type "$flavour" \
-			--mode "$mode" \
-			--output "$SCHEME_JSON" 2>/dev/null || true
-	elif command -v dots-m3-colors >/dev/null 2>&1; then
-		dots-m3-colors \
-			--image "$wallpaper" \
-			--scheme-type "$flavour" \
-			--mode "$mode" \
-			--output "$SCHEME_JSON" 2>/dev/null || true
-	elif command -v python3 >/dev/null 2>&1; then
-		python3 "$M3_SCRIPT" \
-			--image "$wallpaper" \
-			--scheme-type "$flavour" \
-			--mode "$mode" \
-			--output "$SCHEME_JSON" 2>/dev/null || true
-	fi
-	if command -v dots-color-scheme >/dev/null 2>&1; then
-		dots-color-scheme sync-state >/dev/null 2>&1 || true
-	fi
-	if command -v dots-gtk-theme >/dev/null 2>&1; then
-		dots-gtk-theme -q color-scheme "$mode" >/dev/null 2>&1 || true
-	elif [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
-		# shellcheck source=/dev/null
-		source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
-		if declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
-			apply_gtk_color_scheme "$mode" >/dev/null 2>&1 || true
-		fi
-	fi
-	if command -v dots-hyprlock-theme >/dev/null 2>&1; then
-		dots-hyprlock-theme >/dev/null 2>&1 || true
-	fi
+  # Prefer system Python with materialyoucolor over pyenv shims on PATH.
+  # shellcheck source=/dev/null
+  source "${HOME}/.local/lib/dots/python-m3.sh" 2>/dev/null || true
+  if declare -f dots_run_m3_colors >/dev/null 2>&1; then
+    dots_run_m3_colors \
+      --image "$wallpaper" \
+      --scheme-type "$flavour" \
+      --mode "$mode" \
+      --output "$SCHEME_JSON" 2>/dev/null || true
+  elif command -v dots-m3-colors >/dev/null 2>&1; then
+    dots-m3-colors \
+      --image "$wallpaper" \
+      --scheme-type "$flavour" \
+      --mode "$mode" \
+      --output "$SCHEME_JSON" 2>/dev/null || true
+  elif command -v python3 >/dev/null 2>&1; then
+    python3 "$M3_SCRIPT" \
+      --image "$wallpaper" \
+      --scheme-type "$flavour" \
+      --mode "$mode" \
+      --output "$SCHEME_JSON" 2>/dev/null || true
+  fi
+  if command -v dots-color-scheme >/dev/null 2>&1; then
+    dots-color-scheme sync-state >/dev/null 2>&1 || true
+  fi
+  if command -v dots-gtk-theme >/dev/null 2>&1; then
+    dots-gtk-theme -q sync-color-scheme >/dev/null 2>&1 || true
+  elif [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
+    if declare -f sync_gtk_color_scheme >/dev/null 2>&1; then
+      sync_gtk_color_scheme >/dev/null 2>&1 || true
+    elif declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
+      apply_gtk_color_scheme follow >/dev/null 2>&1 || true
+    fi
+  fi
+  if command -v dots-hyprlock-theme >/dev/null 2>&1; then
+    dots-hyprlock-theme >/dev/null 2>&1 || true
+  fi
 fi

--- a/home/dot_local/bin/executable_dots-wal-reload
+++ b/home/dot_local/bin/executable_dots-wal-reload
@@ -15,40 +15,40 @@ set -euo pipefail
 # Verifies IPC readiness, not just process presence, so we do not apply
 # state.json mode via the fallback and ignore theme.json gtkPreferDark.
 if [[ -n ${HYPRLAND_INSTANCE_SIGNATURE:-} ]]; then
-  for _w in $(seq 1 30); do
-    if pgrep -x quickshell >/dev/null 2>&1 && quickshell ipc call appearance isBusy >/dev/null 2>&1; then
-      break
-    fi
-    sleep 0.5
-  done
+	for _w in $(seq 1 30); do
+		if pgrep -x quickshell >/dev/null 2>&1 && quickshell ipc call appearance isBusy >/dev/null 2>&1; then
+			break
+		fi
+		sleep 0.5
+	done
 fi
 
 if pgrep -x quickshell >/dev/null 2>&1; then
-  if quickshell ipc call appearance reload >/dev/null 2>&1; then
-    busy=""
-    for _i in $(seq 1 120); do
-      if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
-        echo "Error: could not read appearance job status via Quickshell IPC" >&2
-        exit 1
-      fi
-      busy="${busy//$'\r'/}"
-      busy="${busy//$'\n'/}"
-      [[ $busy == "1" ]] || break
-      sleep 0.5
-    done
-    if [[ $busy == "1" ]]; then
-      echo "Error: appearance reload timed out" >&2
-      exit 1
-    fi
-    last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
-    last_error="${last_error//$'\r'/}"
-    last_error="${last_error//$'\n'/}"
-    if [[ -n $last_error ]]; then
-      echo "Error: appearance reload failed: $last_error" >&2
-      exit 1
-    fi
-    exit 0
-  fi
+	if quickshell ipc call appearance reload >/dev/null 2>&1; then
+		busy=""
+		for _i in $(seq 1 120); do
+			if ! busy="$(quickshell ipc call appearance isBusy 2>/dev/null)"; then
+				echo "Error: could not read appearance job status via Quickshell IPC" >&2
+				exit 1
+			fi
+			busy="${busy//$'\r'/}"
+			busy="${busy//$'\n'/}"
+			[[ $busy == "1" ]] || break
+			sleep 0.5
+		done
+		if [[ $busy == "1" ]]; then
+			echo "Error: appearance reload timed out" >&2
+			exit 1
+		fi
+		last_error="$(quickshell ipc call appearance lastError 2>/dev/null || true)"
+		last_error="${last_error//$'\r'/}"
+		last_error="${last_error//$'\n'/}"
+		if [[ -n $last_error ]]; then
+			echo "Error: appearance reload failed: $last_error" >&2
+			exit 1
+		fi
+		exit 0
+	fi
 fi
 
 # Fallback: direct wal reload + M3 from live state prefs
@@ -59,67 +59,67 @@ STATE_JSON="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
 
 wallpaper=""
 if [[ -f $WALL_POINTER ]]; then
-  wallpaper="$(head -n 1 "$WALL_POINTER" 2>/dev/null | tr -d '\r' || true)"
+	wallpaper="$(head -n 1 "$WALL_POINTER" 2>/dev/null | tr -d '\r' || true)"
 fi
 
 if command -v wal >/dev/null 2>&1; then
-  wal -R -q 2>/dev/null || true
+	wal -R -q 2>/dev/null || true
 fi
 
 # wal -R may recreate ~/.cache/wal/wal as an image symlink; writers that
 # echo into that path would truncate the wallpaper. Keep a text path file.
 if [[ -n ${wallpaper:-} && -f $wallpaper ]]; then
-  mkdir -p "$HOME/.cache/wal"
-  rm -f "$HOME/.cache/wal/wal"
-  printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
+	mkdir -p "$HOME/.cache/wal"
+	rm -f "$HOME/.cache/wal/wal"
+	printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
 fi
 
 mode="dark"
 flavour="tonal-spot"
 if [[ -f $STATE_JSON ]]; then
-  mode="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('mode','dark'))" 2>/dev/null || echo dark)"
-  flavour="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('flavour','tonal-spot'))" 2>/dev/null || echo tonal-spot)"
+	mode="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('mode','dark'))" 2>/dev/null || echo dark)"
+	flavour="$(python3 -c "import json;print(json.load(open('$STATE_JSON')).get('flavour','tonal-spot'))" 2>/dev/null || echo tonal-spot)"
 fi
 [[ $mode == "light" || $mode == "dark" ]] || mode="dark"
 
 if [[ -n ${wallpaper:-} && -f $wallpaper && -f $M3_SCRIPT ]]; then
-  # Prefer system Python with materialyoucolor over pyenv shims on PATH.
-  # shellcheck source=/dev/null
-  source "${HOME}/.local/lib/dots/python-m3.sh" 2>/dev/null || true
-  if declare -f dots_run_m3_colors >/dev/null 2>&1; then
-    dots_run_m3_colors \
-      --image "$wallpaper" \
-      --scheme-type "$flavour" \
-      --mode "$mode" \
-      --output "$SCHEME_JSON" 2>/dev/null || true
-  elif command -v dots-m3-colors >/dev/null 2>&1; then
-    dots-m3-colors \
-      --image "$wallpaper" \
-      --scheme-type "$flavour" \
-      --mode "$mode" \
-      --output "$SCHEME_JSON" 2>/dev/null || true
-  elif command -v python3 >/dev/null 2>&1; then
-    python3 "$M3_SCRIPT" \
-      --image "$wallpaper" \
-      --scheme-type "$flavour" \
-      --mode "$mode" \
-      --output "$SCHEME_JSON" 2>/dev/null || true
-  fi
-  if command -v dots-color-scheme >/dev/null 2>&1; then
-    dots-color-scheme sync-state >/dev/null 2>&1 || true
-  fi
-  if command -v dots-gtk-theme >/dev/null 2>&1; then
-    dots-gtk-theme -q sync-color-scheme >/dev/null 2>&1 || true
-  elif [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
-    # shellcheck source=/dev/null
-    source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
-    if declare -f sync_gtk_color_scheme >/dev/null 2>&1; then
-      sync_gtk_color_scheme >/dev/null 2>&1 || true
-    elif declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
-      apply_gtk_color_scheme follow >/dev/null 2>&1 || true
-    fi
-  fi
-  if command -v dots-hyprlock-theme >/dev/null 2>&1; then
-    dots-hyprlock-theme >/dev/null 2>&1 || true
-  fi
+	# Prefer system Python with materialyoucolor over pyenv shims on PATH.
+	# shellcheck source=/dev/null
+	source "${HOME}/.local/lib/dots/python-m3.sh" 2>/dev/null || true
+	if declare -f dots_run_m3_colors >/dev/null 2>&1; then
+		dots_run_m3_colors \
+			--image "$wallpaper" \
+			--scheme-type "$flavour" \
+			--mode "$mode" \
+			--output "$SCHEME_JSON" 2>/dev/null || true
+	elif command -v dots-m3-colors >/dev/null 2>&1; then
+		dots-m3-colors \
+			--image "$wallpaper" \
+			--scheme-type "$flavour" \
+			--mode "$mode" \
+			--output "$SCHEME_JSON" 2>/dev/null || true
+	elif command -v python3 >/dev/null 2>&1; then
+		python3 "$M3_SCRIPT" \
+			--image "$wallpaper" \
+			--scheme-type "$flavour" \
+			--mode "$mode" \
+			--output "$SCHEME_JSON" 2>/dev/null || true
+	fi
+	if command -v dots-color-scheme >/dev/null 2>&1; then
+		dots-color-scheme sync-state >/dev/null 2>&1 || true
+	fi
+	if command -v dots-gtk-theme >/dev/null 2>&1; then
+		dots-gtk-theme -q sync-color-scheme >/dev/null 2>&1 || true
+	elif [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
+		# shellcheck source=/dev/null
+		source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
+		if declare -f sync_gtk_color_scheme >/dev/null 2>&1; then
+			sync_gtk_color_scheme >/dev/null 2>&1 || true
+		elif declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
+			apply_gtk_color_scheme follow >/dev/null 2>&1 || true
+		fi
+	fi
+	if command -v dots-hyprlock-theme >/dev/null 2>&1; then
+		dots-hyprlock-theme >/dev/null 2>&1 || true
+	fi
 fi

--- a/home/dot_local/lib/dots/apply-appearance.sh
+++ b/home/dot_local/lib/dots/apply-appearance.sh
@@ -12,8 +12,8 @@ DOTS_M3_SCRIPT="${DOTS_M3_SCRIPT:-$HOME/.local/lib/dots/generate-m3-colors.py}"
 DOTS_PICTURES_WALLPAPERS="${DOTS_PICTURES_WALLPAPERS:-$HOME/Pictures/Wallpapers}"
 
 _dots_aa_json_get() {
-  local file="$1" key="$2" default="${3:-}"
-  python3 - "$file" "$key" "$default" <<'PY'
+	local file="$1" key="$2" default="${3:-}"
+	python3 - "$file" "$key" "$default" << 'PY'
 import json, sys
 path, key, default = sys.argv[1], sys.argv[2], sys.argv[3]
 try:
@@ -33,307 +33,307 @@ PY
 }
 
 _dots_aa_write_pointer() {
-  local path="$1"
-  mkdir -p "$(dirname "$DOTS_WALLPAPER_POINTER_FILE")"
-  printf '%s\n' "$path" >"$DOTS_WALLPAPER_POINTER_FILE"
+	local path="$1"
+	mkdir -p "$(dirname "$DOTS_WALLPAPER_POINTER_FILE")"
+	printf '%s\n' "$path" > "$DOTS_WALLPAPER_POINTER_FILE"
 }
 
 _dots_aa_normalize_scheme_type() {
-  local raw="${1:-tonal-spot}"
-  raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
-  case "$raw" in
-    vibrant | expressive | fidelity | content | neutral | monochrome) printf '%s\n' "$raw" ;;
-    tonalspot | tonal-spot) printf 'tonal-spot\n' ;;
-    *) printf 'tonal-spot\n' ;;
-  esac
+	local raw="${1:-tonal-spot}"
+	raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
+	case "$raw" in
+		vibrant | expressive | fidelity | content | neutral | monochrome) printf '%s\n' "$raw" ;;
+		tonalspot | tonal-spot) printf 'tonal-spot\n' ;;
+		*) printf 'tonal-spot\n' ;;
+	esac
 }
 
 # Resolve gtk-application-prefer-dark independently of shell darkMode when possible.
 # Priority: theme.json gtkPreferDark → Light/Dark in gtk theme name → shell mode.
 _dots_aa_resolve_gtk_prefer() {
-  local config_json="${1:-}"
-  local dark_mode="${2:-dark}"
-  local gtk_theme="${3:-}"
-  local explicit=""
+	local config_json="${1:-}"
+	local dark_mode="${2:-dark}"
+	local gtk_theme="${3:-}"
+	local explicit=""
 
-  if [[ -n $config_json && -f $config_json ]]; then
-    explicit="$(_dots_aa_json_get "$config_json" gtkPreferDark "")"
-  fi
-  case "$explicit" in
-    true | false)
-      printf '%s\n' "$explicit"
-      return 0
-      ;;
-  esac
+	if [[ -n $config_json && -f $config_json ]]; then
+		explicit="$(_dots_aa_json_get "$config_json" gtkPreferDark "")"
+	fi
+	case "$explicit" in
+		true | false)
+			printf '%s\n' "$explicit"
+			return 0
+			;;
+	esac
 
-  local gtk_lc
-  gtk_lc=$(printf '%s' "$gtk_theme" | tr '[:upper:]' '[:lower:]')
-  case "$gtk_lc" in
-    *light*)
-      printf 'false\n'
-      ;;
-    *dark*)
-      printf 'true\n'
-      ;;
-    *)
-      if [[ $dark_mode == "light" ]]; then
-        printf 'false\n'
-      else
-        printf 'true\n'
-      fi
-      ;;
-  esac
+	local gtk_lc
+	gtk_lc=$(printf '%s' "$gtk_theme" | tr '[:upper:]' '[:lower:]')
+	case "$gtk_lc" in
+		*light*)
+			printf 'false\n'
+			;;
+		*dark*)
+			printf 'true\n'
+			;;
+		*)
+			if [[ $dark_mode == "light" ]]; then
+				printf 'false\n'
+			else
+				printf 'true\n'
+			fi
+			;;
+	esac
 }
 
 _dots_aa_resolve_theme_wallpaper() {
-  local theme_id="$1"
-  local wallpaper_dir="$2"
-  local default_name="$3"
-  local override="${4:-}"
-  local candidate=""
+	local theme_id="$1"
+	local wallpaper_dir="$2"
+	local default_name="$3"
+	local override="${4:-}"
+	local candidate=""
 
-  if [[ -n $override ]]; then
-    candidate="$(readlink -f "$override" 2>/dev/null || true)"
-    [[ -n ${candidate:-} && -f $candidate ]] && {
-      printf '%s\n' "$candidate"
-      return 0
-    }
-  fi
+	if [[ -n $override ]]; then
+		candidate="$(readlink -f "$override" 2> /dev/null || true)"
+		[[ -n ${candidate:-} && -f $candidate ]] && {
+			printf '%s\n' "$candidate"
+			return 0
+		}
+	fi
 
-  for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
-    if [[ -n $default_name && -f $base/$default_name ]]; then
-      readlink -f "$base/$default_name"
-      return 0
-    fi
-  done
+	for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
+		if [[ -n $default_name && -f $base/$default_name ]]; then
+			readlink -f "$base/$default_name"
+			return 0
+		fi
+	done
 
-  for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
-    [[ -d $base ]] || continue
-    candidate="$(
-      find -L "$base" -maxdepth 1 \( -type f -o -type l \) \
-        \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" \
-        -o -iname "*.gif" -o -iname "*.bmp" \) 2>/dev/null | sort | head -n 1 || true
-    )"
-    [[ -n ${candidate:-} && -f $candidate ]] && {
-      printf '%s\n' "$candidate"
-      return 0
-    }
-  done
-  return 1
+	for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
+		[[ -d $base ]] || continue
+		candidate="$(
+			find -L "$base" -maxdepth 1 \( -type f -o -type l \) \
+				\( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" \
+				-o -iname "*.gif" -o -iname "*.bmp" \) 2> /dev/null | sort | head -n 1 || true
+		)"
+		[[ -n ${candidate:-} && -f $candidate ]] && {
+			printf '%s\n' "$candidate"
+			return 0
+		}
+	done
+	return 1
 }
 
 # Re-apply persisted GTK color-scheme policy (follow tracks shell mode).
 # Optional $1 is ignored except as a legacy positional from older callers.
 _dots_aa_sync_gtk_color_scheme() {
-  if command -v dots-gtk-theme >/dev/null 2>&1; then
-    dots-gtk-theme -q sync-color-scheme >/dev/null 2>&1 || true
-  elif [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
-    # shellcheck source=/dev/null
-    source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
-    if declare -f sync_gtk_color_scheme >/dev/null 2>&1; then
-      sync_gtk_color_scheme >/dev/null 2>&1 || true
-    elif declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
-      apply_gtk_color_scheme follow >/dev/null 2>&1 || true
-    fi
-  fi
+	if command -v dots-gtk-theme > /dev/null 2>&1; then
+		dots-gtk-theme -q sync-color-scheme > /dev/null 2>&1 || true
+	elif [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
+		# shellcheck source=/dev/null
+		source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2> /dev/null || true
+		if declare -f sync_gtk_color_scheme > /dev/null 2>&1; then
+			sync_gtk_color_scheme > /dev/null 2>&1 || true
+		elif declare -f apply_gtk_color_scheme > /dev/null 2>&1; then
+			apply_gtk_color_scheme follow > /dev/null 2>&1 || true
+		fi
+	fi
 }
 
 # Pack recipe → canonical gtkColorScheme policy.
 _dots_aa_resolve_gtk_color_scheme() {
-  local config_json="${1:-}"
-  local dark_mode="${2:-dark}"
-  local gtk_theme="${3:-}"
-  local explicit=""
+	local config_json="${1:-}"
+	local dark_mode="${2:-dark}"
+	local gtk_theme="${3:-}"
+	local explicit=""
 
-  if [[ -n $config_json && -f $config_json ]]; then
-    explicit="$(_dots_aa_json_get "$config_json" gtkColorScheme "")"
-  fi
-  case "$explicit" in
-    follow | default | prefer-light | prefer-dark)
-      printf '%s\n' "$explicit"
-      return 0
-      ;;
-    light)
-      printf 'prefer-light\n'
-      return 0
-      ;;
-    dark)
-      printf 'prefer-dark\n'
-      return 0
-      ;;
-    auto)
-      printf 'default\n'
-      return 0
-      ;;
-  esac
+	if [[ -n $config_json && -f $config_json ]]; then
+		explicit="$(_dots_aa_json_get "$config_json" gtkColorScheme "")"
+	fi
+	case "$explicit" in
+		follow | default | prefer-light | prefer-dark)
+			printf '%s\n' "$explicit"
+			return 0
+			;;
+		light)
+			printf 'prefer-light\n'
+			return 0
+			;;
+		dark)
+			printf 'prefer-dark\n'
+			return 0
+			;;
+		auto)
+			printf 'default\n'
+			return 0
+			;;
+	esac
 
-  local prefer
-  prefer="$(_dots_aa_resolve_gtk_prefer "$config_json" "$dark_mode" "$gtk_theme")"
-  if [[ $prefer == "false" ]]; then
-    printf 'prefer-light\n'
-  else
-    printf 'prefer-dark\n'
-  fi
+	local prefer
+	prefer="$(_dots_aa_resolve_gtk_prefer "$config_json" "$dark_mode" "$gtk_theme")"
+	if [[ $prefer == "false" ]]; then
+		printf 'prefer-light\n'
+	else
+		printf 'prefer-dark\n'
+	fi
 }
 
 _dots_aa_run_palette() {
-  local wallpaper="$1"
-  local scheme_type="$2"
-  local dark_mode="$3"
+	local wallpaper="$1"
+	local scheme_type="$2"
+	local dark_mode="$3"
 
-  if ! command -v wal >/dev/null 2>&1; then
-    echo "apply-appearance: wal not found" >&2
-    return 1
-  fi
-  # Drop any prior wal→image symlink before wal runs; echoing a path through
-  # that symlink would truncate the wallpaper file itself.
-  mkdir -p "$HOME/.cache/wal"
-  rm -f "$HOME/.cache/wal/wal"
-  if [[ $dark_mode == "light" ]]; then
-    wal -i "$wallpaper" -q -l || return 1
-  else
-    wal -i "$wallpaper" -q || return 1
-  fi
+	if ! command -v wal > /dev/null 2>&1; then
+		echo "apply-appearance: wal not found" >&2
+		return 1
+	fi
+	# Drop any prior wal→image symlink before wal runs; echoing a path through
+	# that symlink would truncate the wallpaper file itself.
+	mkdir -p "$HOME/.cache/wal"
+	rm -f "$HOME/.cache/wal/wal"
+	if [[ $dark_mode == "light" ]]; then
+		wal -i "$wallpaper" -q -l || return 1
+	else
+		wal -i "$wallpaper" -q || return 1
+	fi
 
-  _dots_aa_write_pointer "$wallpaper"
-  rm -f "$HOME/.cache/wal/wal"
-  printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
+	_dots_aa_write_pointer "$wallpaper"
+	rm -f "$HOME/.cache/wal/wal"
+	printf '%s\n' "$wallpaper" > "$HOME/.cache/wal/wal"
 
-  [[ -f $DOTS_M3_SCRIPT ]] || {
-    echo "apply-appearance: missing generate-m3-colors.py" >&2
-    return 1
-  }
-  # Prefer system Python with materialyoucolor over pyenv shims on PATH.
-  # shellcheck source=/dev/null
-  source "${HOME}/.local/lib/dots/python-m3.sh" 2>/dev/null || true
-  mkdir -p "$(dirname "$DOTS_SCHEME_FILE")"
-  if declare -f dots_run_m3_colors >/dev/null 2>&1; then
-    dots_run_m3_colors \
-      --image "$wallpaper" \
-      --scheme-type "$scheme_type" \
-      --mode "$dark_mode" \
-      --output "$DOTS_SCHEME_FILE" || return 1
-  elif command -v dots-m3-colors >/dev/null 2>&1; then
-    dots-m3-colors \
-      --image "$wallpaper" \
-      --scheme-type "$scheme_type" \
-      --mode "$dark_mode" \
-      --output "$DOTS_SCHEME_FILE" || return 1
-  else
-    python3 "$DOTS_M3_SCRIPT" \
-      --image "$wallpaper" \
-      --scheme-type "$scheme_type" \
-      --mode "$dark_mode" \
-      --output "$DOTS_SCHEME_FILE" || return 1
-  fi
+	[[ -f $DOTS_M3_SCRIPT ]] || {
+		echo "apply-appearance: missing generate-m3-colors.py" >&2
+		return 1
+	}
+	# Prefer system Python with materialyoucolor over pyenv shims on PATH.
+	# shellcheck source=/dev/null
+	source "${HOME}/.local/lib/dots/python-m3.sh" 2> /dev/null || true
+	mkdir -p "$(dirname "$DOTS_SCHEME_FILE")"
+	if declare -f dots_run_m3_colors > /dev/null 2>&1; then
+		dots_run_m3_colors \
+			--image "$wallpaper" \
+			--scheme-type "$scheme_type" \
+			--mode "$dark_mode" \
+			--output "$DOTS_SCHEME_FILE" || return 1
+	elif command -v dots-m3-colors > /dev/null 2>&1; then
+		dots-m3-colors \
+			--image "$wallpaper" \
+			--scheme-type "$scheme_type" \
+			--mode "$dark_mode" \
+			--output "$DOTS_SCHEME_FILE" || return 1
+	else
+		python3 "$DOTS_M3_SCRIPT" \
+			--image "$wallpaper" \
+			--scheme-type "$scheme_type" \
+			--mode "$dark_mode" \
+			--output "$DOTS_SCHEME_FILE" || return 1
+	fi
 
-  if command -v dots-color-scheme >/dev/null 2>&1; then
-    dots-color-scheme sync-state >/dev/null 2>&1 || return 1
-  fi
-  _dots_aa_sync_gtk_color_scheme "$dark_mode"
-  if command -v dots-hyprlock-theme >/dev/null 2>&1; then
-    dots-hyprlock-theme >/dev/null 2>&1 || true
-  fi
-  if command -v hyprctl >/dev/null 2>&1; then
-    hyprctl reload >/dev/null 2>&1 || true
-  fi
-  return 0
+	if command -v dots-color-scheme > /dev/null 2>&1; then
+		dots-color-scheme sync-state > /dev/null 2>&1 || return 1
+	fi
+	_dots_aa_sync_gtk_color_scheme "$dark_mode"
+	if command -v dots-hyprlock-theme > /dev/null 2>&1; then
+		dots-hyprlock-theme > /dev/null 2>&1 || true
+	fi
+	if command -v hyprctl > /dev/null 2>&1; then
+		hyprctl reload > /dev/null 2>&1 || true
+	fi
+	return 0
 }
 
 # Apply a theme pack once (no persistent current-theme state).
 dots_apply_theme() {
-  local theme_id="${1:-}"
-  local wallpaper_override="${2:-}"
+	local theme_id="${1:-}"
+	local wallpaper_override="${2:-}"
 
-  [[ -n $theme_id ]] || {
-    echo "dots_apply_theme: theme id required" >&2
-    return 1
-  }
-  local config_json="$DOTS_THEMES_DIR/$theme_id/theme.json"
-  [[ -f $config_json ]] || {
-    echo "dots_apply_theme: theme not found: $theme_id" >&2
-    return 1
-  }
+	[[ -n $theme_id ]] || {
+		echo "dots_apply_theme: theme id required" >&2
+		return 1
+	}
+	local config_json="$DOTS_THEMES_DIR/$theme_id/theme.json"
+	[[ -f $config_json ]] || {
+		echo "dots_apply_theme: theme not found: $theme_id" >&2
+		return 1
+	}
 
-  local scheme_type dark_mode_raw dark_mode gtk_theme icon_theme theme_name wallpaper_dir default_wp wallpaper
-  scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$config_json" schemeType tonal-spot)")"
-  dark_mode_raw="$(_dots_aa_json_get "$config_json" darkMode true)"
-  if [[ $dark_mode_raw == "false" ]]; then
-    dark_mode="light"
-  else
-    dark_mode="dark"
-  fi
-  gtk_theme="$(_dots_aa_json_get "$config_json" gtkTheme Orchis-Light-Compact)"
-  icon_theme="$(_dots_aa_json_get "$config_json" iconTheme Numix-Circle)"
-  theme_name="$(_dots_aa_json_get "$config_json" name "$theme_id")"
-  wallpaper_dir="$(_dots_aa_json_get "$config_json" wallpaperDir "$theme_id")"
-  default_wp="$(_dots_aa_json_get "$config_json" defaultWallpaper "")"
+	local scheme_type dark_mode_raw dark_mode gtk_theme icon_theme theme_name wallpaper_dir default_wp wallpaper
+	scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$config_json" schemeType tonal-spot)")"
+	dark_mode_raw="$(_dots_aa_json_get "$config_json" darkMode true)"
+	if [[ $dark_mode_raw == "false" ]]; then
+		dark_mode="light"
+	else
+		dark_mode="dark"
+	fi
+	gtk_theme="$(_dots_aa_json_get "$config_json" gtkTheme Orchis-Light-Compact)"
+	icon_theme="$(_dots_aa_json_get "$config_json" iconTheme Numix-Circle)"
+	theme_name="$(_dots_aa_json_get "$config_json" name "$theme_id")"
+	wallpaper_dir="$(_dots_aa_json_get "$config_json" wallpaperDir "$theme_id")"
+	default_wp="$(_dots_aa_json_get "$config_json" defaultWallpaper "")"
 
-  wallpaper="$(_dots_aa_resolve_theme_wallpaper "$theme_id" "$wallpaper_dir" "$default_wp" "$wallpaper_override" || true)"
-  [[ -n ${wallpaper:-} && -f $wallpaper ]] || {
-    echo "dots_apply_theme: no wallpaper for theme $theme_id" >&2
-    return 1
-  }
+	wallpaper="$(_dots_aa_resolve_theme_wallpaper "$theme_id" "$wallpaper_dir" "$default_wp" "$wallpaper_override" || true)"
+	[[ -n ${wallpaper:-} && -f $wallpaper ]] || {
+		echo "dots_apply_theme: no wallpaper for theme $theme_id" >&2
+		return 1
+	}
 
-  _dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode" || return 1
+	_dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode" || return 1
 
-  local gtk_policy
-  gtk_policy="$(_dots_aa_resolve_gtk_color_scheme "$config_json" "$dark_mode" "$gtk_theme")"
+	local gtk_policy
+	gtk_policy="$(_dots_aa_resolve_gtk_color_scheme "$config_json" "$dark_mode" "$gtk_theme")"
 
-  if command -v dots-gtk-theme >/dev/null 2>&1; then
-    if [[ -n $gtk_theme && $gtk_theme != "auto" ]]; then
-      dots-gtk-theme -q apply "$gtk_theme" "${icon_theme:-Numix-Circle}" "$gtk_policy" >/dev/null 2>&1 || true
-    elif [[ $gtk_theme == "auto" ]]; then
-      dots-gtk-theme -q theme "$theme_id" >/dev/null 2>&1 || true
-      dots-gtk-theme -q color-scheme "$gtk_policy" >/dev/null 2>&1 || true
-    elif [[ -n $icon_theme ]]; then
-      dots-gtk-theme -q set-icons "$icon_theme" >/dev/null 2>&1 || true
-      dots-gtk-theme -q color-scheme "$gtk_policy" >/dev/null 2>&1 || true
-    else
-      dots-gtk-theme -q color-scheme "$gtk_policy" >/dev/null 2>&1 || true
-    fi
-  elif [[ -n $icon_theme ]] && command -v gsettings >/dev/null 2>&1; then
-    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" >/dev/null 2>&1 || true
-    _dots_aa_sync_gtk_color_scheme
-  else
-    _dots_aa_sync_gtk_color_scheme
-  fi
+	if command -v dots-gtk-theme > /dev/null 2>&1; then
+		if [[ -n $gtk_theme && $gtk_theme != "auto" ]]; then
+			dots-gtk-theme -q apply "$gtk_theme" "${icon_theme:-Numix-Circle}" "$gtk_policy" > /dev/null 2>&1 || true
+		elif [[ $gtk_theme == "auto" ]]; then
+			dots-gtk-theme -q theme "$theme_id" > /dev/null 2>&1 || true
+			dots-gtk-theme -q color-scheme "$gtk_policy" > /dev/null 2>&1 || true
+		elif [[ -n $icon_theme ]]; then
+			dots-gtk-theme -q set-icons "$icon_theme" > /dev/null 2>&1 || true
+			dots-gtk-theme -q color-scheme "$gtk_policy" > /dev/null 2>&1 || true
+		else
+			dots-gtk-theme -q color-scheme "$gtk_policy" > /dev/null 2>&1 || true
+		fi
+	elif [[ -n $icon_theme ]] && command -v gsettings > /dev/null 2>&1; then
+		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" > /dev/null 2>&1 || true
+		_dots_aa_sync_gtk_color_scheme
+	else
+		_dots_aa_sync_gtk_color_scheme
+	fi
 
-  if [[ -f $HOME/.local/lib/dots/snappy-switcher-manager.sh ]]; then
-    # shellcheck source=/dev/null
-    source "$HOME/.local/lib/dots/snappy-switcher-manager.sh" 2>/dev/null || true
-    if declare -f apply_theme_snappy_switcher_theme >/dev/null 2>&1; then
-      apply_theme_snappy_switcher_theme "$theme_id" >/dev/null 2>&1 || true
-    fi
-  fi
+	if [[ -f $HOME/.local/lib/dots/snappy-switcher-manager.sh ]]; then
+		# shellcheck source=/dev/null
+		source "$HOME/.local/lib/dots/snappy-switcher-manager.sh" 2> /dev/null || true
+		if declare -f apply_theme_snappy_switcher_theme > /dev/null 2>&1; then
+			apply_theme_snappy_switcher_theme "$theme_id" > /dev/null 2>&1 || true
+		fi
+	fi
 
-  if command -v notify-send >/dev/null 2>&1; then
-    notify-send "HorneroConfig" "${theme_name} theme applied" >/dev/null 2>&1 || true
-  fi
-  return 0
+	if command -v notify-send > /dev/null 2>&1; then
+		notify-send "HorneroConfig" "${theme_name} theme applied" > /dev/null 2>&1 || true
+	fi
+	return 0
 }
 
 # Back-compat name used by older callers during transition.
 dots_apply_appearance() {
-  dots_apply_theme "$@"
+	dots_apply_theme "$@"
 }
 
 # Wallpaper-only: live mode/flavour from scheme state.
 dots_apply_wallpaper_only() {
-  local wallpaper="${1:-}"
-  wallpaper="$(readlink -f "$wallpaper" 2>/dev/null || true)"
-  [[ -n ${wallpaper:-} && -f $wallpaper ]] || {
-    echo "dots_apply_wallpaper_only: wallpaper not found" >&2
-    return 1
-  }
+	local wallpaper="${1:-}"
+	wallpaper="$(readlink -f "$wallpaper" 2> /dev/null || true)"
+	[[ -n ${wallpaper:-} && -f $wallpaper ]] || {
+		echo "dots_apply_wallpaper_only: wallpaper not found" >&2
+		return 1
+	}
 
-  local scheme_type="tonal-spot" dark_mode="dark"
-  local state_file="$DOTS_STATE_DIR/scheme/state.json"
-  if [[ -f $state_file ]]; then
-    scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$state_file" flavour tonal-spot)")"
-    dark_mode="$(_dots_aa_json_get "$state_file" mode dark)"
-    [[ $dark_mode == "light" || $dark_mode == "dark" ]] || dark_mode="dark"
-  fi
+	local scheme_type="tonal-spot" dark_mode="dark"
+	local state_file="$DOTS_STATE_DIR/scheme/state.json"
+	if [[ -f $state_file ]]; then
+		scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$state_file" flavour tonal-spot)")"
+		dark_mode="$(_dots_aa_json_get "$state_file" mode dark)"
+		[[ $dark_mode == "light" || $dark_mode == "dark" ]] || dark_mode="dark"
+	fi
 
-  _dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode"
+	_dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode"
 }

--- a/home/dot_local/lib/dots/apply-appearance.sh
+++ b/home/dot_local/lib/dots/apply-appearance.sh
@@ -12,8 +12,8 @@ DOTS_M3_SCRIPT="${DOTS_M3_SCRIPT:-$HOME/.local/lib/dots/generate-m3-colors.py}"
 DOTS_PICTURES_WALLPAPERS="${DOTS_PICTURES_WALLPAPERS:-$HOME/Pictures/Wallpapers}"
 
 _dots_aa_json_get() {
-	local file="$1" key="$2" default="${3:-}"
-	python3 - "$file" "$key" "$default" << 'PY'
+  local file="$1" key="$2" default="${3:-}"
+  python3 - "$file" "$key" "$default" <<'PY'
 import json, sys
 path, key, default = sys.argv[1], sys.argv[2], sys.argv[3]
 try:
@@ -33,271 +33,307 @@ PY
 }
 
 _dots_aa_write_pointer() {
-	local path="$1"
-	mkdir -p "$(dirname "$DOTS_WALLPAPER_POINTER_FILE")"
-	printf '%s\n' "$path" > "$DOTS_WALLPAPER_POINTER_FILE"
+  local path="$1"
+  mkdir -p "$(dirname "$DOTS_WALLPAPER_POINTER_FILE")"
+  printf '%s\n' "$path" >"$DOTS_WALLPAPER_POINTER_FILE"
 }
 
 _dots_aa_normalize_scheme_type() {
-	local raw="${1:-tonal-spot}"
-	raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
-	case "$raw" in
-		vibrant | expressive | fidelity | content | neutral | monochrome) printf '%s\n' "$raw" ;;
-		tonalspot | tonal-spot) printf 'tonal-spot\n' ;;
-		*) printf 'tonal-spot\n' ;;
-	esac
+  local raw="${1:-tonal-spot}"
+  raw=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | tr -d ' ')
+  case "$raw" in
+    vibrant | expressive | fidelity | content | neutral | monochrome) printf '%s\n' "$raw" ;;
+    tonalspot | tonal-spot) printf 'tonal-spot\n' ;;
+    *) printf 'tonal-spot\n' ;;
+  esac
 }
 
 # Resolve gtk-application-prefer-dark independently of shell darkMode when possible.
 # Priority: theme.json gtkPreferDark → Light/Dark in gtk theme name → shell mode.
 _dots_aa_resolve_gtk_prefer() {
-	local config_json="${1:-}"
-	local dark_mode="${2:-dark}"
-	local gtk_theme="${3:-}"
-	local explicit=""
+  local config_json="${1:-}"
+  local dark_mode="${2:-dark}"
+  local gtk_theme="${3:-}"
+  local explicit=""
 
-	if [[ -n $config_json && -f $config_json ]]; then
-		explicit="$(_dots_aa_json_get "$config_json" gtkPreferDark "")"
-	fi
-	case "$explicit" in
-		true | false)
-			printf '%s\n' "$explicit"
-			return 0
-			;;
-	esac
+  if [[ -n $config_json && -f $config_json ]]; then
+    explicit="$(_dots_aa_json_get "$config_json" gtkPreferDark "")"
+  fi
+  case "$explicit" in
+    true | false)
+      printf '%s\n' "$explicit"
+      return 0
+      ;;
+  esac
 
-	local gtk_lc
-	gtk_lc=$(printf '%s' "$gtk_theme" | tr '[:upper:]' '[:lower:]')
-	case "$gtk_lc" in
-		*light*)
-			printf 'false\n'
-			;;
-		*dark*)
-			printf 'true\n'
-			;;
-		*)
-			if [[ $dark_mode == "light" ]]; then
-				printf 'false\n'
-			else
-				printf 'true\n'
-			fi
-			;;
-	esac
+  local gtk_lc
+  gtk_lc=$(printf '%s' "$gtk_theme" | tr '[:upper:]' '[:lower:]')
+  case "$gtk_lc" in
+    *light*)
+      printf 'false\n'
+      ;;
+    *dark*)
+      printf 'true\n'
+      ;;
+    *)
+      if [[ $dark_mode == "light" ]]; then
+        printf 'false\n'
+      else
+        printf 'true\n'
+      fi
+      ;;
+  esac
 }
 
 _dots_aa_resolve_theme_wallpaper() {
-	local theme_id="$1"
-	local wallpaper_dir="$2"
-	local default_name="$3"
-	local override="${4:-}"
-	local candidate=""
+  local theme_id="$1"
+  local wallpaper_dir="$2"
+  local default_name="$3"
+  local override="${4:-}"
+  local candidate=""
 
-	if [[ -n $override ]]; then
-		candidate="$(readlink -f "$override" 2> /dev/null || true)"
-		[[ -n ${candidate:-} && -f $candidate ]] && {
-			printf '%s\n' "$candidate"
-			return 0
-		}
-	fi
+  if [[ -n $override ]]; then
+    candidate="$(readlink -f "$override" 2>/dev/null || true)"
+    [[ -n ${candidate:-} && -f $candidate ]] && {
+      printf '%s\n' "$candidate"
+      return 0
+    }
+  fi
 
-	for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
-		if [[ -n $default_name && -f $base/$default_name ]]; then
-			readlink -f "$base/$default_name"
-			return 0
-		fi
-	done
+  for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
+    if [[ -n $default_name && -f $base/$default_name ]]; then
+      readlink -f "$base/$default_name"
+      return 0
+    fi
+  done
 
-	for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
-		[[ -d $base ]] || continue
-		candidate="$(
-			find -L "$base" -maxdepth 1 \( -type f -o -type l \) \
-				\( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" \
-				-o -iname "*.gif" -o -iname "*.bmp" \) 2> /dev/null | sort | head -n 1 || true
-		)"
-		[[ -n ${candidate:-} && -f $candidate ]] && {
-			printf '%s\n' "$candidate"
-			return 0
-		}
-	done
-	return 1
+  for base in "$DOTS_PICTURES_WALLPAPERS/$wallpaper_dir" "$DOTS_WALLPAPERS_DIR/$wallpaper_dir"; do
+    [[ -d $base ]] || continue
+    candidate="$(
+      find -L "$base" -maxdepth 1 \( -type f -o -type l \) \
+        \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.png" -o -iname "*.webp" \
+        -o -iname "*.gif" -o -iname "*.bmp" \) 2>/dev/null | sort | head -n 1 || true
+    )"
+    [[ -n ${candidate:-} && -f $candidate ]] && {
+      printf '%s\n' "$candidate"
+      return 0
+    }
+  done
+  return 1
 }
 
+# Re-apply persisted GTK color-scheme policy (follow tracks shell mode).
+# Optional $1 is ignored except as a legacy positional from older callers.
 _dots_aa_sync_gtk_color_scheme() {
-	local mode="${1:-dark}"
-	if command -v dots-gtk-theme > /dev/null 2>&1; then
-		dots-gtk-theme -q color-scheme "$mode" > /dev/null 2>&1 || true
-	elif [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
-		# shellcheck source=/dev/null
-		source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2> /dev/null || true
-		if declare -f apply_gtk_color_scheme > /dev/null 2>&1; then
-			apply_gtk_color_scheme "$mode" > /dev/null 2>&1 || true
-		fi
-	fi
+  if command -v dots-gtk-theme >/dev/null 2>&1; then
+    dots-gtk-theme -q sync-color-scheme >/dev/null 2>&1 || true
+  elif [[ -f $HOME/.local/lib/dots/gtk-theme-manager.sh ]]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.local/lib/dots/gtk-theme-manager.sh" 2>/dev/null || true
+    if declare -f sync_gtk_color_scheme >/dev/null 2>&1; then
+      sync_gtk_color_scheme >/dev/null 2>&1 || true
+    elif declare -f apply_gtk_color_scheme >/dev/null 2>&1; then
+      apply_gtk_color_scheme follow >/dev/null 2>&1 || true
+    fi
+  fi
+}
+
+# Pack recipe → canonical gtkColorScheme policy.
+_dots_aa_resolve_gtk_color_scheme() {
+  local config_json="${1:-}"
+  local dark_mode="${2:-dark}"
+  local gtk_theme="${3:-}"
+  local explicit=""
+
+  if [[ -n $config_json && -f $config_json ]]; then
+    explicit="$(_dots_aa_json_get "$config_json" gtkColorScheme "")"
+  fi
+  case "$explicit" in
+    follow | default | prefer-light | prefer-dark)
+      printf '%s\n' "$explicit"
+      return 0
+      ;;
+    light)
+      printf 'prefer-light\n'
+      return 0
+      ;;
+    dark)
+      printf 'prefer-dark\n'
+      return 0
+      ;;
+    auto)
+      printf 'default\n'
+      return 0
+      ;;
+  esac
+
+  local prefer
+  prefer="$(_dots_aa_resolve_gtk_prefer "$config_json" "$dark_mode" "$gtk_theme")"
+  if [[ $prefer == "false" ]]; then
+    printf 'prefer-light\n'
+  else
+    printf 'prefer-dark\n'
+  fi
 }
 
 _dots_aa_run_palette() {
-	local wallpaper="$1"
-	local scheme_type="$2"
-	local dark_mode="$3"
+  local wallpaper="$1"
+  local scheme_type="$2"
+  local dark_mode="$3"
 
-	if ! command -v wal > /dev/null 2>&1; then
-		echo "apply-appearance: wal not found" >&2
-		return 1
-	fi
-	# Drop any prior wal→image symlink before wal runs; echoing a path through
-	# that symlink would truncate the wallpaper file itself.
-	mkdir -p "$HOME/.cache/wal"
-	rm -f "$HOME/.cache/wal/wal"
-	if [[ $dark_mode == "light" ]]; then
-		wal -i "$wallpaper" -q -l || return 1
-	else
-		wal -i "$wallpaper" -q || return 1
-	fi
+  if ! command -v wal >/dev/null 2>&1; then
+    echo "apply-appearance: wal not found" >&2
+    return 1
+  fi
+  # Drop any prior wal→image symlink before wal runs; echoing a path through
+  # that symlink would truncate the wallpaper file itself.
+  mkdir -p "$HOME/.cache/wal"
+  rm -f "$HOME/.cache/wal/wal"
+  if [[ $dark_mode == "light" ]]; then
+    wal -i "$wallpaper" -q -l || return 1
+  else
+    wal -i "$wallpaper" -q || return 1
+  fi
 
-	_dots_aa_write_pointer "$wallpaper"
-	rm -f "$HOME/.cache/wal/wal"
-	printf '%s\n' "$wallpaper" > "$HOME/.cache/wal/wal"
+  _dots_aa_write_pointer "$wallpaper"
+  rm -f "$HOME/.cache/wal/wal"
+  printf '%s\n' "$wallpaper" >"$HOME/.cache/wal/wal"
 
-	[[ -f $DOTS_M3_SCRIPT ]] || {
-		echo "apply-appearance: missing generate-m3-colors.py" >&2
-		return 1
-	}
-	# Prefer system Python with materialyoucolor over pyenv shims on PATH.
-	# shellcheck source=/dev/null
-	source "${HOME}/.local/lib/dots/python-m3.sh" 2> /dev/null || true
-	mkdir -p "$(dirname "$DOTS_SCHEME_FILE")"
-	if declare -f dots_run_m3_colors > /dev/null 2>&1; then
-		dots_run_m3_colors \
-			--image "$wallpaper" \
-			--scheme-type "$scheme_type" \
-			--mode "$dark_mode" \
-			--output "$DOTS_SCHEME_FILE" || return 1
-	elif command -v dots-m3-colors > /dev/null 2>&1; then
-		dots-m3-colors \
-			--image "$wallpaper" \
-			--scheme-type "$scheme_type" \
-			--mode "$dark_mode" \
-			--output "$DOTS_SCHEME_FILE" || return 1
-	else
-		python3 "$DOTS_M3_SCRIPT" \
-			--image "$wallpaper" \
-			--scheme-type "$scheme_type" \
-			--mode "$dark_mode" \
-			--output "$DOTS_SCHEME_FILE" || return 1
-	fi
+  [[ -f $DOTS_M3_SCRIPT ]] || {
+    echo "apply-appearance: missing generate-m3-colors.py" >&2
+    return 1
+  }
+  # Prefer system Python with materialyoucolor over pyenv shims on PATH.
+  # shellcheck source=/dev/null
+  source "${HOME}/.local/lib/dots/python-m3.sh" 2>/dev/null || true
+  mkdir -p "$(dirname "$DOTS_SCHEME_FILE")"
+  if declare -f dots_run_m3_colors >/dev/null 2>&1; then
+    dots_run_m3_colors \
+      --image "$wallpaper" \
+      --scheme-type "$scheme_type" \
+      --mode "$dark_mode" \
+      --output "$DOTS_SCHEME_FILE" || return 1
+  elif command -v dots-m3-colors >/dev/null 2>&1; then
+    dots-m3-colors \
+      --image "$wallpaper" \
+      --scheme-type "$scheme_type" \
+      --mode "$dark_mode" \
+      --output "$DOTS_SCHEME_FILE" || return 1
+  else
+    python3 "$DOTS_M3_SCRIPT" \
+      --image "$wallpaper" \
+      --scheme-type "$scheme_type" \
+      --mode "$dark_mode" \
+      --output "$DOTS_SCHEME_FILE" || return 1
+  fi
 
-	if command -v dots-color-scheme > /dev/null 2>&1; then
-		dots-color-scheme sync-state > /dev/null 2>&1 || return 1
-	fi
-	_dots_aa_sync_gtk_color_scheme "$dark_mode"
-	if command -v dots-hyprlock-theme > /dev/null 2>&1; then
-		dots-hyprlock-theme > /dev/null 2>&1 || true
-	fi
-	if command -v hyprctl > /dev/null 2>&1; then
-		hyprctl reload > /dev/null 2>&1 || true
-	fi
-	return 0
+  if command -v dots-color-scheme >/dev/null 2>&1; then
+    dots-color-scheme sync-state >/dev/null 2>&1 || return 1
+  fi
+  _dots_aa_sync_gtk_color_scheme "$dark_mode"
+  if command -v dots-hyprlock-theme >/dev/null 2>&1; then
+    dots-hyprlock-theme >/dev/null 2>&1 || true
+  fi
+  if command -v hyprctl >/dev/null 2>&1; then
+    hyprctl reload >/dev/null 2>&1 || true
+  fi
+  return 0
 }
 
 # Apply a theme pack once (no persistent current-theme state).
 dots_apply_theme() {
-	local theme_id="${1:-}"
-	local wallpaper_override="${2:-}"
+  local theme_id="${1:-}"
+  local wallpaper_override="${2:-}"
 
-	[[ -n $theme_id ]] || {
-		echo "dots_apply_theme: theme id required" >&2
-		return 1
-	}
-	local config_json="$DOTS_THEMES_DIR/$theme_id/theme.json"
-	[[ -f $config_json ]] || {
-		echo "dots_apply_theme: theme not found: $theme_id" >&2
-		return 1
-	}
+  [[ -n $theme_id ]] || {
+    echo "dots_apply_theme: theme id required" >&2
+    return 1
+  }
+  local config_json="$DOTS_THEMES_DIR/$theme_id/theme.json"
+  [[ -f $config_json ]] || {
+    echo "dots_apply_theme: theme not found: $theme_id" >&2
+    return 1
+  }
 
-	local scheme_type dark_mode_raw dark_mode gtk_theme icon_theme theme_name wallpaper_dir default_wp wallpaper
-	scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$config_json" schemeType tonal-spot)")"
-	dark_mode_raw="$(_dots_aa_json_get "$config_json" darkMode true)"
-	if [[ $dark_mode_raw == "false" ]]; then
-		dark_mode="light"
-	else
-		dark_mode="dark"
-	fi
-	gtk_theme="$(_dots_aa_json_get "$config_json" gtkTheme Orchis-Light-Compact)"
-	icon_theme="$(_dots_aa_json_get "$config_json" iconTheme Numix-Circle)"
-	theme_name="$(_dots_aa_json_get "$config_json" name "$theme_id")"
-	wallpaper_dir="$(_dots_aa_json_get "$config_json" wallpaperDir "$theme_id")"
-	default_wp="$(_dots_aa_json_get "$config_json" defaultWallpaper "")"
+  local scheme_type dark_mode_raw dark_mode gtk_theme icon_theme theme_name wallpaper_dir default_wp wallpaper
+  scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$config_json" schemeType tonal-spot)")"
+  dark_mode_raw="$(_dots_aa_json_get "$config_json" darkMode true)"
+  if [[ $dark_mode_raw == "false" ]]; then
+    dark_mode="light"
+  else
+    dark_mode="dark"
+  fi
+  gtk_theme="$(_dots_aa_json_get "$config_json" gtkTheme Orchis-Light-Compact)"
+  icon_theme="$(_dots_aa_json_get "$config_json" iconTheme Numix-Circle)"
+  theme_name="$(_dots_aa_json_get "$config_json" name "$theme_id")"
+  wallpaper_dir="$(_dots_aa_json_get "$config_json" wallpaperDir "$theme_id")"
+  default_wp="$(_dots_aa_json_get "$config_json" defaultWallpaper "")"
 
-	wallpaper="$(_dots_aa_resolve_theme_wallpaper "$theme_id" "$wallpaper_dir" "$default_wp" "$wallpaper_override" || true)"
-	[[ -n ${wallpaper:-} && -f $wallpaper ]] || {
-		echo "dots_apply_theme: no wallpaper for theme $theme_id" >&2
-		return 1
-	}
+  wallpaper="$(_dots_aa_resolve_theme_wallpaper "$theme_id" "$wallpaper_dir" "$default_wp" "$wallpaper_override" || true)"
+  [[ -n ${wallpaper:-} && -f $wallpaper ]] || {
+    echo "dots_apply_theme: no wallpaper for theme $theme_id" >&2
+    return 1
+  }
 
-	_dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode" || return 1
+  _dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode" || return 1
 
-	if command -v dots-gtk-theme > /dev/null 2>&1; then
-		if [[ -n $gtk_theme && $gtk_theme != "auto" ]]; then
-			local prefer
-			prefer="$(_dots_aa_resolve_gtk_prefer "$config_json" "$dark_mode" "$gtk_theme")"
-			dots-gtk-theme -q apply "$gtk_theme" "${icon_theme:-Numix-Circle}" "$prefer" > /dev/null 2>&1 || true
-		elif [[ $gtk_theme == "auto" ]]; then
-			dots-gtk-theme -q theme "$theme_id" > /dev/null 2>&1 || true
-			local prefer_auto
-			prefer_auto="$(_dots_aa_resolve_gtk_prefer "$config_json" "$dark_mode" "")"
-			if [[ $prefer_auto == "false" ]]; then
-				dots-gtk-theme -q color-scheme light > /dev/null 2>&1 || true
-			else
-				dots-gtk-theme -q color-scheme dark > /dev/null 2>&1 || true
-			fi
-		elif [[ -n $icon_theme ]]; then
-			dots-gtk-theme -q set-icons "$icon_theme" > /dev/null 2>&1 || true
-			dots-gtk-theme -q color-scheme "$dark_mode" > /dev/null 2>&1 || true
-		else
-			dots-gtk-theme -q color-scheme "$dark_mode" > /dev/null 2>&1 || true
-		fi
-	elif [[ -n $icon_theme ]] && command -v gsettings > /dev/null 2>&1; then
-		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" > /dev/null 2>&1 || true
-		_dots_aa_sync_gtk_color_scheme "$dark_mode"
-	else
-		_dots_aa_sync_gtk_color_scheme "$dark_mode"
-	fi
+  local gtk_policy
+  gtk_policy="$(_dots_aa_resolve_gtk_color_scheme "$config_json" "$dark_mode" "$gtk_theme")"
 
-	if [[ -f $HOME/.local/lib/dots/snappy-switcher-manager.sh ]]; then
-		# shellcheck source=/dev/null
-		source "$HOME/.local/lib/dots/snappy-switcher-manager.sh" 2> /dev/null || true
-		if declare -f apply_theme_snappy_switcher_theme > /dev/null 2>&1; then
-			apply_theme_snappy_switcher_theme "$theme_id" > /dev/null 2>&1 || true
-		fi
-	fi
+  if command -v dots-gtk-theme >/dev/null 2>&1; then
+    if [[ -n $gtk_theme && $gtk_theme != "auto" ]]; then
+      dots-gtk-theme -q apply "$gtk_theme" "${icon_theme:-Numix-Circle}" "$gtk_policy" >/dev/null 2>&1 || true
+    elif [[ $gtk_theme == "auto" ]]; then
+      dots-gtk-theme -q theme "$theme_id" >/dev/null 2>&1 || true
+      dots-gtk-theme -q color-scheme "$gtk_policy" >/dev/null 2>&1 || true
+    elif [[ -n $icon_theme ]]; then
+      dots-gtk-theme -q set-icons "$icon_theme" >/dev/null 2>&1 || true
+      dots-gtk-theme -q color-scheme "$gtk_policy" >/dev/null 2>&1 || true
+    else
+      dots-gtk-theme -q color-scheme "$gtk_policy" >/dev/null 2>&1 || true
+    fi
+  elif [[ -n $icon_theme ]] && command -v gsettings >/dev/null 2>&1; then
+    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" >/dev/null 2>&1 || true
+    _dots_aa_sync_gtk_color_scheme
+  else
+    _dots_aa_sync_gtk_color_scheme
+  fi
 
-	if command -v notify-send > /dev/null 2>&1; then
-		notify-send "HorneroConfig" "${theme_name} theme applied" > /dev/null 2>&1 || true
-	fi
-	return 0
+  if [[ -f $HOME/.local/lib/dots/snappy-switcher-manager.sh ]]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.local/lib/dots/snappy-switcher-manager.sh" 2>/dev/null || true
+    if declare -f apply_theme_snappy_switcher_theme >/dev/null 2>&1; then
+      apply_theme_snappy_switcher_theme "$theme_id" >/dev/null 2>&1 || true
+    fi
+  fi
+
+  if command -v notify-send >/dev/null 2>&1; then
+    notify-send "HorneroConfig" "${theme_name} theme applied" >/dev/null 2>&1 || true
+  fi
+  return 0
 }
 
 # Back-compat name used by older callers during transition.
 dots_apply_appearance() {
-	dots_apply_theme "$@"
+  dots_apply_theme "$@"
 }
 
 # Wallpaper-only: live mode/flavour from scheme state.
 dots_apply_wallpaper_only() {
-	local wallpaper="${1:-}"
-	wallpaper="$(readlink -f "$wallpaper" 2> /dev/null || true)"
-	[[ -n ${wallpaper:-} && -f $wallpaper ]] || {
-		echo "dots_apply_wallpaper_only: wallpaper not found" >&2
-		return 1
-	}
+  local wallpaper="${1:-}"
+  wallpaper="$(readlink -f "$wallpaper" 2>/dev/null || true)"
+  [[ -n ${wallpaper:-} && -f $wallpaper ]] || {
+    echo "dots_apply_wallpaper_only: wallpaper not found" >&2
+    return 1
+  }
 
-	local scheme_type="tonal-spot" dark_mode="dark"
-	local state_file="$DOTS_STATE_DIR/scheme/state.json"
-	if [[ -f $state_file ]]; then
-		scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$state_file" flavour tonal-spot)")"
-		dark_mode="$(_dots_aa_json_get "$state_file" mode dark)"
-		[[ $dark_mode == "light" || $dark_mode == "dark" ]] || dark_mode="dark"
-	fi
+  local scheme_type="tonal-spot" dark_mode="dark"
+  local state_file="$DOTS_STATE_DIR/scheme/state.json"
+  if [[ -f $state_file ]]; then
+    scheme_type="$(_dots_aa_normalize_scheme_type "$(_dots_aa_json_get "$state_file" flavour tonal-spot)")"
+    dark_mode="$(_dots_aa_json_get "$state_file" mode dark)"
+    [[ $dark_mode == "light" || $dark_mode == "dark" ]] || dark_mode="dark"
+  fi
 
-	_dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode"
+  _dots_aa_run_palette "$wallpaper" "$scheme_type" "$dark_mode"
 }

--- a/home/dot_local/lib/dots/gtk-theme-manager.sh
+++ b/home/dot_local/lib/dots/gtk-theme-manager.sh
@@ -19,129 +19,130 @@ set -euo pipefail
 
 # Source smart colors for theme detection
 if [[ -f "$HOME/.local/lib/dots/smart-colors.sh" ]]; then
-	source "$HOME/.local/lib/dots/smart-colors.sh"
+  source "$HOME/.local/lib/dots/smart-colors.sh"
 fi
 
 # GTK configuration paths
 readonly GTK2_CONFIG="$HOME/.gtkrc-2.0"
 readonly GTK3_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini"
+readonly GTK4_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/gtk-4.0/settings.ini"
+readonly DOTS_SCHEME_STATE="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/state.json"
 
 # Function to log messages
 log() {
-	local level="$1"
-	shift
-	local message="$*"
-	local timestamp
-	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+  local level="$1"
+  shift
+  local message="$*"
+  local timestamp
+  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-	echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
+  echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
 }
 
 # Function to check if a GTK theme is installed
 is_gtk_theme_installed() {
-	local theme_name="$1"
+  local theme_name="$1"
 
-	# Check in common theme directories
-	local theme_dirs=(
-		"/usr/share/themes"
-		"/usr/local/share/themes"
-		"$HOME/.themes"
-		"$HOME/.local/share/themes"
-	)
+  # Check in common theme directories
+  local theme_dirs=(
+    "/usr/share/themes"
+    "/usr/local/share/themes"
+    "$HOME/.themes"
+    "$HOME/.local/share/themes"
+  )
 
-	for theme_dir in "${theme_dirs[@]}"; do
-		if [[ -d "$theme_dir/$theme_name" ]]; then
-			return 0
-		fi
-	done
+  for theme_dir in "${theme_dirs[@]}"; do
+    if [[ -d "$theme_dir/$theme_name" ]]; then
+      return 0
+    fi
+  done
 
-	return 1
+  return 1
 }
 
 # Function to check if an icon theme is installed
 is_icon_theme_installed() {
-	local icon_theme="$1"
+  local icon_theme="$1"
 
-	# Check in common icon directories
-	local icon_dirs=(
-		"/usr/share/icons"
-		"/usr/local/share/icons"
-		"$HOME/.icons"
-		"$HOME/.local/share/icons"
-	)
+  # Check in common icon directories
+  local icon_dirs=(
+    "/usr/share/icons"
+    "/usr/local/share/icons"
+    "$HOME/.icons"
+    "$HOME/.local/share/icons"
+  )
 
-	for icon_dir in "${icon_dirs[@]}"; do
-		if [[ -d "$icon_dir/$icon_theme" ]]; then
-			return 0
-		fi
-	done
+  for icon_dir in "${icon_dirs[@]}"; do
+    if [[ -d "$icon_dir/$icon_theme" ]]; then
+      return 0
+    fi
+  done
 
-	return 1
+  return 1
 }
 
 # Function to apply GTK theme with fallbacks
 apply_gtk_theme() {
-	local gtk_theme="$1"
-	local icon_theme="${2:-elementary}"
-	local prefer_dark="${3:-false}"
+  local gtk_theme="$1"
+  local icon_theme="${2:-elementary}"
 
-	log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
+  log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
 
-	# Validate theme availability with fallbacks
-	if ! is_gtk_theme_installed "$gtk_theme"; then
-		log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
+  # Validate theme availability with fallbacks
+  if ! is_gtk_theme_installed "$gtk_theme"; then
+    log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
 
-		# Common fallback themes in order of preference
-		local fallback_themes=(
-			"Orchis-Light"
-			"elementary"
-			"Arc-Dark"
-			"Arc"
-			"Breeze"
-			"oxygen-gtk"
-		)
+    # Common fallback themes in order of preference
+    local fallback_themes=(
+      "Orchis-Light"
+      "elementary"
+      "Arc-Dark"
+      "Arc"
+      "Breeze"
+      "oxygen-gtk"
+    )
 
-		for fallback in "${fallback_themes[@]}"; do
-			if is_gtk_theme_installed "$fallback"; then
-				gtk_theme="$fallback"
-				log "INFO" "Using fallback theme: $gtk_theme"
-				break
-			fi
-		done
+    for fallback in "${fallback_themes[@]}"; do
+      if is_gtk_theme_installed "$fallback"; then
+        gtk_theme="$fallback"
+        log "INFO" "Using fallback theme: $gtk_theme"
+        break
+      fi
+    done
 
-		if ! is_gtk_theme_installed "$gtk_theme"; then
-			log "ERROR" "No suitable GTK theme found, keeping current theme"
-			return 1
-		fi
-	fi
+    if ! is_gtk_theme_installed "$gtk_theme"; then
+      log "ERROR" "No suitable GTK theme found, keeping current theme"
+      return 1
+    fi
+  fi
 
-	# Validate icon theme with fallbacks
-	if ! is_icon_theme_installed "$icon_theme"; then
-		log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
+  # Validate icon theme with fallbacks
+  if ! is_icon_theme_installed "$icon_theme"; then
+    log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
 
-		local fallback_icons=(
-			"Numix-Circle"
-			"elementary"
-			"hicolor"
-		)
+    local fallback_icons=(
+      "Numix-Circle"
+      "elementary"
+      "hicolor"
+    )
 
-		for fallback in "${fallback_icons[@]}"; do
-			if is_icon_theme_installed "$fallback"; then
-				icon_theme="$fallback"
-				log "INFO" "Using fallback icon theme: $icon_theme"
-				break
-			fi
-		done
-	fi
+    for fallback in "${fallback_icons[@]}"; do
+      if is_icon_theme_installed "$fallback"; then
+        icon_theme="$fallback"
+        log "INFO" "Using fallback icon theme: $icon_theme"
+        break
+      fi
+    done
+  fi
 
-	# Update GTK2 configuration
-	if [[ -f $GTK2_CONFIG ]]; then
-		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
-		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
-		log "INFO" "Updated GTK2 configuration"
-	else
-		log "WARN" "GTK2 config not found, creating basic configuration"
-		cat > "$GTK2_CONFIG" << EOF
+  # Update GTK2 configuration
+  if [[ -f $GTK2_CONFIG ]]; then
+    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
+    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
+    log "INFO" "Updated GTK2 configuration"
+  else
+    log "WARN" "GTK2 config not found, creating basic configuration"
+    cat >"$GTK2_CONFIG" <<EOF
 # DO NOT EDIT! This file will be overwritten by LXAppearance.
 # Any customization should be done in ~/.gtkrc-2.0.mine instead.
 
@@ -162,20 +163,18 @@ gtk-xft-hinting=1
 gtk-xft-hintstyle="hintslight"
 gtk-xft-rgba="rgb"
 EOF
-	fi
+  fi
 
-	# Update GTK3 configuration
-	if [[ -f $GTK3_CONFIG ]]; then
-		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
-		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
-		sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-		log "INFO" "Updated GTK3 configuration"
-	else
-		log "WARN" "GTK3 config not found, creating configuration"
-		mkdir -p "$(dirname "$GTK3_CONFIG")"
-		cat > "$GTK3_CONFIG" << EOF
+  # Update GTK3 configuration (color-scheme / prefer-dark is applied below).
+  if [[ -f $GTK3_CONFIG ]]; then
+    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
+    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
+    log "INFO" "Updated GTK3 configuration"
+  else
+    log "WARN" "GTK3 config not found, creating configuration"
+    mkdir -p "$(dirname "$GTK3_CONFIG")"
+    cat >"$GTK3_CONFIG" <<EOF
 [Settings]
-gtk-application-prefer-dark-theme=$prefer_dark
 gtk-theme-name=$gtk_theme
 gtk-icon-theme-name=$icon_theme
 gtk-font-name=sans 11
@@ -193,335 +192,461 @@ gtk-xft-hintstyle=hintslight
 gtk-xft-rgba=rgb
 gtk-modules=colorreload-gtk-module
 EOF
-	fi
+  fi
 
-	# Notify running GTK applications to reload themes
-	if command -v gsettings > /dev/null 2>&1; then
-		gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2> /dev/null || true
-		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2> /dev/null || true
-		# Older schemas expose this key; portals/libadwaita use color-scheme instead.
-		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
-		log "INFO" "Updated gsettings"
-	fi
+  # Notify running GTK applications to reload themes
+  if command -v gsettings >/dev/null 2>&1; then
+    gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2>/dev/null || true
+    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2>/dev/null || true
+    log "INFO" "Updated gsettings"
+  fi
 
-	# Keep portal/libadwaita color-scheme in lockstep with prefer-dark.
-	if [[ $prefer_dark == "true" ]]; then
-		apply_gtk_color_scheme dark
-	else
-		apply_gtk_color_scheme light
-	fi
+  _gtk_ini_set "$GTK4_CONFIG" "gtk-theme-name" "$gtk_theme"
+  _gtk_ini_set "$GTK4_CONFIG" "gtk-icon-theme-name" "$icon_theme"
 
-	# XFCE4 settings support removed - using gsettings only
-	# If running XFCE4 session, gsettings should be sufficient
-	# Legacy xfconf-query support can be re-enabled if needed
+  # Color-scheme is independent of the GTK theme name. An explicit 3rd arg
+  # (true/false or a gtkColorScheme policy) sets/persists policy; otherwise
+  # re-apply the live policy so a theme-name change cannot clobber it.
+  if [[ -n ${3:-} ]]; then
+    local policy
+    policy="$(normalize_gtk_color_scheme "$3")"
+    if [[ $policy == "invalid" ]]; then
+      log "WARN" "Unknown GTK color-scheme '$3', re-applying live policy"
+      sync_gtk_color_scheme
+    else
+      apply_gtk_color_scheme "$policy"
+    fi
+  else
+    sync_gtk_color_scheme
+  fi
 
-	log "INFO" "GTK theme applied successfully: $gtk_theme"
-	return 0
+  log "INFO" "GTK theme applied successfully: $gtk_theme"
+  return 0
 }
 
-# Sync GTK/libadwaita light-dark preference without changing the theme name.
-# mode: "dark" | "light"
+# Canonical gtkColorScheme policy: follow | default | prefer-light | prefer-dark
+# Aliases: light→prefer-light, dark→prefer-dark, auto→default.
+normalize_gtk_color_scheme() {
+  local raw
+  raw="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')"
+  case "$raw" in
+    follow | follow-mode | follow-theme | follow-theme-mode) printf 'follow\n' ;;
+    default | auto | apps | apps-decide) printf 'default\n' ;;
+    prefer-light | light) printf 'prefer-light\n' ;;
+    prefer-dark | dark) printf 'prefer-dark\n' ;;
+    true | 1 | yes) printf 'prefer-dark\n' ;;
+    false | 0 | no) printf 'prefer-light\n' ;;
+    *) printf 'invalid\n' ;;
+  esac
+}
+
+read_live_shell_mode() {
+  local mode="dark"
+  if [[ -f $DOTS_SCHEME_STATE ]]; then
+    mode="$(python3 -c "import json;print(json.load(open('$DOTS_SCHEME_STATE')).get('mode','dark'))" 2>/dev/null || echo dark)"
+  fi
+  if [[ $mode == "light" || $mode == "dark" ]]; then
+    printf '%s\n' "$mode"
+  else
+    printf 'dark\n'
+  fi
+}
+
+# Persisted policy. Missing key → follow (legacy: GTK tracked shell mode).
+read_live_gtk_color_scheme() {
+  local policy=""
+  if [[ -f $DOTS_SCHEME_STATE ]]; then
+    policy="$(python3 -c "import json;print(json.load(open('$DOTS_SCHEME_STATE')).get('gtkColorScheme','') or '')" 2>/dev/null || true)"
+  fi
+  policy="$(normalize_gtk_color_scheme "${policy:-follow}")"
+  if [[ $policy == "invalid" ]]; then
+    policy="follow"
+  fi
+  printf '%s\n' "$policy"
+}
+
+write_live_gtk_color_scheme() {
+  local policy="$1"
+  policy="$(normalize_gtk_color_scheme "$policy")"
+  [[ $policy != "invalid" ]] || return 1
+  mkdir -p "$(dirname "$DOTS_SCHEME_STATE")" 2>/dev/null || true
+  python3 - "$DOTS_SCHEME_STATE" "$policy" <<'PY' || true
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+policy = sys.argv[2]
+try:
+    data = json.loads(path.read_text(encoding="utf-8"))
+except Exception:
+    data = {}
+if not isinstance(data, dict):
+    data = {}
+data["gtkColorScheme"] = policy
+data.setdefault("name", "dynamic")
+data.setdefault("flavour", "tonal-spot")
+data.setdefault("variant", "tonalspot")
+data.setdefault("mode", "dark")
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+PY
+}
+
+# Resolve follow → prefer-light|prefer-dark from shell mode. Other policies pass through.
+effective_gtk_color_scheme() {
+  local policy
+  policy="$(normalize_gtk_color_scheme "${1:-}")"
+  if [[ $policy == "invalid" ]]; then
+    policy="$(read_live_gtk_color_scheme)"
+  fi
+  if [[ $policy == "follow" ]]; then
+    local mode
+    mode="$(read_live_shell_mode)"
+    if [[ $mode == "light" ]]; then
+      printf 'prefer-light\n'
+    else
+      printf 'prefer-dark\n'
+    fi
+    return 0
+  fi
+  printf '%s\n' "$policy"
+}
+
+_gtk_ini_set() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+  mkdir -p "$(dirname "$file")" || return 1
+  if [[ ! -f $file ]]; then
+    printf '[Settings]\n%s=%s\n' "$key" "$value" >"$file" || return 1
+    return 0
+  fi
+  if grep -q "^${key}=" "$file" 2>/dev/null; then
+    sed -i "s|^${key}=.*|${key}=${value}|" "$file"
+  else
+    if ! grep -q '^\[Settings\]' "$file" 2>/dev/null; then
+      printf '[Settings]\n' >>"$file"
+    fi
+    printf '%s=%s\n' "$key" "$value" >>"$file"
+  fi
+}
+
+_gtk_write_prefer_dark() {
+  local prefer_dark="$1"
+  _gtk_ini_set "$GTK3_CONFIG" "gtk-application-prefer-dark-theme" "$prefer_dark"
+  _gtk_ini_set "$GTK4_CONFIG" "gtk-application-prefer-dark-theme" "$prefer_dark"
+}
+
+# Sync GTK/libadwaita color-scheme without changing the theme name.
+# Accepts follow|default|prefer-light|prefer-dark|light|dark.
+# Persists gtkColorScheme in state.json — never writes shell `mode`.
 apply_gtk_color_scheme() {
-	local mode="${1:-dark}"
-	local prefer_dark="true"
-	local color_scheme="prefer-dark"
-	if [[ $mode == "light" ]]; then
-		prefer_dark="false"
-		color_scheme="prefer-light"
-	elif [[ $mode != "dark" ]]; then
-		log "ERROR" "apply_gtk_color_scheme: mode must be light or dark (got: $mode)"
-		return 1
-	fi
+  local requested="${1:-follow}"
+  local policy
+  policy="$(normalize_gtk_color_scheme "$requested")"
+  if [[ $policy == "invalid" ]]; then
+    log "ERROR" "apply_gtk_color_scheme: expected follow|default|prefer-light|prefer-dark|light|dark (got: $requested)"
+    return 1
+  fi
 
-	if [[ -f $GTK3_CONFIG ]]; then
-		if grep -q '^gtk-application-prefer-dark-theme=' "$GTK3_CONFIG" 2> /dev/null; then
-			sed -i "s/^gtk-application-prefer-dark-theme=.*/gtk-application-prefer-dark-theme=$prefer_dark/" "$GTK3_CONFIG"
-		else
-			printf '\ngtk-application-prefer-dark-theme=%s\n' "$prefer_dark" >> "$GTK3_CONFIG"
-		fi
-	else
-		mkdir -p "$(dirname "$GTK3_CONFIG")" || {
-			log "ERROR" "Failed to create directory for $GTK3_CONFIG"
-			return 1
-		}
-		if ! cat > "$GTK3_CONFIG" << EOF; then
-[Settings]
-gtk-application-prefer-dark-theme=$prefer_dark
-EOF
-			log "ERROR" "Failed to write $GTK3_CONFIG"
-			return 1
-		fi
-		log "INFO" "Created GTK3 config for color-scheme sync"
-	fi
+  write_live_gtk_color_scheme "$policy"
 
-	if command -v gsettings > /dev/null 2>&1; then
-		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
-		gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" > /dev/null 2>&1 || true
-	fi
-	log "INFO" "GTK color-scheme set to $color_scheme"
-	return 0
+  local effective prefer_dark="false" color_scheme="prefer-dark"
+  effective="$(effective_gtk_color_scheme "$policy")"
+  case "$effective" in
+    default)
+      prefer_dark="false"
+      color_scheme="default"
+      ;;
+    prefer-light)
+      prefer_dark="false"
+      color_scheme="prefer-light"
+      ;;
+    *)
+      prefer_dark="true"
+      color_scheme="prefer-dark"
+      ;;
+  esac
+
+  _gtk_write_prefer_dark "$prefer_dark"
+
+  if command -v gsettings >/dev/null 2>&1; then
+    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
+    gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" >/dev/null 2>&1 || true
+  fi
+  log "INFO" "GTK color-scheme policy=$policy effective=$color_scheme"
+  return 0
+}
+
+# Re-apply persisted policy (follow resolves from current shell mode).
+sync_gtk_color_scheme() {
+  apply_gtk_color_scheme "$(read_live_gtk_color_scheme)"
+}
+
+get_current_gtk_color_scheme() {
+  read_live_gtk_color_scheme
 }
 
 # Function to detect optimal GTK theme based on wallpaper colors
 detect_optimal_gtk_theme() {
-	local wallpaper_path="$1"
-	local detected_theme="Orchis-Light" # Default
-	local prefer_dark="false"
+  local wallpaper_path="$1"
+  local detected_theme="Orchis-Light" # Default
+  local prefer_dark="false"
 
-	# First, try to use pywal's background color to determine if theme should be dark or light
-	if [[ -f "$HOME/.cache/wal/colors" ]]; then
-		log "INFO" "Analyzing pywal colors for optimal theme selection"
+  # First, try to use pywal's background color to determine if theme should be dark or light
+  if [[ -f "$HOME/.cache/wal/colors" ]]; then
+    log "INFO" "Analyzing pywal colors for optimal theme selection"
 
-		# Read background color from pywal
-		local bg_color
-		bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
+    # Read background color from pywal
+    local bg_color
+    bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
 
-		if [[ -n $bg_color ]]; then
-			# Convert hex to RGB and calculate brightness
-			local r=$((16#${bg_color:0:2}))
-			local g=$((16#${bg_color:2:2}))
-			local b=$((16#${bg_color:4:2}))
-			local brightness=$((r + g + b))
+    if [[ -n $bg_color ]]; then
+      # Convert hex to RGB and calculate brightness
+      local r=$((16#${bg_color:0:2}))
+      local g=$((16#${bg_color:2:2}))
+      local b=$((16#${bg_color:4:2}))
+      local brightness=$((r + g + b))
 
-			# If background is dark (low brightness), suggest dark theme
-			if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
-				log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
-				local dark_themes=(
-					"Orchis-Dark-Compact"
-					"Arc-Dark"
-					"elementary-dark"
-					"Breeze-Dark"
-				)
+      # If background is dark (low brightness), suggest dark theme
+      if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
+        log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
+        local dark_themes=(
+          "Orchis-Dark-Compact"
+          "Arc-Dark"
+          "elementary-dark"
+          "Breeze-Dark"
+        )
 
-				for theme in "${dark_themes[@]}"; do
-					if is_gtk_theme_installed "$theme"; then
-						detected_theme="$theme"
-						prefer_dark="true"
-						break
-					fi
-				done
-			else
-				log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
-				local light_themes=(
-					"Orchis-Light"
-					"Arc"
-					"elementary"
-					"Breeze"
-				)
+        for theme in "${dark_themes[@]}"; do
+          if is_gtk_theme_installed "$theme"; then
+            detected_theme="$theme"
+            prefer_dark="true"
+            break
+          fi
+        done
+      else
+        log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
+        local light_themes=(
+          "Orchis-Light"
+          "Arc"
+          "elementary"
+          "Breeze"
+        )
 
-				for theme in "${light_themes[@]}"; do
-					if is_gtk_theme_installed "$theme"; then
-						detected_theme="$theme"
-						prefer_dark="false"
-						break
-					fi
-				done
-			fi
-		fi
-	elif command -v dots-smart-colors > /dev/null 2>&1; then
-		# Fallback: use smart-colors to analyze current theme
-		log "INFO" "Using smart-colors to analyze current theme"
+        for theme in "${light_themes[@]}"; do
+          if is_gtk_theme_installed "$theme"; then
+            detected_theme="$theme"
+            prefer_dark="false"
+            break
+          fi
+        done
+      fi
+    fi
+  elif command -v dots-smart-colors >/dev/null 2>&1; then
+    # Fallback: use smart-colors to analyze current theme
+    log "INFO" "Using smart-colors to analyze current theme"
 
-		# Check if current theme is light or dark using smart-colors logic
-		if dots-smart-colors --analyze 2> /dev/null | grep -q "light theme\|bright"; then
-			log "INFO" "Light theme detected, suggesting light GTK theme"
-			local light_themes=(
-				"Orchis-Light"
-				"Arc"
-				"elementary"
-				"Breeze"
-			)
+    # Check if current theme is light or dark using smart-colors logic
+    if dots-smart-colors --analyze 2>/dev/null | grep -q "light theme\|bright"; then
+      log "INFO" "Light theme detected, suggesting light GTK theme"
+      local light_themes=(
+        "Orchis-Light"
+        "Arc"
+        "elementary"
+        "Breeze"
+      )
 
-			for theme in "${light_themes[@]}"; do
-				if is_gtk_theme_installed "$theme"; then
-					detected_theme="$theme"
-					prefer_dark="false"
-					break
-				fi
-			done
-		else
-			log "INFO" "Dark theme detected, suggesting dark GTK theme"
-			local dark_themes=(
-				"Orchis-Dark-Compact"
-				"Arc-Dark"
-				"elementary-dark"
-				"Breeze-Dark"
-			)
+      for theme in "${light_themes[@]}"; do
+        if is_gtk_theme_installed "$theme"; then
+          detected_theme="$theme"
+          prefer_dark="false"
+          break
+        fi
+      done
+    else
+      log "INFO" "Dark theme detected, suggesting dark GTK theme"
+      local dark_themes=(
+        "Orchis-Dark-Compact"
+        "Arc-Dark"
+        "elementary-dark"
+        "Breeze-Dark"
+      )
 
-			for theme in "${dark_themes[@]}"; do
-				if is_gtk_theme_installed "$theme"; then
-					detected_theme="$theme"
-					prefer_dark="true"
-					break
-				fi
-			done
-		fi
-	else
-		log "WARN" "No color analysis available, using default light theme"
-	fi
+      for theme in "${dark_themes[@]}"; do
+        if is_gtk_theme_installed "$theme"; then
+          detected_theme="$theme"
+          prefer_dark="true"
+          break
+        fi
+      done
+    fi
+  else
+    log "WARN" "No color analysis available, using default light theme"
+  fi
 
-	log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
-	echo "$detected_theme:$prefer_dark"
+  log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
+  echo "$detected_theme:$prefer_dark"
 }
 
 # Normalize prefer-dark to a real GTK boolean string (true/false).
 normalize_prefer_dark() {
-	case "${1:-auto}" in
-		true | 1 | yes | dark) echo "true" ;;
-		false | 0 | no | light) echo "false" ;;
-		*) echo "auto" ;;
-	esac
+  case "${1:-auto}" in
+    true | 1 | yes | dark) echo "true" ;;
+    false | 0 | no | light) echo "false" ;;
+    *) echo "auto" ;;
+  esac
 }
 
 # Apply GTK/icons from an appearance theme pack (one-shot recipe).
 apply_theme_gtk_theme() {
-	local theme_id="${1:-}"
+  local theme_id="${1:-}"
 
-	if [[ -z $theme_id ]]; then
-		log "WARN" "No theme specified, using wallpaper-based detection"
-		local wallpaper=""
-		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-			# shellcheck source=/dev/null
-			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-			wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
-		fi
-		# Never readlink ~/.cache/wal/wal — it is a text path file, not an image symlink.
-		if [[ -n $wallpaper && -f $wallpaper ]]; then
-			local theme_info
-			theme_info=$(detect_optimal_gtk_theme "$wallpaper")
-			local gtk_theme="${theme_info%:*}"
-			local prefer_dark
-			prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-			apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
-		else
-			apply_gtk_theme "Orchis-Dark" "Numix-Circle" "true"
-		fi
-		return
-	fi
+  if [[ -z $theme_id ]]; then
+    log "WARN" "No theme specified, using wallpaper-based detection"
+    local wallpaper=""
+    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+      # shellcheck source=/dev/null
+      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+      wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
+    fi
+    # Never readlink ~/.cache/wal/wal — it is a text path file, not an image symlink.
+    if [[ -n $wallpaper && -f $wallpaper ]]; then
+      local theme_info
+      theme_info=$(detect_optimal_gtk_theme "$wallpaper")
+      local gtk_theme="${theme_info%:*}"
+      local prefer_dark
+      prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+      apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
+    else
+      apply_gtk_theme "Orchis-Dark" "Numix-Circle" "true"
+    fi
+    return
+  fi
 
-	log "INFO" "Applying GTK theme from appearance pack: $theme_id"
+  log "INFO" "Applying GTK theme from appearance pack: $theme_id"
 
-	local gtk_theme="" icon_theme="Numix-Circle" prefer_dark="auto"
-	local theme_json="$HOME/.local/share/dots/themes/$theme_id/theme.json"
+  local gtk_theme="" icon_theme="Numix-Circle" color_scheme="prefer-dark"
+  local theme_json="$HOME/.local/share/dots/themes/$theme_id/theme.json"
 
-	if [[ ! -f $theme_json ]]; then
-		log "ERROR" "Theme pack not found: $theme_id ($theme_json)"
-		return 1
-	fi
+  if [[ ! -f $theme_json ]]; then
+    log "ERROR" "Theme pack not found: $theme_id ($theme_json)"
+    return 1
+  fi
 
-	local meta
-	meta="$(
-		python3 - "$theme_json" << 'PY'
+  local meta
+  meta="$(
+    python3 - "$theme_json" <<'PY'
 import json, sys
 data = json.load(open(sys.argv[1], encoding="utf-8"))
 gtk = data.get("gtkTheme") or "auto"
 icon = data.get("iconTheme") or "Numix-Circle"
-if "gtkPreferDark" in data and data["gtkPreferDark"] is not None:
-    prefer = "true" if data["gtkPreferDark"] else "false"
+scheme = data.get("gtkColorScheme")
+if scheme:
+    prefer = str(scheme)
+elif "gtkPreferDark" in data and data["gtkPreferDark"] is not None:
+    prefer = "prefer-dark" if data["gtkPreferDark"] else "prefer-light"
 else:
     gtk_lc = str(gtk).lower()
     if "light" in gtk_lc:
-        prefer = "false"
+        prefer = "prefer-light"
     elif "dark" in gtk_lc:
-        prefer = "true"
+        prefer = "prefer-dark"
     else:
-        prefer = "true" if data.get("darkMode", True) else "false"
+        prefer = "prefer-dark" if data.get("darkMode", True) else "prefer-light"
 print(gtk)
 print(icon)
 print(prefer)
 PY
-	)"
-	gtk_theme="$(sed -n '1p' <<< "$meta")"
-	icon_theme="$(sed -n '2p' <<< "$meta")"
-	prefer_dark="$(sed -n '3p' <<< "$meta")"
-	prefer_dark="$(normalize_prefer_dark "$prefer_dark")"
+  )"
+  gtk_theme="$(sed -n '1p' <<<"$meta")"
+  icon_theme="$(sed -n '2p' <<<"$meta")"
+  color_scheme="$(sed -n '3p' <<<"$meta")"
+  color_scheme="$(normalize_gtk_color_scheme "$color_scheme")"
+  if [[ $color_scheme == "invalid" ]]; then
+    color_scheme="prefer-dark"
+  fi
 
-	if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
-		local wal_wallpaper=""
-		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-			# shellcheck source=/dev/null
-			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-			wal_wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
-		fi
-		# Prefer wallpaper-resolver (handles text wal pointer + state pointer).
-		if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
-			local theme_info
-			theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
-			gtk_theme="${theme_info%:*}"
-			if [[ $prefer_dark == "auto" ]]; then
-				prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-			fi
-		else
-			if [[ $prefer_dark == "true" ]]; then
-				gtk_theme="Orchis-Dark-Compact"
-			else
-				gtk_theme="Orchis-Light-Compact"
-			fi
-		fi
-	fi
+  if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
+    local wal_wallpaper=""
+    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+      # shellcheck source=/dev/null
+      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+      wal_wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
+    fi
+    # Prefer wallpaper-resolver (handles text wal pointer + state pointer).
+    if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
+      local theme_info
+      theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
+      gtk_theme="${theme_info%:*}"
+    else
+      if [[ $color_scheme == "prefer-dark" ]]; then
+        gtk_theme="Orchis-Dark-Compact"
+      else
+        gtk_theme="Orchis-Light-Compact"
+      fi
+    fi
+  fi
 
-	if [[ $prefer_dark == "auto" ]]; then
-		prefer_dark="false"
-	fi
-
-	apply_gtk_theme "$gtk_theme" "$icon_theme" "$prefer_dark"
+  apply_gtk_theme "$gtk_theme" "$icon_theme" "$color_scheme"
 }
 
 # Function to get current GTK theme
 get_current_gtk_theme() {
-	local value=""
-	if [[ -f $GTK3_CONFIG ]]; then
-		value="$(grep "^gtk-theme-name=" "$GTK3_CONFIG" 2> /dev/null | cut -d'=' -f2 || true)"
-	fi
-	if [[ -z $value && -f $GTK2_CONFIG ]]; then
-		value="$(grep "^gtk-theme-name=" "$GTK2_CONFIG" 2> /dev/null | cut -d'"' -f2 || true)"
-	fi
-	if [[ -z $value ]] && command -v gsettings > /dev/null 2>&1; then
-		value="$(gsettings get org.gnome.desktop.interface gtk-theme 2> /dev/null | tr -d "'" || true)"
-	fi
-	printf '%s\n' "${value:-Unknown}"
-	return 0
+  local value=""
+  if [[ -f $GTK3_CONFIG ]]; then
+    value="$(grep "^gtk-theme-name=" "$GTK3_CONFIG" 2>/dev/null | cut -d'=' -f2 || true)"
+  fi
+  if [[ -z $value && -f $GTK2_CONFIG ]]; then
+    value="$(grep "^gtk-theme-name=" "$GTK2_CONFIG" 2>/dev/null | cut -d'"' -f2 || true)"
+  fi
+  if [[ -z $value ]] && command -v gsettings >/dev/null 2>&1; then
+    value="$(gsettings get org.gnome.desktop.interface gtk-theme 2>/dev/null | tr -d "'" || true)"
+  fi
+  printf '%s\n' "${value:-Unknown}"
+  return 0
 }
 
 # Function to get current icon theme
 get_current_icon_theme() {
-	local value=""
-	if [[ -f $GTK3_CONFIG ]]; then
-		value="$(grep "^gtk-icon-theme-name=" "$GTK3_CONFIG" 2> /dev/null | cut -d'=' -f2 || true)"
-	fi
-	if [[ -z $value ]] && command -v gsettings > /dev/null 2>&1; then
-		value="$(gsettings get org.gnome.desktop.interface icon-theme 2> /dev/null | tr -d "'" || true)"
-	fi
-	if [[ -z $value && -f $GTK2_CONFIG ]]; then
-		value="$(grep "^gtk-icon-theme-name=" "$GTK2_CONFIG" 2> /dev/null | cut -d'"' -f2 || true)"
-	fi
-	printf '%s\n' "${value:-}"
-	return 0
+  local value=""
+  if [[ -f $GTK3_CONFIG ]]; then
+    value="$(grep "^gtk-icon-theme-name=" "$GTK3_CONFIG" 2>/dev/null | cut -d'=' -f2 || true)"
+  fi
+  if [[ -z $value ]] && command -v gsettings >/dev/null 2>&1; then
+    value="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'" || true)"
+  fi
+  if [[ -z $value && -f $GTK2_CONFIG ]]; then
+    value="$(grep "^gtk-icon-theme-name=" "$GTK2_CONFIG" 2>/dev/null | cut -d'"' -f2 || true)"
+  fi
+  printf '%s\n' "${value:-}"
+  return 0
 }
 
 # Function to list installed GTK themes
 list_installed_gtk_themes() {
-	local themes=()
+  local themes=()
 
-	local theme_dirs=(
-		"/usr/share/themes"
-		"/usr/local/share/themes"
-		"$HOME/.themes"
-		"$HOME/.local/share/themes"
-	)
+  local theme_dirs=(
+    "/usr/share/themes"
+    "/usr/local/share/themes"
+    "$HOME/.themes"
+    "$HOME/.local/share/themes"
+  )
 
-	for theme_dir in "${theme_dirs[@]}"; do
-		if [[ -d $theme_dir ]]; then
-			while IFS= read -r -d '' theme_path; do
-				local theme_name
-				theme_name=$(basename "$theme_path")
-				if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
-					themes+=("$theme_name")
-				fi
-			done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
-		fi
-	done
+  for theme_dir in "${theme_dirs[@]}"; do
+    if [[ -d $theme_dir ]]; then
+      while IFS= read -r -d '' theme_path; do
+        local theme_name
+        theme_name=$(basename "$theme_path")
+        if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
+          themes+=("$theme_name")
+        fi
+      done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
+    fi
+  done
 
-	# Remove duplicates and sort
-	printf '%s\n' "${themes[@]}" | sort -u
+  # Remove duplicates and sort
+  printf '%s\n' "${themes[@]}" | sort -u
 }

--- a/home/dot_local/lib/dots/gtk-theme-manager.sh
+++ b/home/dot_local/lib/dots/gtk-theme-manager.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 # Source smart colors for theme detection
 if [[ -f "$HOME/.local/lib/dots/smart-colors.sh" ]]; then
-  source "$HOME/.local/lib/dots/smart-colors.sh"
+	source "$HOME/.local/lib/dots/smart-colors.sh"
 fi
 
 # GTK configuration paths
@@ -30,119 +30,119 @@ readonly DOTS_SCHEME_STATE="${XDG_STATE_HOME:-$HOME/.local/state}/dots/scheme/st
 
 # Function to log messages
 log() {
-  local level="$1"
-  shift
-  local message="$*"
-  local timestamp
-  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+	local level="$1"
+	shift
+	local message="$*"
+	local timestamp
+	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 
-  echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
+	echo "[$timestamp] [GTK-THEME] [$level] $message" >&2
 }
 
 # Function to check if a GTK theme is installed
 is_gtk_theme_installed() {
-  local theme_name="$1"
+	local theme_name="$1"
 
-  # Check in common theme directories
-  local theme_dirs=(
-    "/usr/share/themes"
-    "/usr/local/share/themes"
-    "$HOME/.themes"
-    "$HOME/.local/share/themes"
-  )
+	# Check in common theme directories
+	local theme_dirs=(
+		"/usr/share/themes"
+		"/usr/local/share/themes"
+		"$HOME/.themes"
+		"$HOME/.local/share/themes"
+	)
 
-  for theme_dir in "${theme_dirs[@]}"; do
-    if [[ -d "$theme_dir/$theme_name" ]]; then
-      return 0
-    fi
-  done
+	for theme_dir in "${theme_dirs[@]}"; do
+		if [[ -d "$theme_dir/$theme_name" ]]; then
+			return 0
+		fi
+	done
 
-  return 1
+	return 1
 }
 
 # Function to check if an icon theme is installed
 is_icon_theme_installed() {
-  local icon_theme="$1"
+	local icon_theme="$1"
 
-  # Check in common icon directories
-  local icon_dirs=(
-    "/usr/share/icons"
-    "/usr/local/share/icons"
-    "$HOME/.icons"
-    "$HOME/.local/share/icons"
-  )
+	# Check in common icon directories
+	local icon_dirs=(
+		"/usr/share/icons"
+		"/usr/local/share/icons"
+		"$HOME/.icons"
+		"$HOME/.local/share/icons"
+	)
 
-  for icon_dir in "${icon_dirs[@]}"; do
-    if [[ -d "$icon_dir/$icon_theme" ]]; then
-      return 0
-    fi
-  done
+	for icon_dir in "${icon_dirs[@]}"; do
+		if [[ -d "$icon_dir/$icon_theme" ]]; then
+			return 0
+		fi
+	done
 
-  return 1
+	return 1
 }
 
 # Function to apply GTK theme with fallbacks
 apply_gtk_theme() {
-  local gtk_theme="$1"
-  local icon_theme="${2:-elementary}"
+	local gtk_theme="$1"
+	local icon_theme="${2:-elementary}"
 
-  log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
+	log "INFO" "Applying GTK theme: $gtk_theme, icons: $icon_theme"
 
-  # Validate theme availability with fallbacks
-  if ! is_gtk_theme_installed "$gtk_theme"; then
-    log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
+	# Validate theme availability with fallbacks
+	if ! is_gtk_theme_installed "$gtk_theme"; then
+		log "WARN" "GTK theme '$gtk_theme' not found, trying fallbacks..."
 
-    # Common fallback themes in order of preference
-    local fallback_themes=(
-      "Orchis-Light"
-      "elementary"
-      "Arc-Dark"
-      "Arc"
-      "Breeze"
-      "oxygen-gtk"
-    )
+		# Common fallback themes in order of preference
+		local fallback_themes=(
+			"Orchis-Light"
+			"elementary"
+			"Arc-Dark"
+			"Arc"
+			"Breeze"
+			"oxygen-gtk"
+		)
 
-    for fallback in "${fallback_themes[@]}"; do
-      if is_gtk_theme_installed "$fallback"; then
-        gtk_theme="$fallback"
-        log "INFO" "Using fallback theme: $gtk_theme"
-        break
-      fi
-    done
+		for fallback in "${fallback_themes[@]}"; do
+			if is_gtk_theme_installed "$fallback"; then
+				gtk_theme="$fallback"
+				log "INFO" "Using fallback theme: $gtk_theme"
+				break
+			fi
+		done
 
-    if ! is_gtk_theme_installed "$gtk_theme"; then
-      log "ERROR" "No suitable GTK theme found, keeping current theme"
-      return 1
-    fi
-  fi
+		if ! is_gtk_theme_installed "$gtk_theme"; then
+			log "ERROR" "No suitable GTK theme found, keeping current theme"
+			return 1
+		fi
+	fi
 
-  # Validate icon theme with fallbacks
-  if ! is_icon_theme_installed "$icon_theme"; then
-    log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
+	# Validate icon theme with fallbacks
+	if ! is_icon_theme_installed "$icon_theme"; then
+		log "WARN" "Icon theme '$icon_theme' not found, trying fallbacks..."
 
-    local fallback_icons=(
-      "Numix-Circle"
-      "elementary"
-      "hicolor"
-    )
+		local fallback_icons=(
+			"Numix-Circle"
+			"elementary"
+			"hicolor"
+		)
 
-    for fallback in "${fallback_icons[@]}"; do
-      if is_icon_theme_installed "$fallback"; then
-        icon_theme="$fallback"
-        log "INFO" "Using fallback icon theme: $icon_theme"
-        break
-      fi
-    done
-  fi
+		for fallback in "${fallback_icons[@]}"; do
+			if is_icon_theme_installed "$fallback"; then
+				icon_theme="$fallback"
+				log "INFO" "Using fallback icon theme: $icon_theme"
+				break
+			fi
+		done
+	fi
 
-  # Update GTK2 configuration
-  if [[ -f $GTK2_CONFIG ]]; then
-    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
-    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
-    log "INFO" "Updated GTK2 configuration"
-  else
-    log "WARN" "GTK2 config not found, creating basic configuration"
-    cat >"$GTK2_CONFIG" <<EOF
+	# Update GTK2 configuration
+	if [[ -f $GTK2_CONFIG ]]; then
+		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=\"$gtk_theme\"/" "$GTK2_CONFIG"
+		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=\"$icon_theme\"/" "$GTK2_CONFIG"
+		log "INFO" "Updated GTK2 configuration"
+	else
+		log "WARN" "GTK2 config not found, creating basic configuration"
+		cat > "$GTK2_CONFIG" << EOF
 # DO NOT EDIT! This file will be overwritten by LXAppearance.
 # Any customization should be done in ~/.gtkrc-2.0.mine instead.
 
@@ -163,17 +163,17 @@ gtk-xft-hinting=1
 gtk-xft-hintstyle="hintslight"
 gtk-xft-rgba="rgb"
 EOF
-  fi
+	fi
 
-  # Update GTK3 configuration (color-scheme / prefer-dark is applied below).
-  if [[ -f $GTK3_CONFIG ]]; then
-    sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
-    sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
-    log "INFO" "Updated GTK3 configuration"
-  else
-    log "WARN" "GTK3 config not found, creating configuration"
-    mkdir -p "$(dirname "$GTK3_CONFIG")"
-    cat >"$GTK3_CONFIG" <<EOF
+	# Update GTK3 configuration (color-scheme / prefer-dark is applied below).
+	if [[ -f $GTK3_CONFIG ]]; then
+		sed -i "s/^gtk-theme-name=.*/gtk-theme-name=$gtk_theme/" "$GTK3_CONFIG"
+		sed -i "s/^gtk-icon-theme-name=.*/gtk-icon-theme-name=$icon_theme/" "$GTK3_CONFIG"
+		log "INFO" "Updated GTK3 configuration"
+	else
+		log "WARN" "GTK3 config not found, creating configuration"
+		mkdir -p "$(dirname "$GTK3_CONFIG")"
+		cat > "$GTK3_CONFIG" << EOF
 [Settings]
 gtk-theme-name=$gtk_theme
 gtk-icon-theme-name=$icon_theme
@@ -192,85 +192,85 @@ gtk-xft-hintstyle=hintslight
 gtk-xft-rgba=rgb
 gtk-modules=colorreload-gtk-module
 EOF
-  fi
+	fi
 
-  # Notify running GTK applications to reload themes
-  if command -v gsettings >/dev/null 2>&1; then
-    gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2>/dev/null || true
-    gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2>/dev/null || true
-    log "INFO" "Updated gsettings"
-  fi
+	# Notify running GTK applications to reload themes
+	if command -v gsettings > /dev/null 2>&1; then
+		gsettings set org.gnome.desktop.interface gtk-theme "$gtk_theme" 2> /dev/null || true
+		gsettings set org.gnome.desktop.interface icon-theme "$icon_theme" 2> /dev/null || true
+		log "INFO" "Updated gsettings"
+	fi
 
-  _gtk_ini_set "$GTK4_CONFIG" "gtk-theme-name" "$gtk_theme"
-  _gtk_ini_set "$GTK4_CONFIG" "gtk-icon-theme-name" "$icon_theme"
+	_gtk_ini_set "$GTK4_CONFIG" "gtk-theme-name" "$gtk_theme"
+	_gtk_ini_set "$GTK4_CONFIG" "gtk-icon-theme-name" "$icon_theme"
 
-  # Color-scheme is independent of the GTK theme name. An explicit 3rd arg
-  # (true/false or a gtkColorScheme policy) sets/persists policy; otherwise
-  # re-apply the live policy so a theme-name change cannot clobber it.
-  if [[ -n ${3:-} ]]; then
-    local policy
-    policy="$(normalize_gtk_color_scheme "$3")"
-    if [[ $policy == "invalid" ]]; then
-      log "WARN" "Unknown GTK color-scheme '$3', re-applying live policy"
-      sync_gtk_color_scheme
-    else
-      apply_gtk_color_scheme "$policy"
-    fi
-  else
-    sync_gtk_color_scheme
-  fi
+	# Color-scheme is independent of the GTK theme name. An explicit 3rd arg
+	# (true/false or a gtkColorScheme policy) sets/persists policy; otherwise
+	# re-apply the live policy so a theme-name change cannot clobber it.
+	if [[ -n ${3:-} ]]; then
+		local policy
+		policy="$(normalize_gtk_color_scheme "$3")"
+		if [[ $policy == "invalid" ]]; then
+			log "WARN" "Unknown GTK color-scheme '$3', re-applying live policy"
+			sync_gtk_color_scheme
+		else
+			apply_gtk_color_scheme "$policy"
+		fi
+	else
+		sync_gtk_color_scheme
+	fi
 
-  log "INFO" "GTK theme applied successfully: $gtk_theme"
-  return 0
+	log "INFO" "GTK theme applied successfully: $gtk_theme"
+	return 0
 }
 
 # Canonical gtkColorScheme policy: follow | default | prefer-light | prefer-dark
 # Aliases: light→prefer-light, dark→prefer-dark, auto→default.
 normalize_gtk_color_scheme() {
-  local raw
-  raw="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')"
-  case "$raw" in
-    follow | follow-mode | follow-theme | follow-theme-mode) printf 'follow\n' ;;
-    default | auto | apps | apps-decide) printf 'default\n' ;;
-    prefer-light | light) printf 'prefer-light\n' ;;
-    prefer-dark | dark) printf 'prefer-dark\n' ;;
-    true | 1 | yes) printf 'prefer-dark\n' ;;
-    false | 0 | no) printf 'prefer-light\n' ;;
-    *) printf 'invalid\n' ;;
-  esac
+	local raw
+	raw="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')"
+	case "$raw" in
+		follow | follow-mode | follow-theme | follow-theme-mode) printf 'follow\n' ;;
+		default | auto | apps | apps-decide) printf 'default\n' ;;
+		prefer-light | light) printf 'prefer-light\n' ;;
+		prefer-dark | dark) printf 'prefer-dark\n' ;;
+		true | 1 | yes) printf 'prefer-dark\n' ;;
+		false | 0 | no) printf 'prefer-light\n' ;;
+		*) printf 'invalid\n' ;;
+	esac
 }
 
 read_live_shell_mode() {
-  local mode="dark"
-  if [[ -f $DOTS_SCHEME_STATE ]]; then
-    mode="$(python3 -c "import json;print(json.load(open('$DOTS_SCHEME_STATE')).get('mode','dark'))" 2>/dev/null || echo dark)"
-  fi
-  if [[ $mode == "light" || $mode == "dark" ]]; then
-    printf '%s\n' "$mode"
-  else
-    printf 'dark\n'
-  fi
+	local mode="dark"
+	if [[ -f $DOTS_SCHEME_STATE ]]; then
+		mode="$(python3 -c "import json;print(json.load(open('$DOTS_SCHEME_STATE')).get('mode','dark'))" 2> /dev/null || echo dark)"
+	fi
+	if [[ $mode == "light" || $mode == "dark" ]]; then
+		printf '%s\n' "$mode"
+	else
+		printf 'dark\n'
+	fi
 }
 
 # Persisted policy. Missing key → follow (legacy: GTK tracked shell mode).
 read_live_gtk_color_scheme() {
-  local policy=""
-  if [[ -f $DOTS_SCHEME_STATE ]]; then
-    policy="$(python3 -c "import json;print(json.load(open('$DOTS_SCHEME_STATE')).get('gtkColorScheme','') or '')" 2>/dev/null || true)"
-  fi
-  policy="$(normalize_gtk_color_scheme "${policy:-follow}")"
-  if [[ $policy == "invalid" ]]; then
-    policy="follow"
-  fi
-  printf '%s\n' "$policy"
+	local policy=""
+	if [[ -f $DOTS_SCHEME_STATE ]]; then
+		policy="$(python3 -c "import json;print(json.load(open('$DOTS_SCHEME_STATE')).get('gtkColorScheme','') or '')" 2> /dev/null || true)"
+	fi
+	policy="$(normalize_gtk_color_scheme "${policy:-follow}")"
+	if [[ $policy == "invalid" ]]; then
+		policy="follow"
+	fi
+	printf '%s\n' "$policy"
 }
 
 write_live_gtk_color_scheme() {
-  local policy="$1"
-  policy="$(normalize_gtk_color_scheme "$policy")"
-  [[ $policy != "invalid" ]] || return 1
-  mkdir -p "$(dirname "$DOTS_SCHEME_STATE")" 2>/dev/null || true
-  python3 - "$DOTS_SCHEME_STATE" "$policy" <<'PY' || true
+	local policy="$1"
+	policy="$(normalize_gtk_color_scheme "$policy")"
+	[[ $policy != "invalid" ]] || return 1
+	mkdir -p "$(dirname "$DOTS_SCHEME_STATE")" 2> /dev/null || true
+	python3 - "$DOTS_SCHEME_STATE" "$policy" << 'PY' || true
 import json
 import pathlib
 import sys
@@ -295,249 +295,249 @@ PY
 
 # Resolve follow → prefer-light|prefer-dark from shell mode. Other policies pass through.
 effective_gtk_color_scheme() {
-  local policy
-  policy="$(normalize_gtk_color_scheme "${1:-}")"
-  if [[ $policy == "invalid" ]]; then
-    policy="$(read_live_gtk_color_scheme)"
-  fi
-  if [[ $policy == "follow" ]]; then
-    local mode
-    mode="$(read_live_shell_mode)"
-    if [[ $mode == "light" ]]; then
-      printf 'prefer-light\n'
-    else
-      printf 'prefer-dark\n'
-    fi
-    return 0
-  fi
-  printf '%s\n' "$policy"
+	local policy
+	policy="$(normalize_gtk_color_scheme "${1:-}")"
+	if [[ $policy == "invalid" ]]; then
+		policy="$(read_live_gtk_color_scheme)"
+	fi
+	if [[ $policy == "follow" ]]; then
+		local mode
+		mode="$(read_live_shell_mode)"
+		if [[ $mode == "light" ]]; then
+			printf 'prefer-light\n'
+		else
+			printf 'prefer-dark\n'
+		fi
+		return 0
+	fi
+	printf '%s\n' "$policy"
 }
 
 _gtk_ini_set() {
-  local file="$1"
-  local key="$2"
-  local value="$3"
-  mkdir -p "$(dirname "$file")" || return 1
-  if [[ ! -f $file ]]; then
-    printf '[Settings]\n%s=%s\n' "$key" "$value" >"$file" || return 1
-    return 0
-  fi
-  if grep -q "^${key}=" "$file" 2>/dev/null; then
-    sed -i "s|^${key}=.*|${key}=${value}|" "$file"
-  else
-    if ! grep -q '^\[Settings\]' "$file" 2>/dev/null; then
-      printf '[Settings]\n' >>"$file"
-    fi
-    printf '%s=%s\n' "$key" "$value" >>"$file"
-  fi
+	local file="$1"
+	local key="$2"
+	local value="$3"
+	mkdir -p "$(dirname "$file")" || return 1
+	if [[ ! -f $file ]]; then
+		printf '[Settings]\n%s=%s\n' "$key" "$value" > "$file" || return 1
+		return 0
+	fi
+	if grep -q "^${key}=" "$file" 2> /dev/null; then
+		sed -i "s|^${key}=.*|${key}=${value}|" "$file"
+	else
+		if ! grep -q '^\[Settings\]' "$file" 2> /dev/null; then
+			printf '[Settings]\n' >> "$file"
+		fi
+		printf '%s=%s\n' "$key" "$value" >> "$file"
+	fi
 }
 
 _gtk_write_prefer_dark() {
-  local prefer_dark="$1"
-  _gtk_ini_set "$GTK3_CONFIG" "gtk-application-prefer-dark-theme" "$prefer_dark"
-  _gtk_ini_set "$GTK4_CONFIG" "gtk-application-prefer-dark-theme" "$prefer_dark"
+	local prefer_dark="$1"
+	_gtk_ini_set "$GTK3_CONFIG" "gtk-application-prefer-dark-theme" "$prefer_dark"
+	_gtk_ini_set "$GTK4_CONFIG" "gtk-application-prefer-dark-theme" "$prefer_dark"
 }
 
 # Sync GTK/libadwaita color-scheme without changing the theme name.
 # Accepts follow|default|prefer-light|prefer-dark|light|dark.
 # Persists gtkColorScheme in state.json — never writes shell `mode`.
 apply_gtk_color_scheme() {
-  local requested="${1:-follow}"
-  local policy
-  policy="$(normalize_gtk_color_scheme "$requested")"
-  if [[ $policy == "invalid" ]]; then
-    log "ERROR" "apply_gtk_color_scheme: expected follow|default|prefer-light|prefer-dark|light|dark (got: $requested)"
-    return 1
-  fi
+	local requested="${1:-follow}"
+	local policy
+	policy="$(normalize_gtk_color_scheme "$requested")"
+	if [[ $policy == "invalid" ]]; then
+		log "ERROR" "apply_gtk_color_scheme: expected follow|default|prefer-light|prefer-dark|light|dark (got: $requested)"
+		return 1
+	fi
 
-  write_live_gtk_color_scheme "$policy"
+	write_live_gtk_color_scheme "$policy"
 
-  local effective prefer_dark="false" color_scheme="prefer-dark"
-  effective="$(effective_gtk_color_scheme "$policy")"
-  case "$effective" in
-    default)
-      prefer_dark="false"
-      color_scheme="default"
-      ;;
-    prefer-light)
-      prefer_dark="false"
-      color_scheme="prefer-light"
-      ;;
-    *)
-      prefer_dark="true"
-      color_scheme="prefer-dark"
-      ;;
-  esac
+	local effective prefer_dark="false" color_scheme="prefer-dark"
+	effective="$(effective_gtk_color_scheme "$policy")"
+	case "$effective" in
+		default)
+			prefer_dark="false"
+			color_scheme="default"
+			;;
+		prefer-light)
+			prefer_dark="false"
+			color_scheme="prefer-light"
+			;;
+		*)
+			prefer_dark="true"
+			color_scheme="prefer-dark"
+			;;
+	esac
 
-  _gtk_write_prefer_dark "$prefer_dark"
+	_gtk_write_prefer_dark "$prefer_dark"
 
-  if command -v gsettings >/dev/null 2>&1; then
-    gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" >/dev/null 2>&1 || true
-    gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" >/dev/null 2>&1 || true
-  fi
-  log "INFO" "GTK color-scheme policy=$policy effective=$color_scheme"
-  return 0
+	if command -v gsettings > /dev/null 2>&1; then
+		gsettings set org.gnome.desktop.interface gtk-application-prefer-dark-theme "$prefer_dark" > /dev/null 2>&1 || true
+		gsettings set org.gnome.desktop.interface color-scheme "$color_scheme" > /dev/null 2>&1 || true
+	fi
+	log "INFO" "GTK color-scheme policy=$policy effective=$color_scheme"
+	return 0
 }
 
 # Re-apply persisted policy (follow resolves from current shell mode).
 sync_gtk_color_scheme() {
-  apply_gtk_color_scheme "$(read_live_gtk_color_scheme)"
+	apply_gtk_color_scheme "$(read_live_gtk_color_scheme)"
 }
 
 get_current_gtk_color_scheme() {
-  read_live_gtk_color_scheme
+	read_live_gtk_color_scheme
 }
 
 # Function to detect optimal GTK theme based on wallpaper colors
 detect_optimal_gtk_theme() {
-  local wallpaper_path="$1"
-  local detected_theme="Orchis-Light" # Default
-  local prefer_dark="false"
+	local wallpaper_path="$1"
+	local detected_theme="Orchis-Light" # Default
+	local prefer_dark="false"
 
-  # First, try to use pywal's background color to determine if theme should be dark or light
-  if [[ -f "$HOME/.cache/wal/colors" ]]; then
-    log "INFO" "Analyzing pywal colors for optimal theme selection"
+	# First, try to use pywal's background color to determine if theme should be dark or light
+	if [[ -f "$HOME/.cache/wal/colors" ]]; then
+		log "INFO" "Analyzing pywal colors for optimal theme selection"
 
-    # Read background color from pywal
-    local bg_color
-    bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
+		# Read background color from pywal
+		local bg_color
+		bg_color=$(head -n 1 "$HOME/.cache/wal/colors" | tr -d '#')
 
-    if [[ -n $bg_color ]]; then
-      # Convert hex to RGB and calculate brightness
-      local r=$((16#${bg_color:0:2}))
-      local g=$((16#${bg_color:2:2}))
-      local b=$((16#${bg_color:4:2}))
-      local brightness=$((r + g + b))
+		if [[ -n $bg_color ]]; then
+			# Convert hex to RGB and calculate brightness
+			local r=$((16#${bg_color:0:2}))
+			local g=$((16#${bg_color:2:2}))
+			local b=$((16#${bg_color:4:2}))
+			local brightness=$((r + g + b))
 
-      # If background is dark (low brightness), suggest dark theme
-      if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
-        log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
-        local dark_themes=(
-          "Orchis-Dark-Compact"
-          "Arc-Dark"
-          "elementary-dark"
-          "Breeze-Dark"
-        )
+			# If background is dark (low brightness), suggest dark theme
+			if [[ $brightness -lt 384 ]]; then # 384 = 128 * 3 (threshold for dark)
+				log "INFO" "Dark background detected (brightness: $brightness), suggesting dark theme"
+				local dark_themes=(
+					"Orchis-Dark-Compact"
+					"Arc-Dark"
+					"elementary-dark"
+					"Breeze-Dark"
+				)
 
-        for theme in "${dark_themes[@]}"; do
-          if is_gtk_theme_installed "$theme"; then
-            detected_theme="$theme"
-            prefer_dark="true"
-            break
-          fi
-        done
-      else
-        log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
-        local light_themes=(
-          "Orchis-Light"
-          "Arc"
-          "elementary"
-          "Breeze"
-        )
+				for theme in "${dark_themes[@]}"; do
+					if is_gtk_theme_installed "$theme"; then
+						detected_theme="$theme"
+						prefer_dark="true"
+						break
+					fi
+				done
+			else
+				log "INFO" "Light background detected (brightness: $brightness), suggesting light theme"
+				local light_themes=(
+					"Orchis-Light"
+					"Arc"
+					"elementary"
+					"Breeze"
+				)
 
-        for theme in "${light_themes[@]}"; do
-          if is_gtk_theme_installed "$theme"; then
-            detected_theme="$theme"
-            prefer_dark="false"
-            break
-          fi
-        done
-      fi
-    fi
-  elif command -v dots-smart-colors >/dev/null 2>&1; then
-    # Fallback: use smart-colors to analyze current theme
-    log "INFO" "Using smart-colors to analyze current theme"
+				for theme in "${light_themes[@]}"; do
+					if is_gtk_theme_installed "$theme"; then
+						detected_theme="$theme"
+						prefer_dark="false"
+						break
+					fi
+				done
+			fi
+		fi
+	elif command -v dots-smart-colors > /dev/null 2>&1; then
+		# Fallback: use smart-colors to analyze current theme
+		log "INFO" "Using smart-colors to analyze current theme"
 
-    # Check if current theme is light or dark using smart-colors logic
-    if dots-smart-colors --analyze 2>/dev/null | grep -q "light theme\|bright"; then
-      log "INFO" "Light theme detected, suggesting light GTK theme"
-      local light_themes=(
-        "Orchis-Light"
-        "Arc"
-        "elementary"
-        "Breeze"
-      )
+		# Check if current theme is light or dark using smart-colors logic
+		if dots-smart-colors --analyze 2> /dev/null | grep -q "light theme\|bright"; then
+			log "INFO" "Light theme detected, suggesting light GTK theme"
+			local light_themes=(
+				"Orchis-Light"
+				"Arc"
+				"elementary"
+				"Breeze"
+			)
 
-      for theme in "${light_themes[@]}"; do
-        if is_gtk_theme_installed "$theme"; then
-          detected_theme="$theme"
-          prefer_dark="false"
-          break
-        fi
-      done
-    else
-      log "INFO" "Dark theme detected, suggesting dark GTK theme"
-      local dark_themes=(
-        "Orchis-Dark-Compact"
-        "Arc-Dark"
-        "elementary-dark"
-        "Breeze-Dark"
-      )
+			for theme in "${light_themes[@]}"; do
+				if is_gtk_theme_installed "$theme"; then
+					detected_theme="$theme"
+					prefer_dark="false"
+					break
+				fi
+			done
+		else
+			log "INFO" "Dark theme detected, suggesting dark GTK theme"
+			local dark_themes=(
+				"Orchis-Dark-Compact"
+				"Arc-Dark"
+				"elementary-dark"
+				"Breeze-Dark"
+			)
 
-      for theme in "${dark_themes[@]}"; do
-        if is_gtk_theme_installed "$theme"; then
-          detected_theme="$theme"
-          prefer_dark="true"
-          break
-        fi
-      done
-    fi
-  else
-    log "WARN" "No color analysis available, using default light theme"
-  fi
+			for theme in "${dark_themes[@]}"; do
+				if is_gtk_theme_installed "$theme"; then
+					detected_theme="$theme"
+					prefer_dark="true"
+					break
+				fi
+			done
+		fi
+	else
+		log "WARN" "No color analysis available, using default light theme"
+	fi
 
-  log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
-  echo "$detected_theme:$prefer_dark"
+	log "INFO" "Detected optimal theme: $detected_theme (dark: $prefer_dark)"
+	echo "$detected_theme:$prefer_dark"
 }
 
 # Normalize prefer-dark to a real GTK boolean string (true/false).
 normalize_prefer_dark() {
-  case "${1:-auto}" in
-    true | 1 | yes | dark) echo "true" ;;
-    false | 0 | no | light) echo "false" ;;
-    *) echo "auto" ;;
-  esac
+	case "${1:-auto}" in
+		true | 1 | yes | dark) echo "true" ;;
+		false | 0 | no | light) echo "false" ;;
+		*) echo "auto" ;;
+	esac
 }
 
 # Apply GTK/icons from an appearance theme pack (one-shot recipe).
 apply_theme_gtk_theme() {
-  local theme_id="${1:-}"
+	local theme_id="${1:-}"
 
-  if [[ -z $theme_id ]]; then
-    log "WARN" "No theme specified, using wallpaper-based detection"
-    local wallpaper=""
-    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-      # shellcheck source=/dev/null
-      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-      wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
-    fi
-    # Never readlink ~/.cache/wal/wal — it is a text path file, not an image symlink.
-    if [[ -n $wallpaper && -f $wallpaper ]]; then
-      local theme_info
-      theme_info=$(detect_optimal_gtk_theme "$wallpaper")
-      local gtk_theme="${theme_info%:*}"
-      local prefer_dark
-      prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
-      apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
-    else
-      apply_gtk_theme "Orchis-Dark" "Numix-Circle" "true"
-    fi
-    return
-  fi
+	if [[ -z $theme_id ]]; then
+		log "WARN" "No theme specified, using wallpaper-based detection"
+		local wallpaper=""
+		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+			# shellcheck source=/dev/null
+			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+			wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
+		fi
+		# Never readlink ~/.cache/wal/wal — it is a text path file, not an image symlink.
+		if [[ -n $wallpaper && -f $wallpaper ]]; then
+			local theme_info
+			theme_info=$(detect_optimal_gtk_theme "$wallpaper")
+			local gtk_theme="${theme_info%:*}"
+			local prefer_dark
+			prefer_dark="$(normalize_prefer_dark "${theme_info#*:}")"
+			apply_gtk_theme "$gtk_theme" "Numix-Circle" "$prefer_dark"
+		else
+			apply_gtk_theme "Orchis-Dark" "Numix-Circle" "true"
+		fi
+		return
+	fi
 
-  log "INFO" "Applying GTK theme from appearance pack: $theme_id"
+	log "INFO" "Applying GTK theme from appearance pack: $theme_id"
 
-  local gtk_theme="" icon_theme="Numix-Circle" color_scheme="prefer-dark"
-  local theme_json="$HOME/.local/share/dots/themes/$theme_id/theme.json"
+	local gtk_theme="" icon_theme="Numix-Circle" color_scheme="prefer-dark"
+	local theme_json="$HOME/.local/share/dots/themes/$theme_id/theme.json"
 
-  if [[ ! -f $theme_json ]]; then
-    log "ERROR" "Theme pack not found: $theme_id ($theme_json)"
-    return 1
-  fi
+	if [[ ! -f $theme_json ]]; then
+		log "ERROR" "Theme pack not found: $theme_id ($theme_json)"
+		return 1
+	fi
 
-  local meta
-  meta="$(
-    python3 - "$theme_json" <<'PY'
+	local meta
+	meta="$(
+		python3 - "$theme_json" << 'PY'
 import json, sys
 data = json.load(open(sys.argv[1], encoding="utf-8"))
 gtk = data.get("gtkTheme") or "auto"
@@ -559,94 +559,94 @@ print(gtk)
 print(icon)
 print(prefer)
 PY
-  )"
-  gtk_theme="$(sed -n '1p' <<<"$meta")"
-  icon_theme="$(sed -n '2p' <<<"$meta")"
-  color_scheme="$(sed -n '3p' <<<"$meta")"
-  color_scheme="$(normalize_gtk_color_scheme "$color_scheme")"
-  if [[ $color_scheme == "invalid" ]]; then
-    color_scheme="prefer-dark"
-  fi
+	)"
+	gtk_theme="$(sed -n '1p' <<< "$meta")"
+	icon_theme="$(sed -n '2p' <<< "$meta")"
+	color_scheme="$(sed -n '3p' <<< "$meta")"
+	color_scheme="$(normalize_gtk_color_scheme "$color_scheme")"
+	if [[ $color_scheme == "invalid" ]]; then
+		color_scheme="prefer-dark"
+	fi
 
-  if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
-    local wal_wallpaper=""
-    if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
-      # shellcheck source=/dev/null
-      source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
-      wal_wallpaper="$(dots_current_wallpaper 2>/dev/null || true)"
-    fi
-    # Prefer wallpaper-resolver (handles text wal pointer + state pointer).
-    if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
-      local theme_info
-      theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
-      gtk_theme="${theme_info%:*}"
-    else
-      if [[ $color_scheme == "prefer-dark" ]]; then
-        gtk_theme="Orchis-Dark-Compact"
-      else
-        gtk_theme="Orchis-Light-Compact"
-      fi
-    fi
-  fi
+	if [[ -z $gtk_theme ]] || [[ $gtk_theme == "auto" ]]; then
+		local wal_wallpaper=""
+		if [[ -f "$HOME/.local/lib/dots/wallpaper-resolver.sh" ]]; then
+			# shellcheck source=/dev/null
+			source "$HOME/.local/lib/dots/wallpaper-resolver.sh"
+			wal_wallpaper="$(dots_current_wallpaper 2> /dev/null || true)"
+		fi
+		# Prefer wallpaper-resolver (handles text wal pointer + state pointer).
+		if [[ -n $wal_wallpaper && -f $wal_wallpaper ]]; then
+			local theme_info
+			theme_info=$(detect_optimal_gtk_theme "$wal_wallpaper")
+			gtk_theme="${theme_info%:*}"
+		else
+			if [[ $color_scheme == "prefer-dark" ]]; then
+				gtk_theme="Orchis-Dark-Compact"
+			else
+				gtk_theme="Orchis-Light-Compact"
+			fi
+		fi
+	fi
 
-  apply_gtk_theme "$gtk_theme" "$icon_theme" "$color_scheme"
+	apply_gtk_theme "$gtk_theme" "$icon_theme" "$color_scheme"
 }
 
 # Function to get current GTK theme
 get_current_gtk_theme() {
-  local value=""
-  if [[ -f $GTK3_CONFIG ]]; then
-    value="$(grep "^gtk-theme-name=" "$GTK3_CONFIG" 2>/dev/null | cut -d'=' -f2 || true)"
-  fi
-  if [[ -z $value && -f $GTK2_CONFIG ]]; then
-    value="$(grep "^gtk-theme-name=" "$GTK2_CONFIG" 2>/dev/null | cut -d'"' -f2 || true)"
-  fi
-  if [[ -z $value ]] && command -v gsettings >/dev/null 2>&1; then
-    value="$(gsettings get org.gnome.desktop.interface gtk-theme 2>/dev/null | tr -d "'" || true)"
-  fi
-  printf '%s\n' "${value:-Unknown}"
-  return 0
+	local value=""
+	if [[ -f $GTK3_CONFIG ]]; then
+		value="$(grep "^gtk-theme-name=" "$GTK3_CONFIG" 2> /dev/null | cut -d'=' -f2 || true)"
+	fi
+	if [[ -z $value && -f $GTK2_CONFIG ]]; then
+		value="$(grep "^gtk-theme-name=" "$GTK2_CONFIG" 2> /dev/null | cut -d'"' -f2 || true)"
+	fi
+	if [[ -z $value ]] && command -v gsettings > /dev/null 2>&1; then
+		value="$(gsettings get org.gnome.desktop.interface gtk-theme 2> /dev/null | tr -d "'" || true)"
+	fi
+	printf '%s\n' "${value:-Unknown}"
+	return 0
 }
 
 # Function to get current icon theme
 get_current_icon_theme() {
-  local value=""
-  if [[ -f $GTK3_CONFIG ]]; then
-    value="$(grep "^gtk-icon-theme-name=" "$GTK3_CONFIG" 2>/dev/null | cut -d'=' -f2 || true)"
-  fi
-  if [[ -z $value ]] && command -v gsettings >/dev/null 2>&1; then
-    value="$(gsettings get org.gnome.desktop.interface icon-theme 2>/dev/null | tr -d "'" || true)"
-  fi
-  if [[ -z $value && -f $GTK2_CONFIG ]]; then
-    value="$(grep "^gtk-icon-theme-name=" "$GTK2_CONFIG" 2>/dev/null | cut -d'"' -f2 || true)"
-  fi
-  printf '%s\n' "${value:-}"
-  return 0
+	local value=""
+	if [[ -f $GTK3_CONFIG ]]; then
+		value="$(grep "^gtk-icon-theme-name=" "$GTK3_CONFIG" 2> /dev/null | cut -d'=' -f2 || true)"
+	fi
+	if [[ -z $value ]] && command -v gsettings > /dev/null 2>&1; then
+		value="$(gsettings get org.gnome.desktop.interface icon-theme 2> /dev/null | tr -d "'" || true)"
+	fi
+	if [[ -z $value && -f $GTK2_CONFIG ]]; then
+		value="$(grep "^gtk-icon-theme-name=" "$GTK2_CONFIG" 2> /dev/null | cut -d'"' -f2 || true)"
+	fi
+	printf '%s\n' "${value:-}"
+	return 0
 }
 
 # Function to list installed GTK themes
 list_installed_gtk_themes() {
-  local themes=()
+	local themes=()
 
-  local theme_dirs=(
-    "/usr/share/themes"
-    "/usr/local/share/themes"
-    "$HOME/.themes"
-    "$HOME/.local/share/themes"
-  )
+	local theme_dirs=(
+		"/usr/share/themes"
+		"/usr/local/share/themes"
+		"$HOME/.themes"
+		"$HOME/.local/share/themes"
+	)
 
-  for theme_dir in "${theme_dirs[@]}"; do
-    if [[ -d $theme_dir ]]; then
-      while IFS= read -r -d '' theme_path; do
-        local theme_name
-        theme_name=$(basename "$theme_path")
-        if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
-          themes+=("$theme_name")
-        fi
-      done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
-    fi
-  done
+	for theme_dir in "${theme_dirs[@]}"; do
+		if [[ -d $theme_dir ]]; then
+			while IFS= read -r -d '' theme_path; do
+				local theme_name
+				theme_name=$(basename "$theme_path")
+				if [[ -d "$theme_path/gtk-2.0" ]] || [[ -d "$theme_path/gtk-3.0" ]]; then
+					themes+=("$theme_name")
+				fi
+			done < <(find "$theme_dir" -maxdepth 1 -type d -print0)
+		fi
+	done
 
-  # Remove duplicates and sort
-  printf '%s\n' "${themes[@]}" | sort -u
+	# Remove duplicates and sort
+	printf '%s\n' "${themes[@]}" | sort -u
 }

--- a/home/dot_local/lib/dots/list-themes.py
+++ b/home/dot_local/lib/dots/list-themes.py
@@ -41,6 +41,26 @@ def wallpaper_index(theme_id: str, wallpaper_dir: str, walls_root: Path) -> dict
     return dict(sorted(paths.items()))
 
 
+def _gtk_color_scheme(data: dict) -> str:
+    raw = str(data.get("gtkColorScheme") or "").strip().lower().replace("_", "-")
+    if raw in {"follow", "default", "prefer-light", "prefer-dark"}:
+        return raw
+    if raw in {"light"}:
+        return "prefer-light"
+    if raw in {"dark"}:
+        return "prefer-dark"
+    if raw in {"auto", "apps"}:
+        return "default"
+    if "gtkPreferDark" in data and data["gtkPreferDark"] is not None:
+        return "prefer-dark" if data["gtkPreferDark"] else "prefer-light"
+    gtk = str(data.get("gtkTheme") or "").lower()
+    if "light" in gtk:
+        return "prefer-light"
+    if "dark" in gtk:
+        return "prefer-dark"
+    return "prefer-dark" if data.get("darkMode", True) else "prefer-light"
+
+
 def load_theme(theme_dir: Path, walls_root: Path) -> dict | None:
     path = theme_dir / "theme.json"
     if not path.is_file():
@@ -85,6 +105,7 @@ def load_theme(theme_dir: Path, walls_root: Path) -> dict | None:
                 else bool(data.get("darkMode", True))
             )
         ),
+        "gtkColorScheme": _gtk_color_scheme(data),
         "defaultWallpaper": default,
         "wallpaperDir": wallpaper_dir,
         "wallpapers": walls,

--- a/scripts/test-appearance-consistency.sh
+++ b/scripts/test-appearance-consistency.sh
@@ -19,32 +19,32 @@ FAIL=0
 SKIP=0
 
 pass() {
-	PASS=$((PASS + 1))
-	printf '  PASS  %s\n' "$*"
+  PASS=$((PASS + 1))
+  printf '  PASS  %s\n' "$*"
 }
 fail() {
-	FAIL=$((FAIL + 1))
-	printf '  FAIL  %s\n' "$*" >&2
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n' "$*" >&2
 }
 skip() {
-	SKIP=$((SKIP + 1))
-	printf '  SKIP  %s\n' "$*"
+  SKIP=$((SKIP + 1))
+  printf '  SKIP  %s\n' "$*"
 }
 
 PYTHON_BIN=""
-if command -v python3 > /dev/null 2>&1; then
-	PYTHON_BIN="$(command -v python3)"
-elif command -v python > /dev/null 2>&1; then
-	PYTHON_BIN="$(command -v python)"
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="$(command -v python3)"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN="$(command -v python)"
 fi
 
 validate_theme_json() {
-	local theme_json="$1"
-	local expected_id="$2"
-	local key
+  local theme_json="$1"
+  local expected_id="$2"
+  local key
 
-	if [[ -n $PYTHON_BIN ]]; then
-		"$PYTHON_BIN" - "$theme_json" "$expected_id" << 'PY'
+  if [[ -n $PYTHON_BIN ]]; then
+    "$PYTHON_BIN" - "$theme_json" "$expected_id" <<'PY'
 import json, sys
 path, expected = sys.argv[1], sys.argv[2]
 data = json.load(open(path, encoding="utf-8"))
@@ -57,26 +57,26 @@ if data.get("id") != expected:
 if not isinstance(data.get("tags", []), list):
     raise SystemExit("tags must be a list")
 PY
-		return $?
-	fi
+    return $?
+  fi
 
-	if command -v jq > /dev/null 2>&1; then
-		local id_val
-		id_val="$(jq -r '.id // empty' "$theme_json")"
-		[[ $id_val == "$expected_id" ]] || return 1
-		for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
-			jq -e --arg k "$key" 'has($k)' "$theme_json" > /dev/null || return 1
-		done
-		jq -e '(.tags == null) or ((.tags | type) == "array")' "$theme_json" > /dev/null || return 1
-		return 0
-	fi
+  if command -v jq >/dev/null 2>&1; then
+    local id_val
+    id_val="$(jq -r '.id // empty' "$theme_json")"
+    [[ $id_val == "$expected_id" ]] || return 1
+    for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
+      jq -e --arg k "$key" 'has($k)' "$theme_json" >/dev/null || return 1
+    done
+    jq -e '(.tags == null) or ((.tags | type) == "array")' "$theme_json" >/dev/null || return 1
+    return 0
+  fi
 
-	# Minimal grep fallback for CI images without Python/jq.
-	for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
-		grep -q "\"$key\"" "$theme_json" || return 1
-	done
-	grep -Eq "\"id\"[[:space:]]*:[[:space:]]*\"${expected_id}\"" "$theme_json" || return 1
-	return 0
+  # Minimal grep fallback for CI images without Python/jq.
+  for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
+    grep -q "\"$key\"" "$theme_json" || return 1
+  done
+  grep -Eq "\"id\"[[:space:]]*:[[:space:]]*\"${expected_id}\"" "$theme_json" || return 1
+  return 0
 }
 
 echo "== appearance consistency =="
@@ -89,39 +89,39 @@ GTK_BIN="${ROOT}/home/dot_local/bin/executable_dots-gtk-theme"
 QS_PIPE="${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml"
 
 [[ -d $THEMES_SRC ]] || {
-	echo "missing themes dir: $THEMES_SRC" >&2
-	exit 1
+  echo "missing themes dir: $THEMES_SRC" >&2
+  exit 1
 }
 
 theme_count=0
 for theme_json in "$THEMES_SRC"/*/theme.json; do
-	[[ -f $theme_json ]] || continue
-	theme_count=$((theme_count + 1))
-	dir="$(dirname "$theme_json")"
-	id="$(basename "$dir")"
-	if validate_theme_json "$theme_json" "$id"; then
-		pass "theme.json valid: $id"
-	else
-		fail "theme.json invalid: $id"
-	fi
-	if [[ -f $dir/preview.jpg || -f $dir/preview.png || -f $dir/preview.webp ]]; then
-		pass "preview asset: $id"
-	else
-		fail "missing preview for $id"
-	fi
+  [[ -f $theme_json ]] || continue
+  theme_count=$((theme_count + 1))
+  dir="$(dirname "$theme_json")"
+  id="$(basename "$dir")"
+  if validate_theme_json "$theme_json" "$id"; then
+    pass "theme.json valid: $id"
+  else
+    fail "theme.json invalid: $id"
+  fi
+  if [[ -f $dir/preview.jpg || -f $dir/preview.png || -f $dir/preview.webp ]]; then
+    pass "preview asset: $id"
+  else
+    fail "missing preview for $id"
+  fi
 done
 if [[ $theme_count -ge 1 ]]; then
-	pass "found $theme_count theme packs"
+  pass "found $theme_count theme packs"
 else
-	fail "no theme packs"
+  fail "no theme packs"
 fi
 
 if [[ -f $LIST_THEMES ]]; then
-	if [[ -z $PYTHON_BIN ]]; then
-		skip "list-themes.py check (python not available)"
-	elif DOTS_THEMES_DIR="$THEMES_SRC" DOTS_WALLPAPERS_DIR="${ROOT}/home/dot_local/share/dots/wallpapers" \
-		"$PYTHON_BIN" "$LIST_THEMES" "$THEMES_SRC" > /tmp/dots-themes-test.json 2> /tmp/dots-themes-test.err; then
-		if "$PYTHON_BIN" - << 'PY'; then
+  if [[ -z $PYTHON_BIN ]]; then
+    skip "list-themes.py check (python not available)"
+  elif DOTS_THEMES_DIR="$THEMES_SRC" DOTS_WALLPAPERS_DIR="${ROOT}/home/dot_local/share/dots/wallpapers" \
+    "$PYTHON_BIN" "$LIST_THEMES" "$THEMES_SRC" >/tmp/dots-themes-test.json 2>/tmp/dots-themes-test.err; then
+    if "$PYTHON_BIN" - <<'PY'; then
 import json
 data = json.load(open("/tmp/dots-themes-test.json", encoding="utf-8"))
 assert isinstance(data, list) and data, "empty theme list"
@@ -132,36 +132,36 @@ for t in data:
         assert name in t["wallpaperPaths"], f"{t.get('id')}: {name} missing from wallpaperPaths"
 print("ok", len(data))
 PY
-			pass "list-themes.py JSON + wallpaperPaths"
-		else
-			fail "list-themes.py schema check"
-		fi
-	else
-		fail "list-themes.py failed: $(head -c 200 /tmp/dots-themes-test.err 2> /dev/null || true)"
-	fi
+      pass "list-themes.py JSON + wallpaperPaths"
+    else
+      fail "list-themes.py schema check"
+    fi
+  else
+    fail "list-themes.py failed: $(head -c 200 /tmp/dots-themes-test.err 2>/dev/null || true)"
+  fi
 else
-	fail "list-themes.py missing"
+  fail "list-themes.py missing"
 fi
 
 # No stale rice IPC / sticky current writers in QS appearance path
 if grep -REn 'target:[[:space:]]*"rice"|IpcHandler.*rice|dots-rice|nwg-look' "$QS_PIPE" \
-	"${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance" > /dev/null 2>&1; then
-	fail "stale rice/nwg-look references in appearance QS"
+  "${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance" >/dev/null 2>&1; then
+  fail "stale rice/nwg-look references in appearance QS"
 else
-	pass "no stale rice IPC in appearance QS"
+  pass "no stale rice IPC in appearance QS"
 fi
 
 if grep -REn 'gsettings set org\.gnome\.desktop\.interface (gtk-theme|icon-theme)' \
-	"${ROOT}/home/dot_config/quickshell" > /dev/null 2>&1; then
-	fail "raw gsettings GTK/icon writes in Quickshell"
+  "${ROOT}/home/dot_config/quickshell" >/dev/null 2>&1; then
+  fail "raw gsettings GTK/icon writes in Quickshell"
 else
-	pass "Quickshell does not write GTK/icons via gsettings"
+  pass "Quickshell does not write GTK/icons via gsettings"
 fi
 
-if grep -En 'gtk-theme-manager\.sh' "${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml" > /dev/null 2>&1; then
-	fail "ThemePipeline still sources gtk-theme-manager.sh"
+if grep -En 'gtk-theme-manager\.sh' "${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml" >/dev/null 2>&1; then
+  fail "ThemePipeline still sources gtk-theme-manager.sh"
 else
-	pass "ThemePipeline uses dots-gtk-theme CLI"
+  pass "ThemePipeline uses dots-gtk-theme CLI"
 fi
 
 M3_BIN="${ROOT}/home/dot_local/bin/executable_dots-m3-colors"
@@ -169,94 +169,140 @@ M3_LIB="${ROOT}/home/dot_local/lib/dots/python-m3.sh"
 COLOR_SCHEME_BIN="${ROOT}/home/dot_local/bin/executable_dots-color-scheme"
 
 if [[ -f $M3_BIN && -f $M3_LIB ]]; then
-	pass "dots-m3-colors + python-m3.sh present"
+  pass "dots-m3-colors + python-m3.sh present"
 else
-	fail "missing dots-m3-colors and/or python-m3.sh"
+  fail "missing dots-m3-colors and/or python-m3.sh"
 fi
 
-if grep -En 'dots-m3-colors|m3Bin' "$QS_PIPE" > /dev/null 2>&1 \
-	&& ! grep -En '["'\'']python3["'\''].*generate-m3-colors|generate-m3-colors\.py' "$QS_PIPE" > /dev/null 2>&1; then
-	pass "ThemePipeline invokes dots-m3-colors (not bare python3)"
+if grep -En 'dots-m3-colors|m3Bin' "$QS_PIPE" >/dev/null 2>&1 &&
+  ! grep -En '["'\'']python3["'\''].*generate-m3-colors|generate-m3-colors\.py' "$QS_PIPE" >/dev/null 2>&1; then
+  pass "ThemePipeline invokes dots-m3-colors (not bare python3)"
 else
-	fail "ThemePipeline still invokes generate-m3-colors via bare python3"
+  fail "ThemePipeline still invokes generate-m3-colors via bare python3"
 fi
 
-if grep -En 'cmd_regenerate' "$COLOR_SCHEME_BIN" > /dev/null 2>&1 \
-	&& grep -A5 'cmd_regenerate()' "$COLOR_SCHEME_BIN" | grep -Eq 'regenerate_scheme'; then
-	pass "dots-color-scheme regenerate calls regenerate_scheme"
+if grep -En 'cmd_regenerate' "$COLOR_SCHEME_BIN" >/dev/null 2>&1 &&
+  grep -A5 'cmd_regenerate()' "$COLOR_SCHEME_BIN" | grep -Eq 'regenerate_scheme'; then
+  pass "dots-color-scheme regenerate calls regenerate_scheme"
 else
-	fail "dots-color-scheme regenerate is a no-op (must call regenerate_scheme)"
+  fail "dots-color-scheme regenerate is a no-op (must call regenerate_scheme)"
+fi
+
+if grep -En 'normalize_gtk_color_scheme|follow \| default \| prefer-light' "$GTK_MGR" >/dev/null 2>&1 &&
+  grep -En 'write_live_gtk_color_scheme' "$GTK_MGR" >/dev/null 2>&1; then
+  pass "gtk-theme-manager has gtkColorScheme policy helpers"
+else
+  fail "gtk-theme-manager missing gtkColorScheme policy helpers"
+fi
+
+if grep -En 'data\["mode"\] = mode' "$GTK_BIN" >/dev/null 2>&1; then
+  fail "dots-gtk-theme color-scheme still writes shell mode"
+else
+  pass "dots-gtk-theme color-scheme does not write shell mode"
+fi
+
+if grep -En 'color-scheme follow' "$COLOR_SCHEME_BIN" >/dev/null 2>&1 &&
+  grep -En 'gtkColorScheme' "$COLOR_SCHEME_BIN" >/dev/null 2>&1; then
+  pass "dots-color-scheme mode only syncs GTK when policy is follow"
+else
+  fail "dots-color-scheme mode still always overwrites GTK color-scheme"
+fi
+
+if grep -En 'sync-color-scheme' "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" >/dev/null 2>&1 &&
+  grep -En 'sync-color-scheme' "${ROOT}/home/dot_local/bin/executable_dots-wal-reload" >/dev/null 2>&1; then
+  pass "wallpaper/wal-reload re-apply GTK policy instead of forcing mode"
+else
+  fail "wallpaper/wal-reload still force GTK color-scheme from shell mode"
+fi
+
+if grep -En 'function setGtkColorScheme' "$QS_PIPE" >/dev/null 2>&1 &&
+  [[ -f ${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance/sections/GtkColorSchemeSection.qml ]]; then
+  pass "ThemePipeline + Appearance pane expose GTK color scheme"
+else
+  fail "missing setGtkColorScheme IPC or GtkColorSchemeSection"
+fi
+
+if grep -En 'gtkColorScheme' "$LIST_THEMES" >/dev/null 2>&1; then
+  pass "list-themes.py exposes gtkColorScheme"
+else
+  fail "list-themes.py missing gtkColorScheme"
+fi
+
+if grep -En 'fontFamilyClock' "${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance/sections/FontsSection.qml" >/dev/null 2>&1; then
+  pass "FontsSection exposes clock font"
+else
+  fail "FontsSection missing clock font"
 fi
 
 # Intentional: match the literal shell source pattern containing $HOME.
 # shellcheck disable=SC2016
 if grep -En 'readlink -f "\$HOME/\.cache/wal/wal"|readlink -f \$HOME/\.cache/wal/wal' \
-	"$GTK_MGR" "$GTK_BIN" "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" > /dev/null 2>&1; then
-	fail "unsafe readlink on wal text pointer"
+  "$GTK_MGR" "$GTK_BIN" "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" >/dev/null 2>&1; then
+  fail "unsafe readlink on wal text pointer"
 else
-	pass "no unsafe wal readlink in GTK apply path"
+  pass "no unsafe wal readlink in GTK apply path"
 fi
 
 [[ $SOURCE_ONLY == true ]] && {
-	echo
-	echo "Results: $PASS pass, $FAIL fail, $SKIP skip (source-only)"
-	[[ $FAIL -eq 0 ]]
-	exit $?
+  echo
+  echo "Results: $PASS pass, $FAIL fail, $SKIP skip (source-only)"
+  [[ $FAIL -eq 0 ]]
+  exit $?
 }
 
 # ── Live environment ─────────────────────────────────────────────────────────
-if ! command -v dots-gtk-theme > /dev/null 2>&1; then
-	skip "dots-gtk-theme not on PATH (live checks)"
+if ! command -v dots-gtk-theme >/dev/null 2>&1; then
+  skip "dots-gtk-theme not on PATH (live checks)"
 else
-	if out="$(dots-gtk-theme -q -p current 2> /dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
-		pass "dots-gtk-theme current: $out"
-	else
-		fail "dots-gtk-theme current"
-	fi
-	if out="$(dots-gtk-theme -q -p current-icon 2> /dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
-		pass "dots-gtk-theme current-icon: $out"
-	else
-		fail "dots-gtk-theme current-icon"
-	fi
-	if mapfile -t themes < <(dots-gtk-theme -q -p list 2> /dev/null); then
-		if [[ ${#themes[@]} -gt 0 ]]; then
-			pass "dots-gtk-theme list (${#themes[@]} themes)"
-		else
-			fail "dots-gtk-theme list empty"
-		fi
-	else
-		fail "dots-gtk-theme list"
-	fi
+  if out="$(dots-gtk-theme -q -p current 2>/dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
+    pass "dots-gtk-theme current: $out"
+  else
+    fail "dots-gtk-theme current"
+  fi
+  if out="$(dots-gtk-theme -q -p current-icon 2>/dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
+    pass "dots-gtk-theme current-icon: $out"
+  else
+    fail "dots-gtk-theme current-icon"
+  fi
+  if mapfile -t themes < <(dots-gtk-theme -q -p list 2>/dev/null); then
+    if [[ ${#themes[@]} -gt 0 ]]; then
+      pass "dots-gtk-theme list (${#themes[@]} themes)"
+    else
+      fail "dots-gtk-theme list empty"
+    fi
+  else
+    fail "dots-gtk-theme list"
+  fi
 fi
 
-if command -v dots-appearance > /dev/null 2>&1; then
-	if dots appearance doctor > /tmp/dots-appearance-doctor.txt 2>&1; then
-		if grep -q '^OK:' /tmp/dots-appearance-doctor.txt; then
-			pass "dots appearance doctor OK"
-		else
-			fail "dots appearance doctor missing OK"
-			cat /tmp/dots-appearance-doctor.txt >&2 || true
-		fi
-	else
-		fail "dots appearance doctor exited nonzero"
-		cat /tmp/dots-appearance-doctor.txt >&2 || true
-	fi
+if command -v dots-appearance >/dev/null 2>&1; then
+  if dots appearance doctor >/tmp/dots-appearance-doctor.txt 2>&1; then
+    if grep -q '^OK:' /tmp/dots-appearance-doctor.txt; then
+      pass "dots appearance doctor OK"
+    else
+      fail "dots appearance doctor missing OK"
+      cat /tmp/dots-appearance-doctor.txt >&2 || true
+    fi
+  else
+    fail "dots appearance doctor exited nonzero"
+    cat /tmp/dots-appearance-doctor.txt >&2 || true
+  fi
 else
-	skip "dots-appearance not on PATH"
+  skip "dots-appearance not on PATH"
 fi
 
 wal="$HOME/.cache/wal/wal"
 if [[ -L $wal ]]; then
-	fail "$HOME/.cache/wal/wal is a symlink (must be text path file)"
+  fail "$HOME/.cache/wal/wal is a symlink (must be text path file)"
 elif [[ -f $wal ]]; then
-	line="$(head -n 1 "$wal" | tr -d '\r')"
-	if [[ -f $line ]]; then
-		pass "wal pointer is text path -> image"
-	else
-		fail "wal pointer does not resolve to an image: $line"
-	fi
+  line="$(head -n 1 "$wal" | tr -d '\r')"
+  if [[ -f $line ]]; then
+    pass "wal pointer is text path -> image"
+  else
+    fail "wal pointer does not resolve to an image: $line"
+  fi
 else
-	skip "wal pointer missing"
+  skip "wal pointer missing"
 fi
 
 echo

--- a/scripts/test-appearance-consistency.sh
+++ b/scripts/test-appearance-consistency.sh
@@ -19,32 +19,32 @@ FAIL=0
 SKIP=0
 
 pass() {
-  PASS=$((PASS + 1))
-  printf '  PASS  %s\n' "$*"
+	PASS=$((PASS + 1))
+	printf '  PASS  %s\n' "$*"
 }
 fail() {
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  %s\n' "$*" >&2
+	FAIL=$((FAIL + 1))
+	printf '  FAIL  %s\n' "$*" >&2
 }
 skip() {
-  SKIP=$((SKIP + 1))
-  printf '  SKIP  %s\n' "$*"
+	SKIP=$((SKIP + 1))
+	printf '  SKIP  %s\n' "$*"
 }
 
 PYTHON_BIN=""
-if command -v python3 >/dev/null 2>&1; then
-  PYTHON_BIN="$(command -v python3)"
-elif command -v python >/dev/null 2>&1; then
-  PYTHON_BIN="$(command -v python)"
+if command -v python3 > /dev/null 2>&1; then
+	PYTHON_BIN="$(command -v python3)"
+elif command -v python > /dev/null 2>&1; then
+	PYTHON_BIN="$(command -v python)"
 fi
 
 validate_theme_json() {
-  local theme_json="$1"
-  local expected_id="$2"
-  local key
+	local theme_json="$1"
+	local expected_id="$2"
+	local key
 
-  if [[ -n $PYTHON_BIN ]]; then
-    "$PYTHON_BIN" - "$theme_json" "$expected_id" <<'PY'
+	if [[ -n $PYTHON_BIN ]]; then
+		"$PYTHON_BIN" - "$theme_json" "$expected_id" << 'PY'
 import json, sys
 path, expected = sys.argv[1], sys.argv[2]
 data = json.load(open(path, encoding="utf-8"))
@@ -57,26 +57,26 @@ if data.get("id") != expected:
 if not isinstance(data.get("tags", []), list):
     raise SystemExit("tags must be a list")
 PY
-    return $?
-  fi
+		return $?
+	fi
 
-  if command -v jq >/dev/null 2>&1; then
-    local id_val
-    id_val="$(jq -r '.id // empty' "$theme_json")"
-    [[ $id_val == "$expected_id" ]] || return 1
-    for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
-      jq -e --arg k "$key" 'has($k)' "$theme_json" >/dev/null || return 1
-    done
-    jq -e '(.tags == null) or ((.tags | type) == "array")' "$theme_json" >/dev/null || return 1
-    return 0
-  fi
+	if command -v jq > /dev/null 2>&1; then
+		local id_val
+		id_val="$(jq -r '.id // empty' "$theme_json")"
+		[[ $id_val == "$expected_id" ]] || return 1
+		for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
+			jq -e --arg k "$key" 'has($k)' "$theme_json" > /dev/null || return 1
+		done
+		jq -e '(.tags == null) or ((.tags | type) == "array")' "$theme_json" > /dev/null || return 1
+		return 0
+	fi
 
-  # Minimal grep fallback for CI images without Python/jq.
-  for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
-    grep -q "\"$key\"" "$theme_json" || return 1
-  done
-  grep -Eq "\"id\"[[:space:]]*:[[:space:]]*\"${expected_id}\"" "$theme_json" || return 1
-  return 0
+	# Minimal grep fallback for CI images without Python/jq.
+	for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
+		grep -q "\"$key\"" "$theme_json" || return 1
+	done
+	grep -Eq "\"id\"[[:space:]]*:[[:space:]]*\"${expected_id}\"" "$theme_json" || return 1
+	return 0
 }
 
 echo "== appearance consistency =="
@@ -89,39 +89,39 @@ GTK_BIN="${ROOT}/home/dot_local/bin/executable_dots-gtk-theme"
 QS_PIPE="${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml"
 
 [[ -d $THEMES_SRC ]] || {
-  echo "missing themes dir: $THEMES_SRC" >&2
-  exit 1
+	echo "missing themes dir: $THEMES_SRC" >&2
+	exit 1
 }
 
 theme_count=0
 for theme_json in "$THEMES_SRC"/*/theme.json; do
-  [[ -f $theme_json ]] || continue
-  theme_count=$((theme_count + 1))
-  dir="$(dirname "$theme_json")"
-  id="$(basename "$dir")"
-  if validate_theme_json "$theme_json" "$id"; then
-    pass "theme.json valid: $id"
-  else
-    fail "theme.json invalid: $id"
-  fi
-  if [[ -f $dir/preview.jpg || -f $dir/preview.png || -f $dir/preview.webp ]]; then
-    pass "preview asset: $id"
-  else
-    fail "missing preview for $id"
-  fi
+	[[ -f $theme_json ]] || continue
+	theme_count=$((theme_count + 1))
+	dir="$(dirname "$theme_json")"
+	id="$(basename "$dir")"
+	if validate_theme_json "$theme_json" "$id"; then
+		pass "theme.json valid: $id"
+	else
+		fail "theme.json invalid: $id"
+	fi
+	if [[ -f $dir/preview.jpg || -f $dir/preview.png || -f $dir/preview.webp ]]; then
+		pass "preview asset: $id"
+	else
+		fail "missing preview for $id"
+	fi
 done
 if [[ $theme_count -ge 1 ]]; then
-  pass "found $theme_count theme packs"
+	pass "found $theme_count theme packs"
 else
-  fail "no theme packs"
+	fail "no theme packs"
 fi
 
 if [[ -f $LIST_THEMES ]]; then
-  if [[ -z $PYTHON_BIN ]]; then
-    skip "list-themes.py check (python not available)"
-  elif DOTS_THEMES_DIR="$THEMES_SRC" DOTS_WALLPAPERS_DIR="${ROOT}/home/dot_local/share/dots/wallpapers" \
-    "$PYTHON_BIN" "$LIST_THEMES" "$THEMES_SRC" >/tmp/dots-themes-test.json 2>/tmp/dots-themes-test.err; then
-    if "$PYTHON_BIN" - <<'PY'; then
+	if [[ -z $PYTHON_BIN ]]; then
+		skip "list-themes.py check (python not available)"
+	elif DOTS_THEMES_DIR="$THEMES_SRC" DOTS_WALLPAPERS_DIR="${ROOT}/home/dot_local/share/dots/wallpapers" \
+		"$PYTHON_BIN" "$LIST_THEMES" "$THEMES_SRC" > /tmp/dots-themes-test.json 2> /tmp/dots-themes-test.err; then
+		if "$PYTHON_BIN" - << 'PY'; then
 import json
 data = json.load(open("/tmp/dots-themes-test.json", encoding="utf-8"))
 assert isinstance(data, list) and data, "empty theme list"
@@ -132,36 +132,36 @@ for t in data:
         assert name in t["wallpaperPaths"], f"{t.get('id')}: {name} missing from wallpaperPaths"
 print("ok", len(data))
 PY
-      pass "list-themes.py JSON + wallpaperPaths"
-    else
-      fail "list-themes.py schema check"
-    fi
-  else
-    fail "list-themes.py failed: $(head -c 200 /tmp/dots-themes-test.err 2>/dev/null || true)"
-  fi
+			pass "list-themes.py JSON + wallpaperPaths"
+		else
+			fail "list-themes.py schema check"
+		fi
+	else
+		fail "list-themes.py failed: $(head -c 200 /tmp/dots-themes-test.err 2> /dev/null || true)"
+	fi
 else
-  fail "list-themes.py missing"
+	fail "list-themes.py missing"
 fi
 
 # No stale rice IPC / sticky current writers in QS appearance path
 if grep -REn 'target:[[:space:]]*"rice"|IpcHandler.*rice|dots-rice|nwg-look' "$QS_PIPE" \
-  "${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance" >/dev/null 2>&1; then
-  fail "stale rice/nwg-look references in appearance QS"
+	"${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance" > /dev/null 2>&1; then
+	fail "stale rice/nwg-look references in appearance QS"
 else
-  pass "no stale rice IPC in appearance QS"
+	pass "no stale rice IPC in appearance QS"
 fi
 
 if grep -REn 'gsettings set org\.gnome\.desktop\.interface (gtk-theme|icon-theme)' \
-  "${ROOT}/home/dot_config/quickshell" >/dev/null 2>&1; then
-  fail "raw gsettings GTK/icon writes in Quickshell"
+	"${ROOT}/home/dot_config/quickshell" > /dev/null 2>&1; then
+	fail "raw gsettings GTK/icon writes in Quickshell"
 else
-  pass "Quickshell does not write GTK/icons via gsettings"
+	pass "Quickshell does not write GTK/icons via gsettings"
 fi
 
-if grep -En 'gtk-theme-manager\.sh' "${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml" >/dev/null 2>&1; then
-  fail "ThemePipeline still sources gtk-theme-manager.sh"
+if grep -En 'gtk-theme-manager\.sh' "${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml" > /dev/null 2>&1; then
+	fail "ThemePipeline still sources gtk-theme-manager.sh"
 else
-  pass "ThemePipeline uses dots-gtk-theme CLI"
+	pass "ThemePipeline uses dots-gtk-theme CLI"
 fi
 
 M3_BIN="${ROOT}/home/dot_local/bin/executable_dots-m3-colors"
@@ -169,140 +169,140 @@ M3_LIB="${ROOT}/home/dot_local/lib/dots/python-m3.sh"
 COLOR_SCHEME_BIN="${ROOT}/home/dot_local/bin/executable_dots-color-scheme"
 
 if [[ -f $M3_BIN && -f $M3_LIB ]]; then
-  pass "dots-m3-colors + python-m3.sh present"
+	pass "dots-m3-colors + python-m3.sh present"
 else
-  fail "missing dots-m3-colors and/or python-m3.sh"
+	fail "missing dots-m3-colors and/or python-m3.sh"
 fi
 
-if grep -En 'dots-m3-colors|m3Bin' "$QS_PIPE" >/dev/null 2>&1 &&
-  ! grep -En '["'\'']python3["'\''].*generate-m3-colors|generate-m3-colors\.py' "$QS_PIPE" >/dev/null 2>&1; then
-  pass "ThemePipeline invokes dots-m3-colors (not bare python3)"
+if grep -En 'dots-m3-colors|m3Bin' "$QS_PIPE" > /dev/null 2>&1 \
+	&& ! grep -En '["'\'']python3["'\''].*generate-m3-colors|generate-m3-colors\.py' "$QS_PIPE" > /dev/null 2>&1; then
+	pass "ThemePipeline invokes dots-m3-colors (not bare python3)"
 else
-  fail "ThemePipeline still invokes generate-m3-colors via bare python3"
+	fail "ThemePipeline still invokes generate-m3-colors via bare python3"
 fi
 
-if grep -En 'cmd_regenerate' "$COLOR_SCHEME_BIN" >/dev/null 2>&1 &&
-  grep -A5 'cmd_regenerate()' "$COLOR_SCHEME_BIN" | grep -Eq 'regenerate_scheme'; then
-  pass "dots-color-scheme regenerate calls regenerate_scheme"
+if grep -En 'cmd_regenerate' "$COLOR_SCHEME_BIN" > /dev/null 2>&1 \
+	&& grep -A5 'cmd_regenerate()' "$COLOR_SCHEME_BIN" | grep -Eq 'regenerate_scheme'; then
+	pass "dots-color-scheme regenerate calls regenerate_scheme"
 else
-  fail "dots-color-scheme regenerate is a no-op (must call regenerate_scheme)"
+	fail "dots-color-scheme regenerate is a no-op (must call regenerate_scheme)"
 fi
 
-if grep -En 'normalize_gtk_color_scheme|follow \| default \| prefer-light' "$GTK_MGR" >/dev/null 2>&1 &&
-  grep -En 'write_live_gtk_color_scheme' "$GTK_MGR" >/dev/null 2>&1; then
-  pass "gtk-theme-manager has gtkColorScheme policy helpers"
+if grep -En 'normalize_gtk_color_scheme|follow \| default \| prefer-light' "$GTK_MGR" > /dev/null 2>&1 \
+	&& grep -En 'write_live_gtk_color_scheme' "$GTK_MGR" > /dev/null 2>&1; then
+	pass "gtk-theme-manager has gtkColorScheme policy helpers"
 else
-  fail "gtk-theme-manager missing gtkColorScheme policy helpers"
+	fail "gtk-theme-manager missing gtkColorScheme policy helpers"
 fi
 
-if grep -En 'data\["mode"\] = mode' "$GTK_BIN" >/dev/null 2>&1; then
-  fail "dots-gtk-theme color-scheme still writes shell mode"
+if grep -En 'data\["mode"\] = mode' "$GTK_BIN" > /dev/null 2>&1; then
+	fail "dots-gtk-theme color-scheme still writes shell mode"
 else
-  pass "dots-gtk-theme color-scheme does not write shell mode"
+	pass "dots-gtk-theme color-scheme does not write shell mode"
 fi
 
-if grep -En 'color-scheme follow' "$COLOR_SCHEME_BIN" >/dev/null 2>&1 &&
-  grep -En 'gtkColorScheme' "$COLOR_SCHEME_BIN" >/dev/null 2>&1; then
-  pass "dots-color-scheme mode only syncs GTK when policy is follow"
+if grep -En 'color-scheme follow' "$COLOR_SCHEME_BIN" > /dev/null 2>&1 \
+	&& grep -En 'gtkColorScheme' "$COLOR_SCHEME_BIN" > /dev/null 2>&1; then
+	pass "dots-color-scheme mode only syncs GTK when policy is follow"
 else
-  fail "dots-color-scheme mode still always overwrites GTK color-scheme"
+	fail "dots-color-scheme mode still always overwrites GTK color-scheme"
 fi
 
-if grep -En 'sync-color-scheme' "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" >/dev/null 2>&1 &&
-  grep -En 'sync-color-scheme' "${ROOT}/home/dot_local/bin/executable_dots-wal-reload" >/dev/null 2>&1; then
-  pass "wallpaper/wal-reload re-apply GTK policy instead of forcing mode"
+if grep -En 'sync-color-scheme' "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" > /dev/null 2>&1 \
+	&& grep -En 'sync-color-scheme' "${ROOT}/home/dot_local/bin/executable_dots-wal-reload" > /dev/null 2>&1; then
+	pass "wallpaper/wal-reload re-apply GTK policy instead of forcing mode"
 else
-  fail "wallpaper/wal-reload still force GTK color-scheme from shell mode"
+	fail "wallpaper/wal-reload still force GTK color-scheme from shell mode"
 fi
 
-if grep -En 'function setGtkColorScheme' "$QS_PIPE" >/dev/null 2>&1 &&
-  [[ -f ${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance/sections/GtkColorSchemeSection.qml ]]; then
-  pass "ThemePipeline + Appearance pane expose GTK color scheme"
+if grep -En 'function setGtkColorScheme' "$QS_PIPE" > /dev/null 2>&1 \
+	&& [[ -f ${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance/sections/GtkColorSchemeSection.qml ]]; then
+	pass "ThemePipeline + Appearance pane expose GTK color scheme"
 else
-  fail "missing setGtkColorScheme IPC or GtkColorSchemeSection"
+	fail "missing setGtkColorScheme IPC or GtkColorSchemeSection"
 fi
 
-if grep -En 'gtkColorScheme' "$LIST_THEMES" >/dev/null 2>&1; then
-  pass "list-themes.py exposes gtkColorScheme"
+if grep -En 'gtkColorScheme' "$LIST_THEMES" > /dev/null 2>&1; then
+	pass "list-themes.py exposes gtkColorScheme"
 else
-  fail "list-themes.py missing gtkColorScheme"
+	fail "list-themes.py missing gtkColorScheme"
 fi
 
-if grep -En 'fontFamilyClock' "${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance/sections/FontsSection.qml" >/dev/null 2>&1; then
-  pass "FontsSection exposes clock font"
+if grep -En 'fontFamilyClock' "${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance/sections/FontsSection.qml" > /dev/null 2>&1; then
+	pass "FontsSection exposes clock font"
 else
-  fail "FontsSection missing clock font"
+	fail "FontsSection missing clock font"
 fi
 
 # Intentional: match the literal shell source pattern containing $HOME.
 # shellcheck disable=SC2016
 if grep -En 'readlink -f "\$HOME/\.cache/wal/wal"|readlink -f \$HOME/\.cache/wal/wal' \
-  "$GTK_MGR" "$GTK_BIN" "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" >/dev/null 2>&1; then
-  fail "unsafe readlink on wal text pointer"
+	"$GTK_MGR" "$GTK_BIN" "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" > /dev/null 2>&1; then
+	fail "unsafe readlink on wal text pointer"
 else
-  pass "no unsafe wal readlink in GTK apply path"
+	pass "no unsafe wal readlink in GTK apply path"
 fi
 
 [[ $SOURCE_ONLY == true ]] && {
-  echo
-  echo "Results: $PASS pass, $FAIL fail, $SKIP skip (source-only)"
-  [[ $FAIL -eq 0 ]]
-  exit $?
+	echo
+	echo "Results: $PASS pass, $FAIL fail, $SKIP skip (source-only)"
+	[[ $FAIL -eq 0 ]]
+	exit $?
 }
 
 # ── Live environment ─────────────────────────────────────────────────────────
-if ! command -v dots-gtk-theme >/dev/null 2>&1; then
-  skip "dots-gtk-theme not on PATH (live checks)"
+if ! command -v dots-gtk-theme > /dev/null 2>&1; then
+	skip "dots-gtk-theme not on PATH (live checks)"
 else
-  if out="$(dots-gtk-theme -q -p current 2>/dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
-    pass "dots-gtk-theme current: $out"
-  else
-    fail "dots-gtk-theme current"
-  fi
-  if out="$(dots-gtk-theme -q -p current-icon 2>/dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
-    pass "dots-gtk-theme current-icon: $out"
-  else
-    fail "dots-gtk-theme current-icon"
-  fi
-  if mapfile -t themes < <(dots-gtk-theme -q -p list 2>/dev/null); then
-    if [[ ${#themes[@]} -gt 0 ]]; then
-      pass "dots-gtk-theme list (${#themes[@]} themes)"
-    else
-      fail "dots-gtk-theme list empty"
-    fi
-  else
-    fail "dots-gtk-theme list"
-  fi
+	if out="$(dots-gtk-theme -q -p current 2> /dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
+		pass "dots-gtk-theme current: $out"
+	else
+		fail "dots-gtk-theme current"
+	fi
+	if out="$(dots-gtk-theme -q -p current-icon 2> /dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
+		pass "dots-gtk-theme current-icon: $out"
+	else
+		fail "dots-gtk-theme current-icon"
+	fi
+	if mapfile -t themes < <(dots-gtk-theme -q -p list 2> /dev/null); then
+		if [[ ${#themes[@]} -gt 0 ]]; then
+			pass "dots-gtk-theme list (${#themes[@]} themes)"
+		else
+			fail "dots-gtk-theme list empty"
+		fi
+	else
+		fail "dots-gtk-theme list"
+	fi
 fi
 
-if command -v dots-appearance >/dev/null 2>&1; then
-  if dots appearance doctor >/tmp/dots-appearance-doctor.txt 2>&1; then
-    if grep -q '^OK:' /tmp/dots-appearance-doctor.txt; then
-      pass "dots appearance doctor OK"
-    else
-      fail "dots appearance doctor missing OK"
-      cat /tmp/dots-appearance-doctor.txt >&2 || true
-    fi
-  else
-    fail "dots appearance doctor exited nonzero"
-    cat /tmp/dots-appearance-doctor.txt >&2 || true
-  fi
+if command -v dots-appearance > /dev/null 2>&1; then
+	if dots appearance doctor > /tmp/dots-appearance-doctor.txt 2>&1; then
+		if grep -q '^OK:' /tmp/dots-appearance-doctor.txt; then
+			pass "dots appearance doctor OK"
+		else
+			fail "dots appearance doctor missing OK"
+			cat /tmp/dots-appearance-doctor.txt >&2 || true
+		fi
+	else
+		fail "dots appearance doctor exited nonzero"
+		cat /tmp/dots-appearance-doctor.txt >&2 || true
+	fi
 else
-  skip "dots-appearance not on PATH"
+	skip "dots-appearance not on PATH"
 fi
 
 wal="$HOME/.cache/wal/wal"
 if [[ -L $wal ]]; then
-  fail "$HOME/.cache/wal/wal is a symlink (must be text path file)"
+	fail "$HOME/.cache/wal/wal is a symlink (must be text path file)"
 elif [[ -f $wal ]]; then
-  line="$(head -n 1 "$wal" | tr -d '\r')"
-  if [[ -f $line ]]; then
-    pass "wal pointer is text path -> image"
-  else
-    fail "wal pointer does not resolve to an image: $line"
-  fi
+	line="$(head -n 1 "$wal" | tr -d '\r')"
+	if [[ -f $line ]]; then
+		pass "wal pointer is text path -> image"
+	else
+		fail "wal pointer does not resolve to an image: $line"
+	fi
 else
-  skip "wal pointer missing"
+	skip "wal pointer missing"
 fi
 
 echo


### PR DESCRIPTION
## Summary

- Add a live `gtkColorScheme` policy (`follow` | `default` | `prefer-light` | `prefer-dark`) stored in `scheme/state.json`, separate from shell/M3 `mode`.
- Control Center → Appearance now has a GTK color scheme section (Follow theme mode, Auto/apps decide, Prefer light, Prefer dark) plus clock font; Theme mode only pushes GTK when the policy is `follow`.
- `dots-gtk-theme color-scheme` no longer writes shell `mode`; wallpaper/wal-reload re-apply the persisted policy instead of forcing light/dark.

## Test plan

- [ ] `./scripts/test-appearance-consistency.sh --source` (40 pass locally)
- [ ] `chezmoi apply` then `dots appearance doctor` still exits 0
- [ ] Theme mode + `follow` updates `gsettings color-scheme` to prefer-dark/prefer-light
- [ ] Theme mode + `prefer-light` or `default` does **not** change GTK color-scheme
- [ ] Applying a pack with `gtkPreferDark: false` (e.g. vapor-dreams) sets sticky prefer-light
- [ ] Appearance preview chip shows the four GTK color-scheme labels
- [ ] Clock font selector in Fonts persists to `Config.appearance.font.family.clock`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added independent GTK color-scheme controls: follow, default, prefer-light, and prefer-dark.
  * Added the `set-gtk-color-scheme` appearance command.
  * Added GTK color-scheme previews, status reporting, and synchronization across GTK versions.
  * Added a collapsible clock font family selector with live previews.
* **Bug Fixes**
  * Preserved GTK color-scheme preferences when changing themes, modes, icons, or wallpapers.
  * Added compatibility for legacy GTK preference settings.
* **Documentation**
  * Updated theme-management, appearance, and wallpaper workflow documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->