### PR TITLE
fix(quickshell): pin Hornero install paths and HORNERO_ env vars

### DIFF
--- a/docs/wiki/Quickshell-Shell.md
+++ b/docs/wiki/Quickshell-Shell.md
@@ -254,7 +254,11 @@ dots-quickshell ipc colours reload
 # Ensure build deps are installed
 yay -S --needed cmake ninja qt6-base qt6-declarative aubio cava pipewire
 
-# Rebuild manually
+# Preferred: pins INSTALL_LIBDIR/INSTALL_QSCONFDIR to hornero and drops a stale
+# CMake cache that still has caelestia paths.
+dots-quickshell rebuild
+
+# Manual plugin-only rebuild
 cd ~/.config/quickshell/plugin
 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
 cmake --build build

--- a/home/dot_config/hypr/hyprland.conf.d/environment.conf
+++ b/home/dot_config/hypr/hyprland.conf.d/environment.conf
@@ -34,9 +34,10 @@ env = MOZ_ENABLE_WAYLAND,1
 env = XCURSOR_SIZE,24
 env = XCURSOR_THEME,elementary
 
-# Quickshell runtime discovery (Horeno plugin + bundled QML modules)
+# Quickshell runtime discovery (Hornero plugin + bundled QML modules)
 env = QML2_IMPORT_PATH,$HOME/.local/usr/lib/qt6/qml:$HOME/.local/lib/quickshell/qml:$XDG_CONFIG_HOME/quickshell
 env = QS_PLUGIN_PATH,$HOME/.local/lib/quickshell
+env = HORNERO_LIB_DIR,$HOME/.local/lib/quickshell/usr/lib/hornero
 
 # ============================================================================
 # Application Compatibility

--- a/home/dot_config/quickshell/flake.lock
+++ b/home/dot_config/quickshell/flake.lock
@@ -1,6 +1,6 @@
 {
   "nodes": {
-    "caelestia-cli": {
+    "cli": {
       "inputs": {
         "caelestia-shell": [],
         "nixpkgs": [
@@ -59,7 +59,7 @@
     },
     "root": {
       "inputs": {
-        "caelestia-cli": "caelestia-cli",
+        "cli": "cli",
         "nixpkgs": "nixpkgs",
         "quickshell": "quickshell"
       }

--- a/home/dot_config/quickshell/flake.nix
+++ b/home/dot_config/quickshell/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Desktop shell for Caelestia dots";
+  description = "Hornero desktop shell";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
@@ -9,7 +9,9 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    caelestia-cli = {
+    # Optional upstream CLI. The GitHub URL and `caelestia-shell` input key are
+    # the upstream flake's names — we cannot rename those without forking it.
+    cli = {
       url = "github:caelestia-dots/cli";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.caelestia-shell.follows = "";
@@ -27,9 +29,8 @@
       );
   in {
     formatter = forAllSystems (pkgs: pkgs.alejandra);
-
     packages = forAllSystems (pkgs: rec {
-      caelestia-shell = pkgs.callPackage ./nix {
+      hornero-shell = pkgs.callPackage ./nix {
         rev = self.rev or self.dirtyRev;
         stdenv = pkgs.clangStdenv;
         quickshell = inputs.quickshell.packages.${pkgs.stdenv.hostPlatform.system}.default.override {
@@ -37,21 +38,21 @@
           withI3 = false;
         };
         app2unit = pkgs.callPackage ./nix/app2unit.nix {inherit pkgs;};
-        caelestia-cli = inputs.caelestia-cli.packages.${pkgs.stdenv.hostPlatform.system}.default;
+        cli = inputs.cli.packages.${pkgs.stdenv.hostPlatform.system}.default;
       };
-      with-cli = caelestia-shell.override {withCli = true;};
-      debug = caelestia-shell.override {debug = true;};
-      default = caelestia-shell;
+      with-cli = hornero-shell.override {withCli = true;};
+      debug = hornero-shell.override {debug = true;};
+      default = hornero-shell;
     });
 
     devShells = forAllSystems (pkgs: {
       default = let
-        shell = self.packages.${pkgs.stdenv.hostPlatform.system}.caelestia-shell;
+        shell = self.packages.${pkgs.stdenv.hostPlatform.system}.hornero-shell;
       in
         pkgs.mkShell.override {stdenv = shell.stdenv;} {
           inputsFrom = [shell shell.plugin shell.extras];
           packages = with pkgs; [clazy material-symbols rubik nerd-fonts.caskaydia-cove];
-          CAELESTIA_XKB_RULES_PATH = "${pkgs.xkeyboard-config}/share/xkeyboard-config-2/rules/base.lst";
+          HORNERO_XKB_RULES_PATH = "${pkgs.xkeyboard-config}/share/xkeyboard-config-2/rules/base.lst";
         };
     });
 

--- a/home/dot_config/quickshell/nix/default.nix
+++ b/home/dot_config/quickshell/nix/default.nix
@@ -28,7 +28,7 @@
   cmake,
   ninja,
   pkg-config,
-  caelestia-cli,
+  cli,
   debug ? false,
   withCli ? false,
   extraRuntimeDeps ? [],
@@ -50,7 +50,7 @@
       hyprland
     ]
     ++ extraRuntimeDeps
-    ++ lib.optional withCli caelestia-cli;
+    ++ lib.optional withCli cli;
 
   fontconfig = makeFontsConf {
     fontDirectories = [material-symbols rubik nerd-fonts.caskaydia-cove];
@@ -69,7 +69,7 @@
 
   extras = stdenv.mkDerivation {
     inherit cmakeBuildType;
-    name = "caelestia-extras${lib.optionalString debug "-debug"}";
+    name = "hornero-extras${lib.optionalString debug "-debug"}";
     src = lib.fileset.toSource {
       root = ./..;
       fileset = lib.fileset.union ./../CMakeLists.txt ./../extras;
@@ -87,7 +87,7 @@
 
   plugin = stdenv.mkDerivation {
     inherit cmakeBuildType;
-    name = "caelestia-qml-plugin${lib.optionalString debug "-debug"}";
+    name = "hornero-qml-plugin${lib.optionalString debug "-debug"}";
     src = lib.fileset.toSource {
       root = ./..;
       fileset = lib.fileset.union ./../CMakeLists.txt ./../plugin;
@@ -107,7 +107,7 @@
 in
   stdenv.mkDerivation {
     inherit version cmakeBuildType;
-    pname = "caelestia-shell${lib.optionalString debug "-debug"}";
+    pname = "hornero-shell${lib.optionalString debug "-debug"}";
     src = ./..;
 
     nativeBuildInputs = [cmake ninja makeWrapper qt6.wrapQtAppsHook];
@@ -117,7 +117,7 @@ in
     cmakeFlags =
       [
         (lib.cmakeFeature "ENABLE_MODULES" "shell")
-        (lib.cmakeFeature "INSTALL_QSCONFDIR" "${placeholder "out"}/share/caelestia-shell")
+        (lib.cmakeFeature "INSTALL_QSCONFDIR" "${placeholder "out"}/share/hornero-shell")
       ]
       ++ cmakeVersionFlags;
 
@@ -131,18 +131,18 @@ in
     '';
 
     postInstall = ''
-      makeWrapper ${quickshell}/bin/qs $out/bin/caelestia-shell \
+      makeWrapper ${quickshell}/bin/qs $out/bin/hornero-shell \
       	--prefix PATH : "${lib.makeBinPath runtimeDeps}" \
       	--set FONTCONFIG_FILE "${fontconfig}" \
-      	--set CAELESTIA_LIB_DIR ${extras}/lib \
-        --set CAELESTIA_XKB_RULES_PATH ${xkeyboard-config}/share/xkeyboard-config-2/rules/base.lst \
-      	--add-flags "-p $out/share/caelestia-shell"
+      	--set HORNERO_LIB_DIR ${extras}/lib \
+        --set HORNERO_XKB_RULES_PATH ${xkeyboard-config}/share/xkeyboard-config-2/rules/base.lst \
+      	--add-flags "-p $out/share/hornero-shell"
 
       mkdir -p $out/lib
       ln -s ${extras}/lib/* $out/lib/
 
       # Ensure wrap_term_launch.sh is executable
-      chmod 755 $out/share/caelestia-shell/assets/wrap_term_launch.sh
+      chmod 755 $out/share/hornero-shell/assets/wrap_term_launch.sh
     '';
 
     passthru = {
@@ -150,9 +150,9 @@ in
     };
 
     meta = {
-      description = "A very segsy desktop shell";
-      homepage = "https://github.com/caelestia-dots/shell";
+      description = "Hornero desktop shell";
+      homepage = "https://github.com/ulises-jeremias/dotfiles";
       license = lib.licenses.gpl3Only;
-      mainProgram = "caelestia-shell";
+      mainProgram = "hornero-shell";
     };
   }

--- a/home/dot_config/quickshell/nix/hm-module.nix
+++ b/home/dot_config/quickshell/nix/hm-module.nix
@@ -6,38 +6,35 @@ self: {
 }: let
   inherit (pkgs.stdenv.hostPlatform) system;
 
-  cli-default = self.inputs.caelestia-cli.packages.${system}.default;
+  cli-default = self.inputs.cli.packages.${system}.default;
   shell-default = self.packages.${system}.with-cli;
 
-  cfg = config.programs.caelestia;
+  cfg = config.programs.hornero;
 in {
-  imports = [
-    (lib.mkRenamedOptionModule ["programs" "caelestia" "environment"] ["programs" "caelestia" "systemd" "environment"])
-  ];
   options = with lib; {
-    programs.caelestia = {
-      enable = mkEnableOption "Enable Caelestia shell";
+    programs.hornero = {
+      enable = mkEnableOption "Enable Hornero shell";
       package = mkOption {
         type = types.package;
         default = shell-default;
-        description = "The package of Caelestia shell";
+        description = "The package of Hornero shell";
       };
       systemd = {
         enable = mkOption {
           type = types.bool;
           default = true;
-          description = "Enable the systemd service for Caelestia shell";
+          description = "Enable the systemd service for Hornero shell";
         };
         target = mkOption {
           type = types.str;
           description = ''
-            The systemd target that will automatically start the Caelestia shell.
+            The systemd target that will automatically start the Hornero shell.
           '';
           default = config.wayland.systemd.target;
         };
         environment = mkOption {
           type = types.listOf types.str;
-          description = "Extra Environment variables to pass to the Caelestia shell systemd service.";
+          description = "Extra Environment variables to pass to the Hornero shell systemd service.";
           default = [];
           example = [
             "QT_QPA_PLATFORMTHEME=gtk3"
@@ -47,29 +44,29 @@ in {
       settings = mkOption {
         type = types.attrsOf types.anything;
         default = {};
-        description = "Caelestia shell settings";
+        description = "Hornero shell settings";
       };
       extraConfig = mkOption {
         type = types.str;
         default = "";
-        description = "Caelestia shell extra configs written to shell.json";
+        description = "Hornero shell extra configs written to shell.json";
       };
       cli = {
-        enable = mkEnableOption "Enable Caelestia CLI";
+        enable = mkEnableOption "Enable optional upstream CLI";
         package = mkOption {
           type = types.package;
           default = cli-default;
-          description = "The package of Caelestia CLI"; # Doesn't override the shell's CLI, only change from home.packages
+          description = "The package of the optional CLI"; # Doesn't override the shell's CLI, only change from home.packages
         };
         settings = mkOption {
           type = types.attrsOf types.anything;
           default = {};
-          description = "Caelestia CLI settings";
+          description = "CLI settings";
         };
         extraConfig = mkOption {
           type = types.str;
           default = "";
-          description = "Caelestia CLI extra configs written to cli.json";
+          description = "CLI extra configs written to cli.json";
         };
       };
     };
@@ -80,19 +77,19 @@ in {
     shell = cfg.package;
   in
     lib.mkIf cfg.enable {
-      systemd.user.services.caelestia = lib.mkIf cfg.systemd.enable {
+      systemd.user.services.hornero = lib.mkIf cfg.systemd.enable {
         Unit = {
-          Description = "Caelestia Shell Service";
+          Description = "Hornero Shell Service";
           After = [cfg.systemd.target];
           PartOf = [cfg.systemd.target];
           X-Restart-Triggers = lib.mkIf (cfg.settings != {}) [
-            "${config.xdg.configFile."caelestia/shell.json".source}"
+            "${config.xdg.configFile."hornero/shell.json".source}"
           ];
         };
 
         Service = {
           Type = "exec";
-          ExecStart = "${shell}/bin/caelestia-shell";
+          ExecStart = "${shell}/bin/hornero-shell";
           Restart = "on-failure";
           RestartSec = "5s";
           TimeoutStopSec = "5s";
@@ -123,10 +120,10 @@ in {
           ];
         shouldGenerate = c: c.extraConfig != "" || c.settings != {};
       in {
-        "caelestia/shell.json" = lib.mkIf (shouldGenerate cfg) {
+        "hornero/shell.json" = lib.mkIf (shouldGenerate cfg) {
           text = mkConfig cfg;
         };
-        "caelestia/cli.json" = lib.mkIf (shouldGenerate cfg.cli) {
+        "hornero/cli.json" = lib.mkIf (shouldGenerate cfg.cli) {
           text = mkConfig cfg.cli;
         };
       };

--- a/home/dot_config/quickshell/services/Hypr.qml
+++ b/home/dot_config/quickshell/services/Hypr.qml
@@ -154,7 +154,7 @@ Singleton {
     FileView {
         id: kbLayoutFile
 
-        path: Quickshell.env("CAELESTIA_XKB_RULES_PATH") || "/usr/share/X11/xkb/rules/base.lst"
+        path: Quickshell.env("HORNERO_XKB_RULES_PATH") || "/usr/share/X11/xkb/rules/base.lst"
         onLoaded: {
             const layoutMatch = text().match(/! layout\n([\s\S]*?)\n\n/);
             if (layoutMatch) {

--- a/home/dot_config/quickshell/utils/Paths.qml
+++ b/home/dot_config/quickshell/utils/Paths.qml
@@ -20,8 +20,8 @@ Singleton {
 
     readonly property string imagecache: `${cache}/imagecache`
     readonly property string notifimagecache: `${imagecache}/notifs`
-    readonly property string wallsdir: Quickshell.env("CAELESTIA_WALLPAPERS_DIR") || absolutePath(Config.paths.wallpaperDir)
-    readonly property string recsdir: Quickshell.env("CAELESTIA_RECORDINGS_DIR") || `${videos}/Recordings`
+    readonly property string wallsdir: Quickshell.env("HORNERO_WALLPAPERS_DIR") || absolutePath(Config.paths.wallpaperDir)
+    readonly property string recsdir: Quickshell.env("HORNERO_RECORDINGS_DIR") || `${videos}/Recordings`
     readonly property string libdir: Quickshell.env("DOTS_LIB_DIR") || Quickshell.env("HORNERO_LIB_DIR") || "/usr/lib/hornero"
 
     function toLocalFile(path: url): string {

--- a/home/dot_local/bin/executable_dots-quickshell
+++ b/home/dot_local/bin/executable_dots-quickshell
@@ -43,7 +43,7 @@
 ##     dots-quickshell ipc colours reload
 ##     dots-quickshell ipc wallpaper set ~/Pictures/wall.png
 ##     dots-quickshell preset list
-##     dots-quickshell preset apply caelestia-left
+##     dots-quickshell preset apply hornero-left
 ##     dots-quickshell preset select
 ##     dots-quickshell config get bar.position
 ##     dots-quickshell config set bar.position top
@@ -61,232 +61,232 @@ CURRENT_PRESET_FILE="${HOME}/.local/state/dots/current-shell-preset"
 
 export QML_IMPORT_PATH="${QML_IMPORT_PATH:-${HOME}/.local/lib/quickshell/qml:${HOME}/.local/usr/lib/qt6/qml}"
 # Ensure XDG quickshell path is present even when QML2_IMPORT_PATH is inherited from Hyprland (which may predate fix)
-if [[ -z "${QML2_IMPORT_PATH:-}" ]]; then
-	export QML2_IMPORT_PATH="${HOME}/.local/usr/lib/qt6/qml:${XDG_CONFIG_HOME:-$HOME/.config}/quickshell"
+if [[ -z ${QML2_IMPORT_PATH:-} ]]; then
+  export QML2_IMPORT_PATH="${HOME}/.local/usr/lib/qt6/qml:${XDG_CONFIG_HOME:-$HOME/.config}/quickshell"
 elif [[ ":$QML2_IMPORT_PATH:" != *:"${XDG_CONFIG_HOME:-$HOME/.config}/quickshell":* ]]; then
-	export QML2_IMPORT_PATH="${QML2_IMPORT_PATH}:${XDG_CONFIG_HOME:-$HOME/.config}/quickshell"
+  export QML2_IMPORT_PATH="${QML2_IMPORT_PATH}:${XDG_CONFIG_HOME:-$HOME/.config}/quickshell"
 fi
 export QS_PLUGIN_PATH="${QS_PLUGIN_PATH:-${HOME}/.local/lib/quickshell}"
 
 is_running() {
-	pgrep -x quickshell >/dev/null 2>&1
+  pgrep -x quickshell >/dev/null 2>&1
 }
 
 ensure_config_dir() {
-	mkdir -p "$(dirname "$SHELL_CONFIG")"
-	mkdir -p "$(dirname "$CURRENT_PRESET_FILE")"
-	[[ -f $SHELL_CONFIG ]] || echo '{}' >"$SHELL_CONFIG"
+  mkdir -p "$(dirname "$SHELL_CONFIG")"
+  mkdir -p "$(dirname "$CURRENT_PRESET_FILE")"
+  [[ -f $SHELL_CONFIG ]] || echo '{}' >"$SHELL_CONFIG"
 }
 
 cmd_start() {
-	if is_running; then
-		log_warn "Quickshell is already running"
-		return 0
-	fi
+  if is_running; then
+    log_warn "Quickshell is already running"
+    return 0
+  fi
 
-	if [[ ! -d $QUICKSHELL_CONFIG_DIR ]]; then
-		log_error "Quickshell config directory not found: ${QUICKSHELL_CONFIG_DIR}"
-		return 1
-	fi
+  if [[ ! -d $QUICKSHELL_CONFIG_DIR ]]; then
+    log_error "Quickshell config directory not found: ${QUICKSHELL_CONFIG_DIR}"
+    return 1
+  fi
 
-	log_info "Starting Quickshell..."
-	env QML2_IMPORT_PATH="${QML2_IMPORT_PATH}" \
-		QML_IMPORT_PATH="${QML_IMPORT_PATH}" \
-		QS_PLUGIN_PATH="${QS_PLUGIN_PATH}" \
-		nohup "$QUICKSHELL_BIN" >/dev/null 2>&1 &
-	sleep 1
+  log_info "Starting Quickshell..."
+  env QML2_IMPORT_PATH="${QML2_IMPORT_PATH}" \
+    QML_IMPORT_PATH="${QML_IMPORT_PATH}" \
+    QS_PLUGIN_PATH="${QS_PLUGIN_PATH}" \
+    nohup "$QUICKSHELL_BIN" >/dev/null 2>&1 &
+  sleep 1
 
-	if is_running; then
-		log_info "Quickshell started successfully (PID: $(pgrep -x quickshell))"
-	else
-		log_error "Failed to start Quickshell"
-		return 1
-	fi
+  if is_running; then
+    log_info "Quickshell started successfully (PID: $(pgrep -x quickshell))"
+  else
+    log_error "Failed to start Quickshell"
+    return 1
+  fi
 }
 
 cmd_stop() {
-	if ! is_running; then
-		log_warn "Quickshell is not running"
-		return 0
-	fi
+  if ! is_running; then
+    log_warn "Quickshell is not running"
+    return 0
+  fi
 
-	log_info "Stopping Quickshell..."
-	pkill -x quickshell || true
-	sleep 1
+  log_info "Stopping Quickshell..."
+  pkill -x quickshell || true
+  sleep 1
 
-	if ! is_running; then
-		log_info "Quickshell stopped"
-	else
-		log_warn "Quickshell did not stop gracefully, sending SIGKILL..."
-		pkill -9 -x quickshell || true
-	fi
+  if ! is_running; then
+    log_info "Quickshell stopped"
+  else
+    log_warn "Quickshell did not stop gracefully, sending SIGKILL..."
+    pkill -9 -x quickshell || true
+  fi
 }
 
 cmd_restart() {
-	cmd_stop
-	sleep 1
-	cmd_start
+  cmd_stop
+  sleep 1
+  cmd_start
 }
 
 cmd_status() {
-	if is_running; then
-		local pid
-		pid=$(pgrep -x quickshell)
-		log_info "Quickshell is running (PID: ${pid})"
+  if is_running; then
+    local pid
+    pid=$(pgrep -x quickshell)
+    log_info "Quickshell is running (PID: ${pid})"
 
-		if command -v ps >/dev/null 2>&1; then
-			local mem
-			mem=$(ps -p "$pid" -o rss= 2>/dev/null | awk '{printf "%.1f MiB", $1/1024}')
-			local uptime_val
-			uptime_val=$(ps -p "$pid" -o etime= 2>/dev/null | xargs)
-			log_info "  Memory: ${mem}"
-			log_info "  Uptime: ${uptime_val}"
-		fi
-	else
-		log_info "Quickshell is not running"
-	fi
+    if command -v ps >/dev/null 2>&1; then
+      local mem
+      mem=$(ps -p "$pid" -o rss= 2>/dev/null | awk '{printf "%.1f MiB", $1/1024}')
+      local uptime_val
+      uptime_val=$(ps -p "$pid" -o etime= 2>/dev/null | xargs)
+      log_info "  Memory: ${mem}"
+      log_info "  Uptime: ${uptime_val}"
+    fi
+  else
+    log_info "Quickshell is not running"
+  fi
 }
 
 cmd_ipc() {
-	local target="${1:-}"
-	local action="${2:-}"
-	shift 2 2>/dev/null || true
+  local target="${1:-}"
+  local action="${2:-}"
+  shift 2 2>/dev/null || true
 
-	if [[ -z $target ]] || [[ -z $action ]]; then
-		log_error "Usage: dots-quickshell ipc <target> <action> [args...]"
-		return 1
-	fi
+  if [[ -z $target ]] || [[ -z $action ]]; then
+    log_error "Usage: dots-quickshell ipc <target> <action> [args...]"
+    return 1
+  fi
 
-	if ! is_running; then
-		log_error "Quickshell is not running"
-		return 1
-	fi
+  if ! is_running; then
+    log_error "Quickshell is not running"
+    return 1
+  fi
 
-	case "$target" in
-	colors) target="colours" ;;
-	notifications) target="notifs" ;;
-	power | power-menu) target="session" ;;
-	monitor-idle | idle | caffeine) target="idleInhibitor" ;;
-	gamemode) target="gameMode" ;;
-	esac
+  case "$target" in
+    colors) target="colours" ;;
+    notifications) target="notifs" ;;
+    power | power-menu) target="session" ;;
+    monitor-idle | idle | caffeine) target="idleInhibitor" ;;
+    gamemode) target="gameMode" ;;
+  esac
 
-	case "$action" in
-	show | open) action="toggle" ;;
-	esac
+  case "$action" in
+    show | open) action="toggle" ;;
+  esac
 
-	local drawer_targets="launcher session dashboard sidebar bar osd utilities"
-	if [[ " $drawer_targets " == *" $target "* ]]; then
-		log_debug "Sending IPC (drawer): drawers $action $target $*"
-		quickshell ipc call drawers "$action" "$target" "$@"
-		return $?
-	fi
+  local drawer_targets="launcher session dashboard sidebar bar osd utilities"
+  if [[ " $drawer_targets " == *" $target "* ]]; then
+    log_debug "Sending IPC (drawer): drawers $action $target $*"
+    quickshell ipc call drawers "$action" "$target" "$@"
+    return $?
+  fi
 
-	if [[ $target == "colours" && $action == "reload" ]]; then
-		# Prefer real Colours IpcHandler; fall back to touching scheme.json for older shells.
-		if quickshell ipc call colours reload >/dev/null 2>&1; then
-			log_debug "Triggered colour reload via IPC"
-			return 0
-		fi
-		local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
-		if [[ -f $scheme_file ]]; then
-			log_debug "IPC unavailable; triggering colour reload via file touch"
-			touch "$scheme_file"
-			return 0
-		fi
-		log_warn "Scheme file not found: $scheme_file"
-		return 1
-	fi
+  if [[ $target == "colours" && $action == "reload" ]]; then
+    # Prefer real Colours IpcHandler; fall back to touching scheme.json for older shells.
+    if quickshell ipc call colours reload >/dev/null 2>&1; then
+      log_debug "Triggered colour reload via IPC"
+      return 0
+    fi
+    local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
+    if [[ -f $scheme_file ]]; then
+      log_debug "IPC unavailable; triggering colour reload via file touch"
+      touch "$scheme_file"
+      return 0
+    fi
+    log_warn "Scheme file not found: $scheme_file"
+    return 1
+  fi
 
-	log_debug "Sending IPC: target=$target action=$action args=$*"
+  log_debug "Sending IPC: target=$target action=$action args=$*"
 
-	quickshell ipc call "$target" "$action" "$@"
+  quickshell ipc call "$target" "$action" "$@"
 }
 
 cmd_preset() {
-	local action="${1:-}"
-	shift 2>/dev/null || true
+  local action="${1:-}"
+  shift 2>/dev/null || true
 
-	case "$action" in
-	list) preset_list ;;
-	apply) preset_apply "${1:-}" ;;
-	select) preset_select ;;
-	current) preset_current ;;
-	*)
-		log_error "Usage: dots-quickshell preset {list|apply <name>|select|current}"
-		return 1
-		;;
-	esac
+  case "$action" in
+    list) preset_list ;;
+    apply) preset_apply "${1:-}" ;;
+    select) preset_select ;;
+    current) preset_current ;;
+    *)
+      log_error "Usage: dots-quickshell preset {list|apply <name>|select|current}"
+      return 1
+      ;;
+  esac
 }
 
 preset_list() {
-	if [[ ! -d $PRESETS_DIR ]]; then
-		log_error "Presets directory not found: $PRESETS_DIR"
-		return 1
-	fi
+  if [[ ! -d $PRESETS_DIR ]]; then
+    log_error "Presets directory not found: $PRESETS_DIR"
+    return 1
+  fi
 
-	local current=""
-	[[ -f $CURRENT_PRESET_FILE ]] && current=$(<"$CURRENT_PRESET_FILE")
+  local current=""
+  [[ -f $CURRENT_PRESET_FILE ]] && current=$(<"$CURRENT_PRESET_FILE")
 
-	local count=0
-	for preset_file in "$PRESETS_DIR"/*.json; do
-		[[ -f $preset_file ]] || continue
-		local name
-		name=$(basename "$preset_file" .json)
-		local display_name description icon
-		display_name=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_name',''))" "$preset_file" 2>/dev/null || echo "$name")
-		description=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_description',''))" "$preset_file" 2>/dev/null || echo "")
-		icon=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_icon','📦'))" "$preset_file" 2>/dev/null || echo "📦")
+  local count=0
+  for preset_file in "$PRESETS_DIR"/*.json; do
+    [[ -f $preset_file ]] || continue
+    local name
+    name=$(basename "$preset_file" .json)
+    local display_name description icon
+    display_name=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_name',''))" "$preset_file" 2>/dev/null || echo "$name")
+    description=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_description',''))" "$preset_file" 2>/dev/null || echo "")
+    icon=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_icon','📦'))" "$preset_file" 2>/dev/null || echo "📦")
 
-		local marker=""
-		[[ $name == "$current" ]] && marker=" ← active"
+    local marker=""
+    [[ $name == "$current" ]] && marker=" ← active"
 
-		echo -e "${icon} \033[1m${display_name}\033[0m (${name})${marker}"
-		[[ -n $description ]] && echo -e "   ${description}"
+    echo -e "${icon} \033[1m${display_name}\033[0m (${name})${marker}"
+    [[ -n $description ]] && echo -e "   ${description}"
 
-		local position entries
-		position=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('bar',{}).get('position',''))" "$preset_file" 2>/dev/null || echo "")
-		entries=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(', '.join(d.get('bar',{}).get('entries',[])))" "$preset_file" 2>/dev/null || echo "")
-		[[ -n $position ]] && echo -e "   bar: ${position} | ${entries}"
-		echo ""
-		count=$((count + 1))
-	done
+    local position entries
+    position=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('bar',{}).get('position',''))" "$preset_file" 2>/dev/null || echo "")
+    entries=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(', '.join(d.get('bar',{}).get('entries',[])))" "$preset_file" 2>/dev/null || echo "")
+    [[ -n $position ]] && echo -e "   bar: ${position} | ${entries}"
+    echo ""
+    count=$((count + 1))
+  done
 
-	if [[ $count -eq 0 ]]; then
-		log_warn "No presets found in $PRESETS_DIR"
-	fi
+  if [[ $count -eq 0 ]]; then
+    log_warn "No presets found in $PRESETS_DIR"
+  fi
 }
 
 preset_current() {
-	if [[ -f $CURRENT_PRESET_FILE ]]; then
-		echo "$(<"$CURRENT_PRESET_FILE")"
-	else
-		echo "none"
-	fi
+  if [[ -f $CURRENT_PRESET_FILE ]]; then
+    echo "$(<"$CURRENT_PRESET_FILE")"
+  else
+    echo "none"
+  fi
 }
 
 preset_apply() {
-	local name="${1:-}"
-	if [[ -z $name ]]; then
-		log_error "Usage: dots-quickshell preset apply <name>"
-		return 1
-	fi
+  local name="${1:-}"
+  if [[ -z $name ]]; then
+    log_error "Usage: dots-quickshell preset apply <name>"
+    return 1
+  fi
 
-	local preset_file="${PRESETS_DIR}/${name}.json"
-	if [[ ! -f $preset_file ]]; then
-		log_error "Preset not found: ${name}"
-		log_info "Available presets:"
-		preset_list
-		return 1
-	fi
+  local preset_file="${PRESETS_DIR}/${name}.json"
+  if [[ ! -f $preset_file ]]; then
+    log_error "Preset not found: ${name}"
+    log_info "Available presets:"
+    preset_list
+    return 1
+  fi
 
-	ensure_config_dir
+  ensure_config_dir
 
-	local display_name
-	display_name=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_name', sys.argv[2]))" "$preset_file" "$name" 2>/dev/null || echo "$name")
+  local display_name
+  display_name=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_name', sys.argv[2]))" "$preset_file" "$name" 2>/dev/null || echo "$name")
 
-	log_info "Applying preset: ${display_name}..."
+  log_info "Applying preset: ${display_name}..."
 
-	python3 -c "
+  python3 -c "
 import json, sys
 
 def deep_merge(base, override):
@@ -322,109 +322,109 @@ with open(config_path, 'w') as f:
     json.dump(merged, f, indent=2)
     f.write('\n')
 " "$SHELL_CONFIG" "$preset_file" || {
-		log_error "Failed to apply preset: ${name}"
-		return 1
-	}
+    log_error "Failed to apply preset: ${name}"
+    return 1
+  }
 
-	echo "$name" >"$CURRENT_PRESET_FILE"
-	log_info "Preset applied: ${display_name}"
+  echo "$name" >"$CURRENT_PRESET_FILE"
+  log_info "Preset applied: ${display_name}"
 
-	if is_running; then
-		log_info "Quickshell will reload automatically"
-	fi
+  if is_running; then
+    log_info "Quickshell will reload automatically"
+  fi
 }
 
 preset_select() {
-	if [[ ! -d $PRESETS_DIR ]]; then
-		log_error "Presets directory not found: $PRESETS_DIR"
-		return 1
-	fi
+  if [[ ! -d $PRESETS_DIR ]]; then
+    log_error "Presets directory not found: $PRESETS_DIR"
+    return 1
+  fi
 
-	local current=""
-	[[ -f $CURRENT_PRESET_FILE ]] && current=$(<"$CURRENT_PRESET_FILE")
+  local current=""
+  [[ -f $CURRENT_PRESET_FILE ]] && current=$(<"$CURRENT_PRESET_FILE")
 
-	local names=()
-	local menu_items=""
-	local selected_index=0
-	local idx=0
+  local names=()
+  local menu_items=""
+  local selected_index=0
+  local idx=0
 
-	for preset_file in "$PRESETS_DIR"/*.json; do
-		[[ -f $preset_file ]] || continue
-		local name
-		name=$(basename "$preset_file" .json)
-		names+=("$name")
+  for preset_file in "$PRESETS_DIR"/*.json; do
+    [[ -f $preset_file ]] || continue
+    local name
+    name=$(basename "$preset_file" .json)
+    names+=("$name")
 
-		local display_name description icon position
-		display_name=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_name',''))" "$preset_file" 2>/dev/null || echo "$name")
-		description=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_description',''))" "$preset_file" 2>/dev/null || echo "")
-		icon=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_icon','📦'))" "$preset_file" 2>/dev/null || echo "📦")
-		position=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('bar',{}).get('position',''))" "$preset_file" 2>/dev/null || echo "")
+    local display_name description icon position
+    display_name=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_name',''))" "$preset_file" 2>/dev/null || echo "$name")
+    description=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_description',''))" "$preset_file" 2>/dev/null || echo "")
+    icon=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_icon','📦'))" "$preset_file" 2>/dev/null || echo "📦")
+    position=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('bar',{}).get('position',''))" "$preset_file" 2>/dev/null || echo "")
 
-		local label="${icon} ${display_name}"
-		[[ -n $position ]] && label="${label} · ${position} bar"
-		[[ -n $description ]] && label="${label} — ${description}"
+    local label="${icon} ${display_name}"
+    [[ -n $position ]] && label="${label} · ${position} bar"
+    [[ -n $description ]] && label="${label} — ${description}"
 
-		menu_items+="${label}\n"
+    menu_items+="${label}\n"
 
-		[[ $name == "$current" ]] && selected_index=$idx
-		idx=$((idx + 1))
-	done
+    [[ $name == "$current" ]] && selected_index=$idx
+    idx=$((idx + 1))
+  done
 
-	if [[ ${#names[@]} -eq 0 ]]; then
-		log_error "No presets found in $PRESETS_DIR"
-		return 1
-	fi
+  if [[ ${#names[@]} -eq 0 ]]; then
+    log_error "No presets found in $PRESETS_DIR"
+    return 1
+  fi
 
-	echo "Shell Preset"
-	i=1
-	for item in "${names[@]}"; do
-		local pf="${PRESETS_DIR}/${item}.json"
-		local icon display_name
-		icon=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_icon','📦'))" "$pf" 2>/dev/null || echo "📦")
-		display_name=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_name',''))" "$pf" 2>/dev/null || echo "$item")
-		if [[ $item == "$current" ]]; then
-			printf "%2d) %s %s (active)\n" "$i" "$icon" "$display_name"
-		else
-			printf "%2d) %s %s\n" "$i" "$icon" "$display_name"
-		fi
-		i=$((i + 1))
-	done
-	printf "Select preset [1-%d, empty to cancel]: " "${#names[@]}"
-	local idx
-	read -r idx || return 1
-	[[ -z ${idx:-} ]] && return 0
-	[[ $idx =~ ^[0-9]+$ ]] || return 1
-	((idx >= 1 && idx <= ${#names[@]})) || return 1
-	local selected="${names[$((idx - 1))]}"
+  echo "Shell Preset"
+  i=1
+  for item in "${names[@]}"; do
+    local pf="${PRESETS_DIR}/${item}.json"
+    local icon display_name
+    icon=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_icon','📦'))" "$pf" 2>/dev/null || echo "📦")
+    display_name=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_name',''))" "$pf" 2>/dev/null || echo "$item")
+    if [[ $item == "$current" ]]; then
+      printf "%2d) %s %s (active)\n" "$i" "$icon" "$display_name"
+    else
+      printf "%2d) %s %s\n" "$i" "$icon" "$display_name"
+    fi
+    i=$((i + 1))
+  done
+  printf "Select preset [1-%d, empty to cancel]: " "${#names[@]}"
+  local idx
+  read -r idx || return 1
+  [[ -z ${idx:-} ]] && return 0
+  [[ $idx =~ ^[0-9]+$ ]] || return 1
+  ((idx >= 1 && idx <= ${#names[@]})) || return 1
+  local selected="${names[$((idx - 1))]}"
 
-	preset_apply "$selected"
+  preset_apply "$selected"
 }
 
 cmd_config() {
-	local action="${1:-}"
-	shift 2>/dev/null || true
+  local action="${1:-}"
+  shift 2>/dev/null || true
 
-	case "$action" in
-	get) config_get "${1:-}" ;;
-	set) config_set "${1:-}" "${2:-}" ;;
-	*)
-		log_error "Usage: dots-quickshell config {get <key>|set <key> <value>}"
-		return 1
-		;;
-	esac
+  case "$action" in
+    get) config_get "${1:-}" ;;
+    set) config_set "${1:-}" "${2:-}" ;;
+    *)
+      log_error "Usage: dots-quickshell config {get <key>|set <key> <value>}"
+      return 1
+      ;;
+  esac
 }
 
 config_get() {
-	local key="${1:-}"
-	if [[ -z $key ]]; then
-		log_error "Usage: dots-quickshell config get <key>"
-		log_info "Key uses dot-notation: bar.position, appearance.rounding, etc."
-		return 1
-	fi
+  local key="${1:-}"
+  if [[ -z $key ]]; then
+    log_error "Usage: dots-quickshell config get <key>"
+    log_info "Key uses dot-notation: bar.position, appearance.rounding, etc."
+    return 1
+  fi
 
-	ensure_config_dir
+  ensure_config_dir
 
-	python3 -c "
+  python3 -c "
 import json, sys
 
 key = sys.argv[1]
@@ -451,17 +451,17 @@ else:
 }
 
 config_set() {
-	local key="${1:-}"
-	local value="${2:-}"
-	if [[ -z $key ]]; then
-		log_error "Usage: dots-quickshell config set <key> <value>"
-		log_info "Key uses dot-notation: bar.position, appearance.rounding, etc."
-		return 1
-	fi
+  local key="${1:-}"
+  local value="${2:-}"
+  if [[ -z $key ]]; then
+    log_error "Usage: dots-quickshell config set <key> <value>"
+    log_info "Key uses dot-notation: bar.position, appearance.rounding, etc."
+    return 1
+  fi
 
-	ensure_config_dir
+  ensure_config_dir
 
-	python3 -c "
+  python3 -c "
 import json, sys
 
 key = sys.argv[1]
@@ -494,111 +494,125 @@ with open(config_path, 'w') as f:
 print(f'{key} = {json.dumps(value)}')
 " "$key" "$value" "$SHELL_CONFIG"
 
-	log_info "Config updated"
-	if is_running; then
-		log_info "Quickshell will reload automatically"
-	fi
+  log_info "Config updated"
+  if is_running; then
+    log_info "Quickshell will reload automatically"
+  fi
 }
 
 cmd_rebuild() {
-	local shell_dir="${QUICKSHELL_CONFIG_DIR}"
-	local build_dir="${XDG_CACHE_HOME:-${HOME}/.cache}/dots/quickshell/build"
-	local install_prefix="${HOME}/.local/lib/quickshell"
+  local shell_dir="${QUICKSHELL_CONFIG_DIR}"
+  local build_dir="${XDG_CACHE_HOME:-${HOME}/.cache}/dots/quickshell/build"
+  local install_prefix="${HOME}/.local/lib/quickshell"
 
-	if [[ ! -d $shell_dir ]]; then
-		log_error "Quickshell directory not found: ${shell_dir}"
-		return 1
-	fi
+  if [[ ! -d $shell_dir ]]; then
+    log_error "Quickshell directory not found: ${shell_dir}"
+    return 1
+  fi
 
-	if ! command -v cmake &>/dev/null; then
-		log_error "cmake not found — install it first"
-		return 1
-	fi
+  if ! command -v cmake &>/dev/null; then
+    log_error "cmake not found — install it first"
+    return 1
+  fi
 
-	if ! command -v ninja &>/dev/null; then
-		log_error "ninja not found — install it first"
-		return 1
-	fi
+  if ! command -v ninja &>/dev/null; then
+    log_error "ninja not found — install it first"
+    return 1
+  fi
 
-	if [[ ! -f "${shell_dir}/CMakeLists.txt" ]]; then
-		log_error "Missing CMakeLists.txt in ${shell_dir}"
-		return 1
-	fi
+  if [[ ! -f "${shell_dir}/CMakeLists.txt" ]]; then
+    log_error "Missing CMakeLists.txt in ${shell_dir}"
+    return 1
+  fi
 
-	local version="v0.0.0"
-	local revision="unknown"
-	local dotfiles_dir
-	dotfiles_dir="$(chezmoi source-path 2>/dev/null || true)"
-	dotfiles_dir="${dotfiles_dir:-${HOME}/.dotfiles}"
-	if command -v git &>/dev/null && git -C "$dotfiles_dir" rev-parse --is-inside-work-tree &>/dev/null 2>&1; then
-		version="$(git -C "$dotfiles_dir" describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")"
-		revision="$(git -C "$dotfiles_dir" rev-parse HEAD 2>/dev/null || echo "unknown")"
-	fi
+  local version="v0.0.0"
+  local revision="unknown"
+  local dotfiles_dir
+  dotfiles_dir="$(chezmoi source-path 2>/dev/null || true)"
+  dotfiles_dir="${dotfiles_dir:-${HOME}/.dotfiles}"
+  if command -v git &>/dev/null && git -C "$dotfiles_dir" rev-parse --is-inside-work-tree &>/dev/null 2>&1; then
+    version="$(git -C "$dotfiles_dir" describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")"
+    revision="$(git -C "$dotfiles_dir" rev-parse HEAD 2>/dev/null || echo "unknown")"
+  fi
 
-	local was_running=false
-	if is_running; then
-		was_running=true
-		log_info "Stopping Quickshell before rebuild..."
-		cmd_stop
-	fi
+  local was_running=false
+  if is_running; then
+    was_running=true
+    log_info "Stopping Quickshell before rebuild..."
+    cmd_stop
+  fi
 
-	log_info "Configuring Hornero plugin (${version})..."
-	mkdir -p "$build_dir"
-	cmake -S "$shell_dir" -B "$build_dir" -G Ninja \
-		-DCMAKE_BUILD_TYPE=Release \
-		-DCMAKE_INSTALL_PREFIX="$install_prefix" \
-		-DINSTALL_QMLDIR="${install_prefix}/qml" \
-		-DVERSION="$version" \
-		-DGIT_REVISION="$revision" || {
-		log_error "CMake configure failed"
-		[[ $was_running == true ]] && cmd_start
-		return 1
-	}
+  log_info "Configuring Hornero plugin (${version})..."
+  mkdir -p "$build_dir"
+  # Drop a pre-rebrand CMake cache that still has INSTALL_*DIR=.../caelestia.
+  # CACHE STRING defaults in CMakeLists.txt do not overwrite an existing cache.
+  if [[ -f ${build_dir}/CMakeCache.txt ]] && grep -qF 'caelestia' "${build_dir}/CMakeCache.txt"; then
+    log_info "Stale CMake cache still references caelestia; reconfiguring from scratch..."
+    rm -rf "$build_dir"
+    mkdir -p "$build_dir"
+  fi
+  cmake -S "$shell_dir" -B "$build_dir" -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$install_prefix" \
+    -DENABLE_MODULES="extras;plugin" \
+    -DINSTALL_LIBDIR="usr/lib/hornero" \
+    -DINSTALL_QMLDIR="${install_prefix}/qml" \
+    -DINSTALL_QSCONFDIR="etc/xdg/quickshell/hornero" \
+    -DVERSION="$version" \
+    -DGIT_REVISION="$revision" || {
+    log_error "CMake configure failed"
+    [[ $was_running == true ]] && cmd_start
+    return 1
+  }
 
-	log_info "Building..."
-	cmake --build "$build_dir" --parallel "$(nproc)" || {
-		log_error "Build failed"
-		[[ $was_running == true ]] && cmd_start
-		return 1
-	}
+  log_info "Building..."
+  cmake --build "$build_dir" --parallel "$(nproc)" || {
+    log_error "Build failed"
+    [[ $was_running == true ]] && cmd_start
+    return 1
+  }
 
-	log_info "Installing to ${install_prefix}..."
-	cmake --install "$build_dir" || {
-		log_error "Install failed"
-		[[ $was_running == true ]] && cmd_start
-		return 1
-	}
+  log_info "Installing to ${install_prefix}..."
+  cmake --install "$build_dir" || {
+    log_error "Install failed"
+    [[ $was_running == true ]] && cmd_start
+    return 1
+  }
 
-	log_info "Hornero plugin rebuilt and installed"
+  # Leftover packaged-shell copy + version binary from the old CACHE paths.
+  rm -rf "${install_prefix}/etc/xdg/quickshell/caelestia" \
+    "${install_prefix}/usr/lib/caelestia"
 
-	if [[ $was_running == true ]]; then
-		log_info "Restarting Quickshell..."
-		cmd_start
-	fi
+  log_info "Hornero plugin rebuilt and installed"
+
+  if [[ $was_running == true ]]; then
+    log_info "Restarting Quickshell..."
+    cmd_start
+  fi
 }
 
 main() {
-	local command="${1:-}"
-	shift 2>/dev/null || true
+  local command="${1:-}"
+  shift 2>/dev/null || true
 
-	case "$command" in
-	start) cmd_start ;;
-	stop) cmd_stop ;;
-	restart) cmd_restart ;;
-	status) cmd_status ;;
-	ipc) cmd_ipc "$@" ;;
-	preset) cmd_preset "$@" ;;
-	config) cmd_config "$@" ;;
-	rebuild) cmd_rebuild ;;
-	"")
-		log_error "No command specified. Use --help for usage."
-		exit 1
-		;;
-	*)
-		log_error "Unknown command: $command. Use --help for usage."
-		exit 1
-		;;
-	esac
+  case "$command" in
+    start) cmd_start ;;
+    stop) cmd_stop ;;
+    restart) cmd_restart ;;
+    status) cmd_status ;;
+    ipc) cmd_ipc "$@" ;;
+    preset) cmd_preset "$@" ;;
+    config) cmd_config "$@" ;;
+    rebuild) cmd_rebuild ;;
+    "")
+      log_error "No command specified. Use --help for usage."
+      exit 1
+      ;;
+    *)
+      log_error "Unknown command: $command. Use --help for usage."
+      exit 1
+      ;;
+  esac
 }
 
 main "$@"

--- a/home/dot_local/bin/executable_dots-quickshell
+++ b/home/dot_local/bin/executable_dots-quickshell
@@ -62,231 +62,231 @@ CURRENT_PRESET_FILE="${HOME}/.local/state/dots/current-shell-preset"
 export QML_IMPORT_PATH="${QML_IMPORT_PATH:-${HOME}/.local/lib/quickshell/qml:${HOME}/.local/usr/lib/qt6/qml}"
 # Ensure XDG quickshell path is present even when QML2_IMPORT_PATH is inherited from Hyprland (which may predate fix)
 if [[ -z ${QML2_IMPORT_PATH:-} ]]; then
-  export QML2_IMPORT_PATH="${HOME}/.local/usr/lib/qt6/qml:${XDG_CONFIG_HOME:-$HOME/.config}/quickshell"
+	export QML2_IMPORT_PATH="${HOME}/.local/usr/lib/qt6/qml:${XDG_CONFIG_HOME:-$HOME/.config}/quickshell"
 elif [[ ":$QML2_IMPORT_PATH:" != *:"${XDG_CONFIG_HOME:-$HOME/.config}/quickshell":* ]]; then
-  export QML2_IMPORT_PATH="${QML2_IMPORT_PATH}:${XDG_CONFIG_HOME:-$HOME/.config}/quickshell"
+	export QML2_IMPORT_PATH="${QML2_IMPORT_PATH}:${XDG_CONFIG_HOME:-$HOME/.config}/quickshell"
 fi
 export QS_PLUGIN_PATH="${QS_PLUGIN_PATH:-${HOME}/.local/lib/quickshell}"
 
 is_running() {
-  pgrep -x quickshell >/dev/null 2>&1
+	pgrep -x quickshell >/dev/null 2>&1
 }
 
 ensure_config_dir() {
-  mkdir -p "$(dirname "$SHELL_CONFIG")"
-  mkdir -p "$(dirname "$CURRENT_PRESET_FILE")"
-  [[ -f $SHELL_CONFIG ]] || echo '{}' >"$SHELL_CONFIG"
+	mkdir -p "$(dirname "$SHELL_CONFIG")"
+	mkdir -p "$(dirname "$CURRENT_PRESET_FILE")"
+	[[ -f $SHELL_CONFIG ]] || echo '{}' >"$SHELL_CONFIG"
 }
 
 cmd_start() {
-  if is_running; then
-    log_warn "Quickshell is already running"
-    return 0
-  fi
+	if is_running; then
+		log_warn "Quickshell is already running"
+		return 0
+	fi
 
-  if [[ ! -d $QUICKSHELL_CONFIG_DIR ]]; then
-    log_error "Quickshell config directory not found: ${QUICKSHELL_CONFIG_DIR}"
-    return 1
-  fi
+	if [[ ! -d $QUICKSHELL_CONFIG_DIR ]]; then
+		log_error "Quickshell config directory not found: ${QUICKSHELL_CONFIG_DIR}"
+		return 1
+	fi
 
-  log_info "Starting Quickshell..."
-  env QML2_IMPORT_PATH="${QML2_IMPORT_PATH}" \
-    QML_IMPORT_PATH="${QML_IMPORT_PATH}" \
-    QS_PLUGIN_PATH="${QS_PLUGIN_PATH}" \
-    nohup "$QUICKSHELL_BIN" >/dev/null 2>&1 &
-  sleep 1
+	log_info "Starting Quickshell..."
+	env QML2_IMPORT_PATH="${QML2_IMPORT_PATH}" \
+		QML_IMPORT_PATH="${QML_IMPORT_PATH}" \
+		QS_PLUGIN_PATH="${QS_PLUGIN_PATH}" \
+		nohup "$QUICKSHELL_BIN" >/dev/null 2>&1 &
+	sleep 1
 
-  if is_running; then
-    log_info "Quickshell started successfully (PID: $(pgrep -x quickshell))"
-  else
-    log_error "Failed to start Quickshell"
-    return 1
-  fi
+	if is_running; then
+		log_info "Quickshell started successfully (PID: $(pgrep -x quickshell))"
+	else
+		log_error "Failed to start Quickshell"
+		return 1
+	fi
 }
 
 cmd_stop() {
-  if ! is_running; then
-    log_warn "Quickshell is not running"
-    return 0
-  fi
+	if ! is_running; then
+		log_warn "Quickshell is not running"
+		return 0
+	fi
 
-  log_info "Stopping Quickshell..."
-  pkill -x quickshell || true
-  sleep 1
+	log_info "Stopping Quickshell..."
+	pkill -x quickshell || true
+	sleep 1
 
-  if ! is_running; then
-    log_info "Quickshell stopped"
-  else
-    log_warn "Quickshell did not stop gracefully, sending SIGKILL..."
-    pkill -9 -x quickshell || true
-  fi
+	if ! is_running; then
+		log_info "Quickshell stopped"
+	else
+		log_warn "Quickshell did not stop gracefully, sending SIGKILL..."
+		pkill -9 -x quickshell || true
+	fi
 }
 
 cmd_restart() {
-  cmd_stop
-  sleep 1
-  cmd_start
+	cmd_stop
+	sleep 1
+	cmd_start
 }
 
 cmd_status() {
-  if is_running; then
-    local pid
-    pid=$(pgrep -x quickshell)
-    log_info "Quickshell is running (PID: ${pid})"
+	if is_running; then
+		local pid
+		pid=$(pgrep -x quickshell)
+		log_info "Quickshell is running (PID: ${pid})"
 
-    if command -v ps >/dev/null 2>&1; then
-      local mem
-      mem=$(ps -p "$pid" -o rss= 2>/dev/null | awk '{printf "%.1f MiB", $1/1024}')
-      local uptime_val
-      uptime_val=$(ps -p "$pid" -o etime= 2>/dev/null | xargs)
-      log_info "  Memory: ${mem}"
-      log_info "  Uptime: ${uptime_val}"
-    fi
-  else
-    log_info "Quickshell is not running"
-  fi
+		if command -v ps >/dev/null 2>&1; then
+			local mem
+			mem=$(ps -p "$pid" -o rss= 2>/dev/null | awk '{printf "%.1f MiB", $1/1024}')
+			local uptime_val
+			uptime_val=$(ps -p "$pid" -o etime= 2>/dev/null | xargs)
+			log_info "  Memory: ${mem}"
+			log_info "  Uptime: ${uptime_val}"
+		fi
+	else
+		log_info "Quickshell is not running"
+	fi
 }
 
 cmd_ipc() {
-  local target="${1:-}"
-  local action="${2:-}"
-  shift 2 2>/dev/null || true
+	local target="${1:-}"
+	local action="${2:-}"
+	shift 2 2>/dev/null || true
 
-  if [[ -z $target ]] || [[ -z $action ]]; then
-    log_error "Usage: dots-quickshell ipc <target> <action> [args...]"
-    return 1
-  fi
+	if [[ -z $target ]] || [[ -z $action ]]; then
+		log_error "Usage: dots-quickshell ipc <target> <action> [args...]"
+		return 1
+	fi
 
-  if ! is_running; then
-    log_error "Quickshell is not running"
-    return 1
-  fi
+	if ! is_running; then
+		log_error "Quickshell is not running"
+		return 1
+	fi
 
-  case "$target" in
-    colors) target="colours" ;;
-    notifications) target="notifs" ;;
-    power | power-menu) target="session" ;;
-    monitor-idle | idle | caffeine) target="idleInhibitor" ;;
-    gamemode) target="gameMode" ;;
-  esac
+	case "$target" in
+	colors) target="colours" ;;
+	notifications) target="notifs" ;;
+	power | power-menu) target="session" ;;
+	monitor-idle | idle | caffeine) target="idleInhibitor" ;;
+	gamemode) target="gameMode" ;;
+	esac
 
-  case "$action" in
-    show | open) action="toggle" ;;
-  esac
+	case "$action" in
+	show | open) action="toggle" ;;
+	esac
 
-  local drawer_targets="launcher session dashboard sidebar bar osd utilities"
-  if [[ " $drawer_targets " == *" $target "* ]]; then
-    log_debug "Sending IPC (drawer): drawers $action $target $*"
-    quickshell ipc call drawers "$action" "$target" "$@"
-    return $?
-  fi
+	local drawer_targets="launcher session dashboard sidebar bar osd utilities"
+	if [[ " $drawer_targets " == *" $target "* ]]; then
+		log_debug "Sending IPC (drawer): drawers $action $target $*"
+		quickshell ipc call drawers "$action" "$target" "$@"
+		return $?
+	fi
 
-  if [[ $target == "colours" && $action == "reload" ]]; then
-    # Prefer real Colours IpcHandler; fall back to touching scheme.json for older shells.
-    if quickshell ipc call colours reload >/dev/null 2>&1; then
-      log_debug "Triggered colour reload via IPC"
-      return 0
-    fi
-    local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
-    if [[ -f $scheme_file ]]; then
-      log_debug "IPC unavailable; triggering colour reload via file touch"
-      touch "$scheme_file"
-      return 0
-    fi
-    log_warn "Scheme file not found: $scheme_file"
-    return 1
-  fi
+	if [[ $target == "colours" && $action == "reload" ]]; then
+		# Prefer real Colours IpcHandler; fall back to touching scheme.json for older shells.
+		if quickshell ipc call colours reload >/dev/null 2>&1; then
+			log_debug "Triggered colour reload via IPC"
+			return 0
+		fi
+		local scheme_file="${HOME}/.cache/dots/smart-colors/scheme.json"
+		if [[ -f $scheme_file ]]; then
+			log_debug "IPC unavailable; triggering colour reload via file touch"
+			touch "$scheme_file"
+			return 0
+		fi
+		log_warn "Scheme file not found: $scheme_file"
+		return 1
+	fi
 
-  log_debug "Sending IPC: target=$target action=$action args=$*"
+	log_debug "Sending IPC: target=$target action=$action args=$*"
 
-  quickshell ipc call "$target" "$action" "$@"
+	quickshell ipc call "$target" "$action" "$@"
 }
 
 cmd_preset() {
-  local action="${1:-}"
-  shift 2>/dev/null || true
+	local action="${1:-}"
+	shift 2>/dev/null || true
 
-  case "$action" in
-    list) preset_list ;;
-    apply) preset_apply "${1:-}" ;;
-    select) preset_select ;;
-    current) preset_current ;;
-    *)
-      log_error "Usage: dots-quickshell preset {list|apply <name>|select|current}"
-      return 1
-      ;;
-  esac
+	case "$action" in
+	list) preset_list ;;
+	apply) preset_apply "${1:-}" ;;
+	select) preset_select ;;
+	current) preset_current ;;
+	*)
+		log_error "Usage: dots-quickshell preset {list|apply <name>|select|current}"
+		return 1
+		;;
+	esac
 }
 
 preset_list() {
-  if [[ ! -d $PRESETS_DIR ]]; then
-    log_error "Presets directory not found: $PRESETS_DIR"
-    return 1
-  fi
+	if [[ ! -d $PRESETS_DIR ]]; then
+		log_error "Presets directory not found: $PRESETS_DIR"
+		return 1
+	fi
 
-  local current=""
-  [[ -f $CURRENT_PRESET_FILE ]] && current=$(<"$CURRENT_PRESET_FILE")
+	local current=""
+	[[ -f $CURRENT_PRESET_FILE ]] && current=$(<"$CURRENT_PRESET_FILE")
 
-  local count=0
-  for preset_file in "$PRESETS_DIR"/*.json; do
-    [[ -f $preset_file ]] || continue
-    local name
-    name=$(basename "$preset_file" .json)
-    local display_name description icon
-    display_name=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_name',''))" "$preset_file" 2>/dev/null || echo "$name")
-    description=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_description',''))" "$preset_file" 2>/dev/null || echo "")
-    icon=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_icon','📦'))" "$preset_file" 2>/dev/null || echo "📦")
+	local count=0
+	for preset_file in "$PRESETS_DIR"/*.json; do
+		[[ -f $preset_file ]] || continue
+		local name
+		name=$(basename "$preset_file" .json)
+		local display_name description icon
+		display_name=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_name',''))" "$preset_file" 2>/dev/null || echo "$name")
+		description=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_description',''))" "$preset_file" 2>/dev/null || echo "")
+		icon=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_icon','📦'))" "$preset_file" 2>/dev/null || echo "📦")
 
-    local marker=""
-    [[ $name == "$current" ]] && marker=" ← active"
+		local marker=""
+		[[ $name == "$current" ]] && marker=" ← active"
 
-    echo -e "${icon} \033[1m${display_name}\033[0m (${name})${marker}"
-    [[ -n $description ]] && echo -e "   ${description}"
+		echo -e "${icon} \033[1m${display_name}\033[0m (${name})${marker}"
+		[[ -n $description ]] && echo -e "   ${description}"
 
-    local position entries
-    position=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('bar',{}).get('position',''))" "$preset_file" 2>/dev/null || echo "")
-    entries=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(', '.join(d.get('bar',{}).get('entries',[])))" "$preset_file" 2>/dev/null || echo "")
-    [[ -n $position ]] && echo -e "   bar: ${position} | ${entries}"
-    echo ""
-    count=$((count + 1))
-  done
+		local position entries
+		position=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('bar',{}).get('position',''))" "$preset_file" 2>/dev/null || echo "")
+		entries=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(', '.join(d.get('bar',{}).get('entries',[])))" "$preset_file" 2>/dev/null || echo "")
+		[[ -n $position ]] && echo -e "   bar: ${position} | ${entries}"
+		echo ""
+		count=$((count + 1))
+	done
 
-  if [[ $count -eq 0 ]]; then
-    log_warn "No presets found in $PRESETS_DIR"
-  fi
+	if [[ $count -eq 0 ]]; then
+		log_warn "No presets found in $PRESETS_DIR"
+	fi
 }
 
 preset_current() {
-  if [[ -f $CURRENT_PRESET_FILE ]]; then
-    echo "$(<"$CURRENT_PRESET_FILE")"
-  else
-    echo "none"
-  fi
+	if [[ -f $CURRENT_PRESET_FILE ]]; then
+		echo "$(<"$CURRENT_PRESET_FILE")"
+	else
+		echo "none"
+	fi
 }
 
 preset_apply() {
-  local name="${1:-}"
-  if [[ -z $name ]]; then
-    log_error "Usage: dots-quickshell preset apply <name>"
-    return 1
-  fi
+	local name="${1:-}"
+	if [[ -z $name ]]; then
+		log_error "Usage: dots-quickshell preset apply <name>"
+		return 1
+	fi
 
-  local preset_file="${PRESETS_DIR}/${name}.json"
-  if [[ ! -f $preset_file ]]; then
-    log_error "Preset not found: ${name}"
-    log_info "Available presets:"
-    preset_list
-    return 1
-  fi
+	local preset_file="${PRESETS_DIR}/${name}.json"
+	if [[ ! -f $preset_file ]]; then
+		log_error "Preset not found: ${name}"
+		log_info "Available presets:"
+		preset_list
+		return 1
+	fi
 
-  ensure_config_dir
+	ensure_config_dir
 
-  local display_name
-  display_name=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_name', sys.argv[2]))" "$preset_file" "$name" 2>/dev/null || echo "$name")
+	local display_name
+	display_name=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_name', sys.argv[2]))" "$preset_file" "$name" 2>/dev/null || echo "$name")
 
-  log_info "Applying preset: ${display_name}..."
+	log_info "Applying preset: ${display_name}..."
 
-  python3 -c "
+	python3 -c "
 import json, sys
 
 def deep_merge(base, override):
@@ -322,109 +322,109 @@ with open(config_path, 'w') as f:
     json.dump(merged, f, indent=2)
     f.write('\n')
 " "$SHELL_CONFIG" "$preset_file" || {
-    log_error "Failed to apply preset: ${name}"
-    return 1
-  }
+		log_error "Failed to apply preset: ${name}"
+		return 1
+	}
 
-  echo "$name" >"$CURRENT_PRESET_FILE"
-  log_info "Preset applied: ${display_name}"
+	echo "$name" >"$CURRENT_PRESET_FILE"
+	log_info "Preset applied: ${display_name}"
 
-  if is_running; then
-    log_info "Quickshell will reload automatically"
-  fi
+	if is_running; then
+		log_info "Quickshell will reload automatically"
+	fi
 }
 
 preset_select() {
-  if [[ ! -d $PRESETS_DIR ]]; then
-    log_error "Presets directory not found: $PRESETS_DIR"
-    return 1
-  fi
+	if [[ ! -d $PRESETS_DIR ]]; then
+		log_error "Presets directory not found: $PRESETS_DIR"
+		return 1
+	fi
 
-  local current=""
-  [[ -f $CURRENT_PRESET_FILE ]] && current=$(<"$CURRENT_PRESET_FILE")
+	local current=""
+	[[ -f $CURRENT_PRESET_FILE ]] && current=$(<"$CURRENT_PRESET_FILE")
 
-  local names=()
-  local menu_items=""
-  local selected_index=0
-  local idx=0
+	local names=()
+	local menu_items=""
+	local selected_index=0
+	local idx=0
 
-  for preset_file in "$PRESETS_DIR"/*.json; do
-    [[ -f $preset_file ]] || continue
-    local name
-    name=$(basename "$preset_file" .json)
-    names+=("$name")
+	for preset_file in "$PRESETS_DIR"/*.json; do
+		[[ -f $preset_file ]] || continue
+		local name
+		name=$(basename "$preset_file" .json)
+		names+=("$name")
 
-    local display_name description icon position
-    display_name=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_name',''))" "$preset_file" 2>/dev/null || echo "$name")
-    description=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_description',''))" "$preset_file" 2>/dev/null || echo "")
-    icon=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_icon','📦'))" "$preset_file" 2>/dev/null || echo "📦")
-    position=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('bar',{}).get('position',''))" "$preset_file" 2>/dev/null || echo "")
+		local display_name description icon position
+		display_name=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_name',''))" "$preset_file" 2>/dev/null || echo "$name")
+		description=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_description',''))" "$preset_file" 2>/dev/null || echo "")
+		icon=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_icon','📦'))" "$preset_file" 2>/dev/null || echo "📦")
+		position=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('bar',{}).get('position',''))" "$preset_file" 2>/dev/null || echo "")
 
-    local label="${icon} ${display_name}"
-    [[ -n $position ]] && label="${label} · ${position} bar"
-    [[ -n $description ]] && label="${label} — ${description}"
+		local label="${icon} ${display_name}"
+		[[ -n $position ]] && label="${label} · ${position} bar"
+		[[ -n $description ]] && label="${label} — ${description}"
 
-    menu_items+="${label}\n"
+		menu_items+="${label}\n"
 
-    [[ $name == "$current" ]] && selected_index=$idx
-    idx=$((idx + 1))
-  done
+		[[ $name == "$current" ]] && selected_index=$idx
+		idx=$((idx + 1))
+	done
 
-  if [[ ${#names[@]} -eq 0 ]]; then
-    log_error "No presets found in $PRESETS_DIR"
-    return 1
-  fi
+	if [[ ${#names[@]} -eq 0 ]]; then
+		log_error "No presets found in $PRESETS_DIR"
+		return 1
+	fi
 
-  echo "Shell Preset"
-  i=1
-  for item in "${names[@]}"; do
-    local pf="${PRESETS_DIR}/${item}.json"
-    local icon display_name
-    icon=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_icon','📦'))" "$pf" 2>/dev/null || echo "📦")
-    display_name=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_name',''))" "$pf" 2>/dev/null || echo "$item")
-    if [[ $item == "$current" ]]; then
-      printf "%2d) %s %s (active)\n" "$i" "$icon" "$display_name"
-    else
-      printf "%2d) %s %s\n" "$i" "$icon" "$display_name"
-    fi
-    i=$((i + 1))
-  done
-  printf "Select preset [1-%d, empty to cancel]: " "${#names[@]}"
-  local idx
-  read -r idx || return 1
-  [[ -z ${idx:-} ]] && return 0
-  [[ $idx =~ ^[0-9]+$ ]] || return 1
-  ((idx >= 1 && idx <= ${#names[@]})) || return 1
-  local selected="${names[$((idx - 1))]}"
+	echo "Shell Preset"
+	i=1
+	for item in "${names[@]}"; do
+		local pf="${PRESETS_DIR}/${item}.json"
+		local icon display_name
+		icon=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_icon','📦'))" "$pf" 2>/dev/null || echo "📦")
+		display_name=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('_name',''))" "$pf" 2>/dev/null || echo "$item")
+		if [[ $item == "$current" ]]; then
+			printf "%2d) %s %s (active)\n" "$i" "$icon" "$display_name"
+		else
+			printf "%2d) %s %s\n" "$i" "$icon" "$display_name"
+		fi
+		i=$((i + 1))
+	done
+	printf "Select preset [1-%d, empty to cancel]: " "${#names[@]}"
+	local idx
+	read -r idx || return 1
+	[[ -z ${idx:-} ]] && return 0
+	[[ $idx =~ ^[0-9]+$ ]] || return 1
+	((idx >= 1 && idx <= ${#names[@]})) || return 1
+	local selected="${names[$((idx - 1))]}"
 
-  preset_apply "$selected"
+	preset_apply "$selected"
 }
 
 cmd_config() {
-  local action="${1:-}"
-  shift 2>/dev/null || true
+	local action="${1:-}"
+	shift 2>/dev/null || true
 
-  case "$action" in
-    get) config_get "${1:-}" ;;
-    set) config_set "${1:-}" "${2:-}" ;;
-    *)
-      log_error "Usage: dots-quickshell config {get <key>|set <key> <value>}"
-      return 1
-      ;;
-  esac
+	case "$action" in
+	get) config_get "${1:-}" ;;
+	set) config_set "${1:-}" "${2:-}" ;;
+	*)
+		log_error "Usage: dots-quickshell config {get <key>|set <key> <value>}"
+		return 1
+		;;
+	esac
 }
 
 config_get() {
-  local key="${1:-}"
-  if [[ -z $key ]]; then
-    log_error "Usage: dots-quickshell config get <key>"
-    log_info "Key uses dot-notation: bar.position, appearance.rounding, etc."
-    return 1
-  fi
+	local key="${1:-}"
+	if [[ -z $key ]]; then
+		log_error "Usage: dots-quickshell config get <key>"
+		log_info "Key uses dot-notation: bar.position, appearance.rounding, etc."
+		return 1
+	fi
 
-  ensure_config_dir
+	ensure_config_dir
 
-  python3 -c "
+	python3 -c "
 import json, sys
 
 key = sys.argv[1]
@@ -451,17 +451,17 @@ else:
 }
 
 config_set() {
-  local key="${1:-}"
-  local value="${2:-}"
-  if [[ -z $key ]]; then
-    log_error "Usage: dots-quickshell config set <key> <value>"
-    log_info "Key uses dot-notation: bar.position, appearance.rounding, etc."
-    return 1
-  fi
+	local key="${1:-}"
+	local value="${2:-}"
+	if [[ -z $key ]]; then
+		log_error "Usage: dots-quickshell config set <key> <value>"
+		log_info "Key uses dot-notation: bar.position, appearance.rounding, etc."
+		return 1
+	fi
 
-  ensure_config_dir
+	ensure_config_dir
 
-  python3 -c "
+	python3 -c "
 import json, sys
 
 key = sys.argv[1]
@@ -494,125 +494,125 @@ with open(config_path, 'w') as f:
 print(f'{key} = {json.dumps(value)}')
 " "$key" "$value" "$SHELL_CONFIG"
 
-  log_info "Config updated"
-  if is_running; then
-    log_info "Quickshell will reload automatically"
-  fi
+	log_info "Config updated"
+	if is_running; then
+		log_info "Quickshell will reload automatically"
+	fi
 }
 
 cmd_rebuild() {
-  local shell_dir="${QUICKSHELL_CONFIG_DIR}"
-  local build_dir="${XDG_CACHE_HOME:-${HOME}/.cache}/dots/quickshell/build"
-  local install_prefix="${HOME}/.local/lib/quickshell"
+	local shell_dir="${QUICKSHELL_CONFIG_DIR}"
+	local build_dir="${XDG_CACHE_HOME:-${HOME}/.cache}/dots/quickshell/build"
+	local install_prefix="${HOME}/.local/lib/quickshell"
 
-  if [[ ! -d $shell_dir ]]; then
-    log_error "Quickshell directory not found: ${shell_dir}"
-    return 1
-  fi
+	if [[ ! -d $shell_dir ]]; then
+		log_error "Quickshell directory not found: ${shell_dir}"
+		return 1
+	fi
 
-  if ! command -v cmake &>/dev/null; then
-    log_error "cmake not found — install it first"
-    return 1
-  fi
+	if ! command -v cmake &>/dev/null; then
+		log_error "cmake not found — install it first"
+		return 1
+	fi
 
-  if ! command -v ninja &>/dev/null; then
-    log_error "ninja not found — install it first"
-    return 1
-  fi
+	if ! command -v ninja &>/dev/null; then
+		log_error "ninja not found — install it first"
+		return 1
+	fi
 
-  if [[ ! -f "${shell_dir}/CMakeLists.txt" ]]; then
-    log_error "Missing CMakeLists.txt in ${shell_dir}"
-    return 1
-  fi
+	if [[ ! -f "${shell_dir}/CMakeLists.txt" ]]; then
+		log_error "Missing CMakeLists.txt in ${shell_dir}"
+		return 1
+	fi
 
-  local version="v0.0.0"
-  local revision="unknown"
-  local dotfiles_dir
-  dotfiles_dir="$(chezmoi source-path 2>/dev/null || true)"
-  dotfiles_dir="${dotfiles_dir:-${HOME}/.dotfiles}"
-  if command -v git &>/dev/null && git -C "$dotfiles_dir" rev-parse --is-inside-work-tree &>/dev/null 2>&1; then
-    version="$(git -C "$dotfiles_dir" describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")"
-    revision="$(git -C "$dotfiles_dir" rev-parse HEAD 2>/dev/null || echo "unknown")"
-  fi
+	local version="v0.0.0"
+	local revision="unknown"
+	local dotfiles_dir
+	dotfiles_dir="$(chezmoi source-path 2>/dev/null || true)"
+	dotfiles_dir="${dotfiles_dir:-${HOME}/.dotfiles}"
+	if command -v git &>/dev/null && git -C "$dotfiles_dir" rev-parse --is-inside-work-tree &>/dev/null 2>&1; then
+		version="$(git -C "$dotfiles_dir" describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")"
+		revision="$(git -C "$dotfiles_dir" rev-parse HEAD 2>/dev/null || echo "unknown")"
+	fi
 
-  local was_running=false
-  if is_running; then
-    was_running=true
-    log_info "Stopping Quickshell before rebuild..."
-    cmd_stop
-  fi
+	local was_running=false
+	if is_running; then
+		was_running=true
+		log_info "Stopping Quickshell before rebuild..."
+		cmd_stop
+	fi
 
-  log_info "Configuring Hornero plugin (${version})..."
-  mkdir -p "$build_dir"
-  # Drop a pre-rebrand CMake cache that still has INSTALL_*DIR=.../caelestia.
-  # CACHE STRING defaults in CMakeLists.txt do not overwrite an existing cache.
-  if [[ -f ${build_dir}/CMakeCache.txt ]] && grep -qF 'caelestia' "${build_dir}/CMakeCache.txt"; then
-    log_info "Stale CMake cache still references caelestia; reconfiguring from scratch..."
-    rm -rf "$build_dir"
-    mkdir -p "$build_dir"
-  fi
-  cmake -S "$shell_dir" -B "$build_dir" -G Ninja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX="$install_prefix" \
-    -DENABLE_MODULES="extras;plugin" \
-    -DINSTALL_LIBDIR="usr/lib/hornero" \
-    -DINSTALL_QMLDIR="${install_prefix}/qml" \
-    -DINSTALL_QSCONFDIR="etc/xdg/quickshell/hornero" \
-    -DVERSION="$version" \
-    -DGIT_REVISION="$revision" || {
-    log_error "CMake configure failed"
-    [[ $was_running == true ]] && cmd_start
-    return 1
-  }
+	log_info "Configuring Hornero plugin (${version})..."
+	mkdir -p "$build_dir"
+	# Drop a pre-rebrand CMake cache that still has INSTALL_*DIR=.../caelestia.
+	# CACHE STRING defaults in CMakeLists.txt do not overwrite an existing cache.
+	if [[ -f ${build_dir}/CMakeCache.txt ]] && grep -qF 'caelestia' "${build_dir}/CMakeCache.txt"; then
+		log_info "Stale CMake cache still references caelestia; reconfiguring from scratch..."
+		rm -rf "$build_dir"
+		mkdir -p "$build_dir"
+	fi
+	cmake -S "$shell_dir" -B "$build_dir" -G Ninja \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX="$install_prefix" \
+		-DENABLE_MODULES="extras;plugin" \
+		-DINSTALL_LIBDIR="usr/lib/hornero" \
+		-DINSTALL_QMLDIR="${install_prefix}/qml" \
+		-DINSTALL_QSCONFDIR="etc/xdg/quickshell/hornero" \
+		-DVERSION="$version" \
+		-DGIT_REVISION="$revision" || {
+		log_error "CMake configure failed"
+		[[ $was_running == true ]] && cmd_start
+		return 1
+	}
 
-  log_info "Building..."
-  cmake --build "$build_dir" --parallel "$(nproc)" || {
-    log_error "Build failed"
-    [[ $was_running == true ]] && cmd_start
-    return 1
-  }
+	log_info "Building..."
+	cmake --build "$build_dir" --parallel "$(nproc)" || {
+		log_error "Build failed"
+		[[ $was_running == true ]] && cmd_start
+		return 1
+	}
 
-  log_info "Installing to ${install_prefix}..."
-  cmake --install "$build_dir" || {
-    log_error "Install failed"
-    [[ $was_running == true ]] && cmd_start
-    return 1
-  }
+	log_info "Installing to ${install_prefix}..."
+	cmake --install "$build_dir" || {
+		log_error "Install failed"
+		[[ $was_running == true ]] && cmd_start
+		return 1
+	}
 
-  # Leftover packaged-shell copy + version binary from the old CACHE paths.
-  rm -rf "${install_prefix}/etc/xdg/quickshell/caelestia" \
-    "${install_prefix}/usr/lib/caelestia"
+	# Leftover packaged-shell copy + version binary from the old CACHE paths.
+	rm -rf "${install_prefix}/etc/xdg/quickshell/caelestia" \
+		"${install_prefix}/usr/lib/caelestia"
 
-  log_info "Hornero plugin rebuilt and installed"
+	log_info "Hornero plugin rebuilt and installed"
 
-  if [[ $was_running == true ]]; then
-    log_info "Restarting Quickshell..."
-    cmd_start
-  fi
+	if [[ $was_running == true ]]; then
+		log_info "Restarting Quickshell..."
+		cmd_start
+	fi
 }
 
 main() {
-  local command="${1:-}"
-  shift 2>/dev/null || true
+	local command="${1:-}"
+	shift 2>/dev/null || true
 
-  case "$command" in
-    start) cmd_start ;;
-    stop) cmd_stop ;;
-    restart) cmd_restart ;;
-    status) cmd_status ;;
-    ipc) cmd_ipc "$@" ;;
-    preset) cmd_preset "$@" ;;
-    config) cmd_config "$@" ;;
-    rebuild) cmd_rebuild ;;
-    "")
-      log_error "No command specified. Use --help for usage."
-      exit 1
-      ;;
-    *)
-      log_error "Unknown command: $command. Use --help for usage."
-      exit 1
-      ;;
-  esac
+	case "$command" in
+	start) cmd_start ;;
+	stop) cmd_stop ;;
+	restart) cmd_restart ;;
+	status) cmd_status ;;
+	ipc) cmd_ipc "$@" ;;
+	preset) cmd_preset "$@" ;;
+	config) cmd_config "$@" ;;
+	rebuild) cmd_rebuild ;;
+	"")
+		log_error "No command specified. Use --help for usage."
+		exit 1
+		;;
+	*)
+		log_error "Unknown command: $command. Use --help for usage."
+		exit 1
+		;;
+	esac
 }
 
 main "$@"

--- a/scripts/test-appearance-consistency.sh
+++ b/scripts/test-appearance-consistency.sh
@@ -19,32 +19,32 @@ FAIL=0
 SKIP=0
 
 pass() {
-  PASS=$((PASS + 1))
-  printf '  PASS  %s\n' "$*"
+	PASS=$((PASS + 1))
+	printf '  PASS  %s\n' "$*"
 }
 fail() {
-  FAIL=$((FAIL + 1))
-  printf '  FAIL  %s\n' "$*" >&2
+	FAIL=$((FAIL + 1))
+	printf '  FAIL  %s\n' "$*" >&2
 }
 skip() {
-  SKIP=$((SKIP + 1))
-  printf '  SKIP  %s\n' "$*"
+	SKIP=$((SKIP + 1))
+	printf '  SKIP  %s\n' "$*"
 }
 
 PYTHON_BIN=""
-if command -v python3 >/dev/null 2>&1; then
-  PYTHON_BIN="$(command -v python3)"
-elif command -v python >/dev/null 2>&1; then
-  PYTHON_BIN="$(command -v python)"
+if command -v python3 > /dev/null 2>&1; then
+	PYTHON_BIN="$(command -v python3)"
+elif command -v python > /dev/null 2>&1; then
+	PYTHON_BIN="$(command -v python)"
 fi
 
 validate_theme_json() {
-  local theme_json="$1"
-  local expected_id="$2"
-  local key
+	local theme_json="$1"
+	local expected_id="$2"
+	local key
 
-  if [[ -n $PYTHON_BIN ]]; then
-    "$PYTHON_BIN" - "$theme_json" "$expected_id" <<'PY'
+	if [[ -n $PYTHON_BIN ]]; then
+		"$PYTHON_BIN" - "$theme_json" "$expected_id" << 'PY'
 import json, sys
 path, expected = sys.argv[1], sys.argv[2]
 data = json.load(open(path, encoding="utf-8"))
@@ -57,26 +57,26 @@ if data.get("id") != expected:
 if not isinstance(data.get("tags", []), list):
     raise SystemExit("tags must be a list")
 PY
-    return $?
-  fi
+		return $?
+	fi
 
-  if command -v jq >/dev/null 2>&1; then
-    local id_val
-    id_val="$(jq -r '.id // empty' "$theme_json")"
-    [[ $id_val == "$expected_id" ]] || return 1
-    for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
-      jq -e --arg k "$key" 'has($k)' "$theme_json" >/dev/null || return 1
-    done
-    jq -e '(.tags == null) or ((.tags | type) == "array")' "$theme_json" >/dev/null || return 1
-    return 0
-  fi
+	if command -v jq > /dev/null 2>&1; then
+		local id_val
+		id_val="$(jq -r '.id // empty' "$theme_json")"
+		[[ $id_val == "$expected_id" ]] || return 1
+		for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
+			jq -e --arg k "$key" 'has($k)' "$theme_json" > /dev/null || return 1
+		done
+		jq -e '(.tags == null) or ((.tags | type) == "array")' "$theme_json" > /dev/null || return 1
+		return 0
+	fi
 
-  # Minimal grep fallback for CI images without Python/jq.
-  for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
-    grep -q "\"$key\"" "$theme_json" || return 1
-  done
-  grep -Eq "\"id\"[[:space:]]*:[[:space:]]*\"${expected_id}\"" "$theme_json" || return 1
-  return 0
+	# Minimal grep fallback for CI images without Python/jq.
+	for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
+		grep -q "\"$key\"" "$theme_json" || return 1
+	done
+	grep -Eq "\"id\"[[:space:]]*:[[:space:]]*\"${expected_id}\"" "$theme_json" || return 1
+	return 0
 }
 
 echo "== appearance consistency =="
@@ -89,39 +89,39 @@ GTK_BIN="${ROOT}/home/dot_local/bin/executable_dots-gtk-theme"
 QS_PIPE="${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml"
 
 [[ -d $THEMES_SRC ]] || {
-  echo "missing themes dir: $THEMES_SRC" >&2
-  exit 1
+	echo "missing themes dir: $THEMES_SRC" >&2
+	exit 1
 }
 
 theme_count=0
 for theme_json in "$THEMES_SRC"/*/theme.json; do
-  [[ -f $theme_json ]] || continue
-  theme_count=$((theme_count + 1))
-  dir="$(dirname "$theme_json")"
-  id="$(basename "$dir")"
-  if validate_theme_json "$theme_json" "$id"; then
-    pass "theme.json valid: $id"
-  else
-    fail "theme.json invalid: $id"
-  fi
-  if [[ -f $dir/preview.jpg || -f $dir/preview.png || -f $dir/preview.webp ]]; then
-    pass "preview asset: $id"
-  else
-    fail "missing preview for $id"
-  fi
+	[[ -f $theme_json ]] || continue
+	theme_count=$((theme_count + 1))
+	dir="$(dirname "$theme_json")"
+	id="$(basename "$dir")"
+	if validate_theme_json "$theme_json" "$id"; then
+		pass "theme.json valid: $id"
+	else
+		fail "theme.json invalid: $id"
+	fi
+	if [[ -f $dir/preview.jpg || -f $dir/preview.png || -f $dir/preview.webp ]]; then
+		pass "preview asset: $id"
+	else
+		fail "missing preview for $id"
+	fi
 done
 if [[ $theme_count -ge 1 ]]; then
-  pass "found $theme_count theme packs"
+	pass "found $theme_count theme packs"
 else
-  fail "no theme packs"
+	fail "no theme packs"
 fi
 
 if [[ -f $LIST_THEMES ]]; then
-  if [[ -z $PYTHON_BIN ]]; then
-    skip "list-themes.py check (python not available)"
-  elif DOTS_THEMES_DIR="$THEMES_SRC" DOTS_WALLPAPERS_DIR="${ROOT}/home/dot_local/share/dots/wallpapers" \
-    "$PYTHON_BIN" "$LIST_THEMES" "$THEMES_SRC" >/tmp/dots-themes-test.json 2>/tmp/dots-themes-test.err; then
-    if "$PYTHON_BIN" - <<'PY'; then
+	if [[ -z $PYTHON_BIN ]]; then
+		skip "list-themes.py check (python not available)"
+	elif DOTS_THEMES_DIR="$THEMES_SRC" DOTS_WALLPAPERS_DIR="${ROOT}/home/dot_local/share/dots/wallpapers" \
+		"$PYTHON_BIN" "$LIST_THEMES" "$THEMES_SRC" > /tmp/dots-themes-test.json 2> /tmp/dots-themes-test.err; then
+		if "$PYTHON_BIN" - << 'PY'; then
 import json
 data = json.load(open("/tmp/dots-themes-test.json", encoding="utf-8"))
 assert isinstance(data, list) and data, "empty theme list"
@@ -132,56 +132,56 @@ for t in data:
         assert name in t["wallpaperPaths"], f"{t.get('id')}: {name} missing from wallpaperPaths"
 print("ok", len(data))
 PY
-      pass "list-themes.py JSON + wallpaperPaths"
-    else
-      fail "list-themes.py schema check"
-    fi
-  else
-    fail "list-themes.py failed: $(head -c 200 /tmp/dots-themes-test.err 2>/dev/null || true)"
-  fi
+			pass "list-themes.py JSON + wallpaperPaths"
+		else
+			fail "list-themes.py schema check"
+		fi
+	else
+		fail "list-themes.py failed: $(head -c 200 /tmp/dots-themes-test.err 2> /dev/null || true)"
+	fi
 else
-  fail "list-themes.py missing"
+	fail "list-themes.py missing"
 fi
 
 # No stale rice IPC / sticky current writers in QS appearance path
 if grep -REn 'target:[[:space:]]*"rice"|IpcHandler.*rice|dots-rice|nwg-look' "$QS_PIPE" \
-  "${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance" >/dev/null 2>&1; then
-  fail "stale rice/nwg-look references in appearance QS"
+	"${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance" > /dev/null 2>&1; then
+	fail "stale rice/nwg-look references in appearance QS"
 else
-  pass "no stale rice IPC in appearance QS"
+	pass "no stale rice IPC in appearance QS"
 fi
 
 if grep -REn 'CAELESTIA_' \
-  "${ROOT}/home/dot_config/quickshell/utils" \
-  "${ROOT}/home/dot_config/quickshell/services" \
-  "${ROOT}/home/dot_config/quickshell/modules" \
-  "${ROOT}/home/dot_config/quickshell/nix" \
-  "${ROOT}/home/dot_config/hypr/hyprland.conf.d/environment.conf" \
-  "${ROOT}/home/dot_local/bin/executable_dots-quickshell" >/dev/null 2>&1; then
-  fail "CAELESTIA_ identifiers still present in Hornero runtime/packaging"
+	"${ROOT}/home/dot_config/quickshell/utils" \
+	"${ROOT}/home/dot_config/quickshell/services" \
+	"${ROOT}/home/dot_config/quickshell/modules" \
+	"${ROOT}/home/dot_config/quickshell/nix" \
+	"${ROOT}/home/dot_config/hypr/hyprland.conf.d/environment.conf" \
+	"${ROOT}/home/dot_local/bin/executable_dots-quickshell" > /dev/null 2>&1; then
+	fail "CAELESTIA_ identifiers still present in Hornero runtime/packaging"
 else
-  pass "no CAELESTIA_ identifiers in Hornero runtime/packaging"
+	pass "no CAELESTIA_ identifiers in Hornero runtime/packaging"
 fi
 
-if grep -En 'INSTALL_LIBDIR="usr/lib/hornero"' "${ROOT}/home/dot_local/bin/executable_dots-quickshell" >/dev/null 2>&1 &&
-  grep -En 'INSTALL_QSCONFDIR="etc/xdg/quickshell/hornero"' "${ROOT}/home/dot_local/bin/executable_dots-quickshell" >/dev/null 2>&1 &&
-  grep -En 'ENABLE_MODULES="extras;plugin"' "${ROOT}/home/dot_local/bin/executable_dots-quickshell" >/dev/null 2>&1; then
-  pass "dots-quickshell rebuild pins Hornero CMake install dirs"
+if grep -En 'INSTALL_LIBDIR="usr/lib/hornero"' "${ROOT}/home/dot_local/bin/executable_dots-quickshell" > /dev/null 2>&1 \
+	&& grep -En 'INSTALL_QSCONFDIR="etc/xdg/quickshell/hornero"' "${ROOT}/home/dot_local/bin/executable_dots-quickshell" > /dev/null 2>&1 \
+	&& grep -En 'ENABLE_MODULES="extras;plugin"' "${ROOT}/home/dot_local/bin/executable_dots-quickshell" > /dev/null 2>&1; then
+	pass "dots-quickshell rebuild pins Hornero CMake install dirs"
 else
-  fail "dots-quickshell rebuild missing Hornero INSTALL_* / ENABLE_MODULES flags"
+	fail "dots-quickshell rebuild missing Hornero INSTALL_* / ENABLE_MODULES flags"
 fi
 
 if grep -REn 'gsettings set org\.gnome\.desktop\.interface (gtk-theme|icon-theme)' \
-  "${ROOT}/home/dot_config/quickshell" >/dev/null 2>&1; then
-  fail "raw gsettings GTK/icon writes in Quickshell"
+	"${ROOT}/home/dot_config/quickshell" > /dev/null 2>&1; then
+	fail "raw gsettings GTK/icon writes in Quickshell"
 else
-  pass "Quickshell does not write GTK/icons via gsettings"
+	pass "Quickshell does not write GTK/icons via gsettings"
 fi
 
-if grep -En 'gtk-theme-manager\.sh' "${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml" >/dev/null 2>&1; then
-  fail "ThemePipeline still sources gtk-theme-manager.sh"
+if grep -En 'gtk-theme-manager\.sh' "${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml" > /dev/null 2>&1; then
+	fail "ThemePipeline still sources gtk-theme-manager.sh"
 else
-  pass "ThemePipeline uses dots-gtk-theme CLI"
+	pass "ThemePipeline uses dots-gtk-theme CLI"
 fi
 
 M3_BIN="${ROOT}/home/dot_local/bin/executable_dots-m3-colors"
@@ -189,140 +189,140 @@ M3_LIB="${ROOT}/home/dot_local/lib/dots/python-m3.sh"
 COLOR_SCHEME_BIN="${ROOT}/home/dot_local/bin/executable_dots-color-scheme"
 
 if [[ -f $M3_BIN && -f $M3_LIB ]]; then
-  pass "dots-m3-colors + python-m3.sh present"
+	pass "dots-m3-colors + python-m3.sh present"
 else
-  fail "missing dots-m3-colors and/or python-m3.sh"
+	fail "missing dots-m3-colors and/or python-m3.sh"
 fi
 
-if grep -En 'dots-m3-colors|m3Bin' "$QS_PIPE" >/dev/null 2>&1 &&
-  ! grep -En '["'\'']python3["'\''].*generate-m3-colors|generate-m3-colors\.py' "$QS_PIPE" >/dev/null 2>&1; then
-  pass "ThemePipeline invokes dots-m3-colors (not bare python3)"
+if grep -En 'dots-m3-colors|m3Bin' "$QS_PIPE" > /dev/null 2>&1 \
+	&& ! grep -En '["'\'']python3["'\''].*generate-m3-colors|generate-m3-colors\.py' "$QS_PIPE" > /dev/null 2>&1; then
+	pass "ThemePipeline invokes dots-m3-colors (not bare python3)"
 else
-  fail "ThemePipeline still invokes generate-m3-colors via bare python3"
+	fail "ThemePipeline still invokes generate-m3-colors via bare python3"
 fi
 
-if grep -En 'cmd_regenerate' "$COLOR_SCHEME_BIN" >/dev/null 2>&1 &&
-  grep -A5 'cmd_regenerate()' "$COLOR_SCHEME_BIN" | grep -Eq 'regenerate_scheme'; then
-  pass "dots-color-scheme regenerate calls regenerate_scheme"
+if grep -En 'cmd_regenerate' "$COLOR_SCHEME_BIN" > /dev/null 2>&1 \
+	&& grep -A5 'cmd_regenerate()' "$COLOR_SCHEME_BIN" | grep -Eq 'regenerate_scheme'; then
+	pass "dots-color-scheme regenerate calls regenerate_scheme"
 else
-  fail "dots-color-scheme regenerate is a no-op (must call regenerate_scheme)"
+	fail "dots-color-scheme regenerate is a no-op (must call regenerate_scheme)"
 fi
 
-if grep -En 'normalize_gtk_color_scheme|follow \| default \| prefer-light' "$GTK_MGR" >/dev/null 2>&1 &&
-  grep -En 'write_live_gtk_color_scheme' "$GTK_MGR" >/dev/null 2>&1; then
-  pass "gtk-theme-manager has gtkColorScheme policy helpers"
+if grep -En 'normalize_gtk_color_scheme|follow \| default \| prefer-light' "$GTK_MGR" > /dev/null 2>&1 \
+	&& grep -En 'write_live_gtk_color_scheme' "$GTK_MGR" > /dev/null 2>&1; then
+	pass "gtk-theme-manager has gtkColorScheme policy helpers"
 else
-  fail "gtk-theme-manager missing gtkColorScheme policy helpers"
+	fail "gtk-theme-manager missing gtkColorScheme policy helpers"
 fi
 
-if grep -En 'data\["mode"\] = mode' "$GTK_BIN" >/dev/null 2>&1; then
-  fail "dots-gtk-theme color-scheme still writes shell mode"
+if grep -En 'data\["mode"\] = mode' "$GTK_BIN" > /dev/null 2>&1; then
+	fail "dots-gtk-theme color-scheme still writes shell mode"
 else
-  pass "dots-gtk-theme color-scheme does not write shell mode"
+	pass "dots-gtk-theme color-scheme does not write shell mode"
 fi
 
-if grep -En 'color-scheme follow' "$COLOR_SCHEME_BIN" >/dev/null 2>&1 &&
-  grep -En 'gtkColorScheme' "$COLOR_SCHEME_BIN" >/dev/null 2>&1; then
-  pass "dots-color-scheme mode only syncs GTK when policy is follow"
+if grep -En 'color-scheme follow' "$COLOR_SCHEME_BIN" > /dev/null 2>&1 \
+	&& grep -En 'gtkColorScheme' "$COLOR_SCHEME_BIN" > /dev/null 2>&1; then
+	pass "dots-color-scheme mode only syncs GTK when policy is follow"
 else
-  fail "dots-color-scheme mode still always overwrites GTK color-scheme"
+	fail "dots-color-scheme mode still always overwrites GTK color-scheme"
 fi
 
-if grep -En 'sync-color-scheme' "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" >/dev/null 2>&1 &&
-  grep -En 'sync-color-scheme' "${ROOT}/home/dot_local/bin/executable_dots-wal-reload" >/dev/null 2>&1; then
-  pass "wallpaper/wal-reload re-apply GTK policy instead of forcing mode"
+if grep -En 'sync-color-scheme' "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" > /dev/null 2>&1 \
+	&& grep -En 'sync-color-scheme' "${ROOT}/home/dot_local/bin/executable_dots-wal-reload" > /dev/null 2>&1; then
+	pass "wallpaper/wal-reload re-apply GTK policy instead of forcing mode"
 else
-  fail "wallpaper/wal-reload still force GTK color-scheme from shell mode"
+	fail "wallpaper/wal-reload still force GTK color-scheme from shell mode"
 fi
 
-if grep -En 'function setGtkColorScheme' "$QS_PIPE" >/dev/null 2>&1 &&
-  [[ -f ${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance/sections/GtkColorSchemeSection.qml ]]; then
-  pass "ThemePipeline + Appearance pane expose GTK color scheme"
+if grep -En 'function setGtkColorScheme' "$QS_PIPE" > /dev/null 2>&1 \
+	&& [[ -f ${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance/sections/GtkColorSchemeSection.qml ]]; then
+	pass "ThemePipeline + Appearance pane expose GTK color scheme"
 else
-  fail "missing setGtkColorScheme IPC or GtkColorSchemeSection"
+	fail "missing setGtkColorScheme IPC or GtkColorSchemeSection"
 fi
 
-if grep -En 'gtkColorScheme' "$LIST_THEMES" >/dev/null 2>&1; then
-  pass "list-themes.py exposes gtkColorScheme"
+if grep -En 'gtkColorScheme' "$LIST_THEMES" > /dev/null 2>&1; then
+	pass "list-themes.py exposes gtkColorScheme"
 else
-  fail "list-themes.py missing gtkColorScheme"
+	fail "list-themes.py missing gtkColorScheme"
 fi
 
-if grep -En 'fontFamilyClock' "${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance/sections/FontsSection.qml" >/dev/null 2>&1; then
-  pass "FontsSection exposes clock font"
+if grep -En 'fontFamilyClock' "${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance/sections/FontsSection.qml" > /dev/null 2>&1; then
+	pass "FontsSection exposes clock font"
 else
-  fail "FontsSection missing clock font"
+	fail "FontsSection missing clock font"
 fi
 
 # Intentional: match the literal shell source pattern containing $HOME.
 # shellcheck disable=SC2016
 if grep -En 'readlink -f "\$HOME/\.cache/wal/wal"|readlink -f \$HOME/\.cache/wal/wal' \
-  "$GTK_MGR" "$GTK_BIN" "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" >/dev/null 2>&1; then
-  fail "unsafe readlink on wal text pointer"
+	"$GTK_MGR" "$GTK_BIN" "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" > /dev/null 2>&1; then
+	fail "unsafe readlink on wal text pointer"
 else
-  pass "no unsafe wal readlink in GTK apply path"
+	pass "no unsafe wal readlink in GTK apply path"
 fi
 
 [[ $SOURCE_ONLY == true ]] && {
-  echo
-  echo "Results: $PASS pass, $FAIL fail, $SKIP skip (source-only)"
-  [[ $FAIL -eq 0 ]]
-  exit $?
+	echo
+	echo "Results: $PASS pass, $FAIL fail, $SKIP skip (source-only)"
+	[[ $FAIL -eq 0 ]]
+	exit $?
 }
 
 # ── Live environment ─────────────────────────────────────────────────────────
-if ! command -v dots-gtk-theme >/dev/null 2>&1; then
-  skip "dots-gtk-theme not on PATH (live checks)"
+if ! command -v dots-gtk-theme > /dev/null 2>&1; then
+	skip "dots-gtk-theme not on PATH (live checks)"
 else
-  if out="$(dots-gtk-theme -q -p current 2>/dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
-    pass "dots-gtk-theme current: $out"
-  else
-    fail "dots-gtk-theme current"
-  fi
-  if out="$(dots-gtk-theme -q -p current-icon 2>/dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
-    pass "dots-gtk-theme current-icon: $out"
-  else
-    fail "dots-gtk-theme current-icon"
-  fi
-  if mapfile -t themes < <(dots-gtk-theme -q -p list 2>/dev/null); then
-    if [[ ${#themes[@]} -gt 0 ]]; then
-      pass "dots-gtk-theme list (${#themes[@]} themes)"
-    else
-      fail "dots-gtk-theme list empty"
-    fi
-  else
-    fail "dots-gtk-theme list"
-  fi
+	if out="$(dots-gtk-theme -q -p current 2> /dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
+		pass "dots-gtk-theme current: $out"
+	else
+		fail "dots-gtk-theme current"
+	fi
+	if out="$(dots-gtk-theme -q -p current-icon 2> /dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
+		pass "dots-gtk-theme current-icon: $out"
+	else
+		fail "dots-gtk-theme current-icon"
+	fi
+	if mapfile -t themes < <(dots-gtk-theme -q -p list 2> /dev/null); then
+		if [[ ${#themes[@]} -gt 0 ]]; then
+			pass "dots-gtk-theme list (${#themes[@]} themes)"
+		else
+			fail "dots-gtk-theme list empty"
+		fi
+	else
+		fail "dots-gtk-theme list"
+	fi
 fi
 
-if command -v dots-appearance >/dev/null 2>&1; then
-  if dots appearance doctor >/tmp/dots-appearance-doctor.txt 2>&1; then
-    if grep -q '^OK:' /tmp/dots-appearance-doctor.txt; then
-      pass "dots appearance doctor OK"
-    else
-      fail "dots appearance doctor missing OK"
-      cat /tmp/dots-appearance-doctor.txt >&2 || true
-    fi
-  else
-    fail "dots appearance doctor exited nonzero"
-    cat /tmp/dots-appearance-doctor.txt >&2 || true
-  fi
+if command -v dots-appearance > /dev/null 2>&1; then
+	if dots appearance doctor > /tmp/dots-appearance-doctor.txt 2>&1; then
+		if grep -q '^OK:' /tmp/dots-appearance-doctor.txt; then
+			pass "dots appearance doctor OK"
+		else
+			fail "dots appearance doctor missing OK"
+			cat /tmp/dots-appearance-doctor.txt >&2 || true
+		fi
+	else
+		fail "dots appearance doctor exited nonzero"
+		cat /tmp/dots-appearance-doctor.txt >&2 || true
+	fi
 else
-  skip "dots-appearance not on PATH"
+	skip "dots-appearance not on PATH"
 fi
 
 wal="$HOME/.cache/wal/wal"
 if [[ -L $wal ]]; then
-  fail "$HOME/.cache/wal/wal is a symlink (must be text path file)"
+	fail "$HOME/.cache/wal/wal is a symlink (must be text path file)"
 elif [[ -f $wal ]]; then
-  line="$(head -n 1 "$wal" | tr -d '\r')"
-  if [[ -f $line ]]; then
-    pass "wal pointer is text path -> image"
-  else
-    fail "wal pointer does not resolve to an image: $line"
-  fi
+	line="$(head -n 1 "$wal" | tr -d '\r')"
+	if [[ -f $line ]]; then
+		pass "wal pointer is text path -> image"
+	else
+		fail "wal pointer does not resolve to an image: $line"
+	fi
 else
-  skip "wal pointer missing"
+	skip "wal pointer missing"
 fi
 
 echo

--- a/scripts/test-appearance-consistency.sh
+++ b/scripts/test-appearance-consistency.sh
@@ -19,32 +19,32 @@ FAIL=0
 SKIP=0
 
 pass() {
-	PASS=$((PASS + 1))
-	printf '  PASS  %s\n' "$*"
+  PASS=$((PASS + 1))
+  printf '  PASS  %s\n' "$*"
 }
 fail() {
-	FAIL=$((FAIL + 1))
-	printf '  FAIL  %s\n' "$*" >&2
+  FAIL=$((FAIL + 1))
+  printf '  FAIL  %s\n' "$*" >&2
 }
 skip() {
-	SKIP=$((SKIP + 1))
-	printf '  SKIP  %s\n' "$*"
+  SKIP=$((SKIP + 1))
+  printf '  SKIP  %s\n' "$*"
 }
 
 PYTHON_BIN=""
-if command -v python3 > /dev/null 2>&1; then
-	PYTHON_BIN="$(command -v python3)"
-elif command -v python > /dev/null 2>&1; then
-	PYTHON_BIN="$(command -v python)"
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="$(command -v python3)"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN="$(command -v python)"
 fi
 
 validate_theme_json() {
-	local theme_json="$1"
-	local expected_id="$2"
-	local key
+  local theme_json="$1"
+  local expected_id="$2"
+  local key
 
-	if [[ -n $PYTHON_BIN ]]; then
-		"$PYTHON_BIN" - "$theme_json" "$expected_id" << 'PY'
+  if [[ -n $PYTHON_BIN ]]; then
+    "$PYTHON_BIN" - "$theme_json" "$expected_id" <<'PY'
 import json, sys
 path, expected = sys.argv[1], sys.argv[2]
 data = json.load(open(path, encoding="utf-8"))
@@ -57,26 +57,26 @@ if data.get("id") != expected:
 if not isinstance(data.get("tags", []), list):
     raise SystemExit("tags must be a list")
 PY
-		return $?
-	fi
+    return $?
+  fi
 
-	if command -v jq > /dev/null 2>&1; then
-		local id_val
-		id_val="$(jq -r '.id // empty' "$theme_json")"
-		[[ $id_val == "$expected_id" ]] || return 1
-		for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
-			jq -e --arg k "$key" 'has($k)' "$theme_json" > /dev/null || return 1
-		done
-		jq -e '(.tags == null) or ((.tags | type) == "array")' "$theme_json" > /dev/null || return 1
-		return 0
-	fi
+  if command -v jq >/dev/null 2>&1; then
+    local id_val
+    id_val="$(jq -r '.id // empty' "$theme_json")"
+    [[ $id_val == "$expected_id" ]] || return 1
+    for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
+      jq -e --arg k "$key" 'has($k)' "$theme_json" >/dev/null || return 1
+    done
+    jq -e '(.tags == null) or ((.tags | type) == "array")' "$theme_json" >/dev/null || return 1
+    return 0
+  fi
 
-	# Minimal grep fallback for CI images without Python/jq.
-	for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
-		grep -q "\"$key\"" "$theme_json" || return 1
-	done
-	grep -Eq "\"id\"[[:space:]]*:[[:space:]]*\"${expected_id}\"" "$theme_json" || return 1
-	return 0
+  # Minimal grep fallback for CI images without Python/jq.
+  for key in schemaVersion id name darkMode schemeType gtkTheme iconTheme defaultWallpaper wallpaperDir; do
+    grep -q "\"$key\"" "$theme_json" || return 1
+  done
+  grep -Eq "\"id\"[[:space:]]*:[[:space:]]*\"${expected_id}\"" "$theme_json" || return 1
+  return 0
 }
 
 echo "== appearance consistency =="
@@ -89,39 +89,39 @@ GTK_BIN="${ROOT}/home/dot_local/bin/executable_dots-gtk-theme"
 QS_PIPE="${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml"
 
 [[ -d $THEMES_SRC ]] || {
-	echo "missing themes dir: $THEMES_SRC" >&2
-	exit 1
+  echo "missing themes dir: $THEMES_SRC" >&2
+  exit 1
 }
 
 theme_count=0
 for theme_json in "$THEMES_SRC"/*/theme.json; do
-	[[ -f $theme_json ]] || continue
-	theme_count=$((theme_count + 1))
-	dir="$(dirname "$theme_json")"
-	id="$(basename "$dir")"
-	if validate_theme_json "$theme_json" "$id"; then
-		pass "theme.json valid: $id"
-	else
-		fail "theme.json invalid: $id"
-	fi
-	if [[ -f $dir/preview.jpg || -f $dir/preview.png || -f $dir/preview.webp ]]; then
-		pass "preview asset: $id"
-	else
-		fail "missing preview for $id"
-	fi
+  [[ -f $theme_json ]] || continue
+  theme_count=$((theme_count + 1))
+  dir="$(dirname "$theme_json")"
+  id="$(basename "$dir")"
+  if validate_theme_json "$theme_json" "$id"; then
+    pass "theme.json valid: $id"
+  else
+    fail "theme.json invalid: $id"
+  fi
+  if [[ -f $dir/preview.jpg || -f $dir/preview.png || -f $dir/preview.webp ]]; then
+    pass "preview asset: $id"
+  else
+    fail "missing preview for $id"
+  fi
 done
 if [[ $theme_count -ge 1 ]]; then
-	pass "found $theme_count theme packs"
+  pass "found $theme_count theme packs"
 else
-	fail "no theme packs"
+  fail "no theme packs"
 fi
 
 if [[ -f $LIST_THEMES ]]; then
-	if [[ -z $PYTHON_BIN ]]; then
-		skip "list-themes.py check (python not available)"
-	elif DOTS_THEMES_DIR="$THEMES_SRC" DOTS_WALLPAPERS_DIR="${ROOT}/home/dot_local/share/dots/wallpapers" \
-		"$PYTHON_BIN" "$LIST_THEMES" "$THEMES_SRC" > /tmp/dots-themes-test.json 2> /tmp/dots-themes-test.err; then
-		if "$PYTHON_BIN" - << 'PY'; then
+  if [[ -z $PYTHON_BIN ]]; then
+    skip "list-themes.py check (python not available)"
+  elif DOTS_THEMES_DIR="$THEMES_SRC" DOTS_WALLPAPERS_DIR="${ROOT}/home/dot_local/share/dots/wallpapers" \
+    "$PYTHON_BIN" "$LIST_THEMES" "$THEMES_SRC" >/tmp/dots-themes-test.json 2>/tmp/dots-themes-test.err; then
+    if "$PYTHON_BIN" - <<'PY'; then
 import json
 data = json.load(open("/tmp/dots-themes-test.json", encoding="utf-8"))
 assert isinstance(data, list) and data, "empty theme list"
@@ -132,36 +132,56 @@ for t in data:
         assert name in t["wallpaperPaths"], f"{t.get('id')}: {name} missing from wallpaperPaths"
 print("ok", len(data))
 PY
-			pass "list-themes.py JSON + wallpaperPaths"
-		else
-			fail "list-themes.py schema check"
-		fi
-	else
-		fail "list-themes.py failed: $(head -c 200 /tmp/dots-themes-test.err 2> /dev/null || true)"
-	fi
+      pass "list-themes.py JSON + wallpaperPaths"
+    else
+      fail "list-themes.py schema check"
+    fi
+  else
+    fail "list-themes.py failed: $(head -c 200 /tmp/dots-themes-test.err 2>/dev/null || true)"
+  fi
 else
-	fail "list-themes.py missing"
+  fail "list-themes.py missing"
 fi
 
 # No stale rice IPC / sticky current writers in QS appearance path
 if grep -REn 'target:[[:space:]]*"rice"|IpcHandler.*rice|dots-rice|nwg-look' "$QS_PIPE" \
-	"${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance" > /dev/null 2>&1; then
-	fail "stale rice/nwg-look references in appearance QS"
+  "${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance" >/dev/null 2>&1; then
+  fail "stale rice/nwg-look references in appearance QS"
 else
-	pass "no stale rice IPC in appearance QS"
+  pass "no stale rice IPC in appearance QS"
+fi
+
+if grep -REn 'CAELESTIA_' \
+  "${ROOT}/home/dot_config/quickshell/utils" \
+  "${ROOT}/home/dot_config/quickshell/services" \
+  "${ROOT}/home/dot_config/quickshell/modules" \
+  "${ROOT}/home/dot_config/quickshell/nix" \
+  "${ROOT}/home/dot_config/hypr/hyprland.conf.d/environment.conf" \
+  "${ROOT}/home/dot_local/bin/executable_dots-quickshell" >/dev/null 2>&1; then
+  fail "CAELESTIA_ identifiers still present in Hornero runtime/packaging"
+else
+  pass "no CAELESTIA_ identifiers in Hornero runtime/packaging"
+fi
+
+if grep -En 'INSTALL_LIBDIR="usr/lib/hornero"' "${ROOT}/home/dot_local/bin/executable_dots-quickshell" >/dev/null 2>&1 &&
+  grep -En 'INSTALL_QSCONFDIR="etc/xdg/quickshell/hornero"' "${ROOT}/home/dot_local/bin/executable_dots-quickshell" >/dev/null 2>&1 &&
+  grep -En 'ENABLE_MODULES="extras;plugin"' "${ROOT}/home/dot_local/bin/executable_dots-quickshell" >/dev/null 2>&1; then
+  pass "dots-quickshell rebuild pins Hornero CMake install dirs"
+else
+  fail "dots-quickshell rebuild missing Hornero INSTALL_* / ENABLE_MODULES flags"
 fi
 
 if grep -REn 'gsettings set org\.gnome\.desktop\.interface (gtk-theme|icon-theme)' \
-	"${ROOT}/home/dot_config/quickshell" > /dev/null 2>&1; then
-	fail "raw gsettings GTK/icon writes in Quickshell"
+  "${ROOT}/home/dot_config/quickshell" >/dev/null 2>&1; then
+  fail "raw gsettings GTK/icon writes in Quickshell"
 else
-	pass "Quickshell does not write GTK/icons via gsettings"
+  pass "Quickshell does not write GTK/icons via gsettings"
 fi
 
-if grep -En 'gtk-theme-manager\.sh' "${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml" > /dev/null 2>&1; then
-	fail "ThemePipeline still sources gtk-theme-manager.sh"
+if grep -En 'gtk-theme-manager\.sh' "${ROOT}/home/dot_config/quickshell/services/ThemePipeline.qml" >/dev/null 2>&1; then
+  fail "ThemePipeline still sources gtk-theme-manager.sh"
 else
-	pass "ThemePipeline uses dots-gtk-theme CLI"
+  pass "ThemePipeline uses dots-gtk-theme CLI"
 fi
 
 M3_BIN="${ROOT}/home/dot_local/bin/executable_dots-m3-colors"
@@ -169,140 +189,140 @@ M3_LIB="${ROOT}/home/dot_local/lib/dots/python-m3.sh"
 COLOR_SCHEME_BIN="${ROOT}/home/dot_local/bin/executable_dots-color-scheme"
 
 if [[ -f $M3_BIN && -f $M3_LIB ]]; then
-	pass "dots-m3-colors + python-m3.sh present"
+  pass "dots-m3-colors + python-m3.sh present"
 else
-	fail "missing dots-m3-colors and/or python-m3.sh"
+  fail "missing dots-m3-colors and/or python-m3.sh"
 fi
 
-if grep -En 'dots-m3-colors|m3Bin' "$QS_PIPE" > /dev/null 2>&1 \
-	&& ! grep -En '["'\'']python3["'\''].*generate-m3-colors|generate-m3-colors\.py' "$QS_PIPE" > /dev/null 2>&1; then
-	pass "ThemePipeline invokes dots-m3-colors (not bare python3)"
+if grep -En 'dots-m3-colors|m3Bin' "$QS_PIPE" >/dev/null 2>&1 &&
+  ! grep -En '["'\'']python3["'\''].*generate-m3-colors|generate-m3-colors\.py' "$QS_PIPE" >/dev/null 2>&1; then
+  pass "ThemePipeline invokes dots-m3-colors (not bare python3)"
 else
-	fail "ThemePipeline still invokes generate-m3-colors via bare python3"
+  fail "ThemePipeline still invokes generate-m3-colors via bare python3"
 fi
 
-if grep -En 'cmd_regenerate' "$COLOR_SCHEME_BIN" > /dev/null 2>&1 \
-	&& grep -A5 'cmd_regenerate()' "$COLOR_SCHEME_BIN" | grep -Eq 'regenerate_scheme'; then
-	pass "dots-color-scheme regenerate calls regenerate_scheme"
+if grep -En 'cmd_regenerate' "$COLOR_SCHEME_BIN" >/dev/null 2>&1 &&
+  grep -A5 'cmd_regenerate()' "$COLOR_SCHEME_BIN" | grep -Eq 'regenerate_scheme'; then
+  pass "dots-color-scheme regenerate calls regenerate_scheme"
 else
-	fail "dots-color-scheme regenerate is a no-op (must call regenerate_scheme)"
+  fail "dots-color-scheme regenerate is a no-op (must call regenerate_scheme)"
 fi
 
-if grep -En 'normalize_gtk_color_scheme|follow \| default \| prefer-light' "$GTK_MGR" > /dev/null 2>&1 \
-	&& grep -En 'write_live_gtk_color_scheme' "$GTK_MGR" > /dev/null 2>&1; then
-	pass "gtk-theme-manager has gtkColorScheme policy helpers"
+if grep -En 'normalize_gtk_color_scheme|follow \| default \| prefer-light' "$GTK_MGR" >/dev/null 2>&1 &&
+  grep -En 'write_live_gtk_color_scheme' "$GTK_MGR" >/dev/null 2>&1; then
+  pass "gtk-theme-manager has gtkColorScheme policy helpers"
 else
-	fail "gtk-theme-manager missing gtkColorScheme policy helpers"
+  fail "gtk-theme-manager missing gtkColorScheme policy helpers"
 fi
 
-if grep -En 'data\["mode"\] = mode' "$GTK_BIN" > /dev/null 2>&1; then
-	fail "dots-gtk-theme color-scheme still writes shell mode"
+if grep -En 'data\["mode"\] = mode' "$GTK_BIN" >/dev/null 2>&1; then
+  fail "dots-gtk-theme color-scheme still writes shell mode"
 else
-	pass "dots-gtk-theme color-scheme does not write shell mode"
+  pass "dots-gtk-theme color-scheme does not write shell mode"
 fi
 
-if grep -En 'color-scheme follow' "$COLOR_SCHEME_BIN" > /dev/null 2>&1 \
-	&& grep -En 'gtkColorScheme' "$COLOR_SCHEME_BIN" > /dev/null 2>&1; then
-	pass "dots-color-scheme mode only syncs GTK when policy is follow"
+if grep -En 'color-scheme follow' "$COLOR_SCHEME_BIN" >/dev/null 2>&1 &&
+  grep -En 'gtkColorScheme' "$COLOR_SCHEME_BIN" >/dev/null 2>&1; then
+  pass "dots-color-scheme mode only syncs GTK when policy is follow"
 else
-	fail "dots-color-scheme mode still always overwrites GTK color-scheme"
+  fail "dots-color-scheme mode still always overwrites GTK color-scheme"
 fi
 
-if grep -En 'sync-color-scheme' "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" > /dev/null 2>&1 \
-	&& grep -En 'sync-color-scheme' "${ROOT}/home/dot_local/bin/executable_dots-wal-reload" > /dev/null 2>&1; then
-	pass "wallpaper/wal-reload re-apply GTK policy instead of forcing mode"
+if grep -En 'sync-color-scheme' "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" >/dev/null 2>&1 &&
+  grep -En 'sync-color-scheme' "${ROOT}/home/dot_local/bin/executable_dots-wal-reload" >/dev/null 2>&1; then
+  pass "wallpaper/wal-reload re-apply GTK policy instead of forcing mode"
 else
-	fail "wallpaper/wal-reload still force GTK color-scheme from shell mode"
+  fail "wallpaper/wal-reload still force GTK color-scheme from shell mode"
 fi
 
-if grep -En 'function setGtkColorScheme' "$QS_PIPE" > /dev/null 2>&1 \
-	&& [[ -f ${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance/sections/GtkColorSchemeSection.qml ]]; then
-	pass "ThemePipeline + Appearance pane expose GTK color scheme"
+if grep -En 'function setGtkColorScheme' "$QS_PIPE" >/dev/null 2>&1 &&
+  [[ -f ${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance/sections/GtkColorSchemeSection.qml ]]; then
+  pass "ThemePipeline + Appearance pane expose GTK color scheme"
 else
-	fail "missing setGtkColorScheme IPC or GtkColorSchemeSection"
+  fail "missing setGtkColorScheme IPC or GtkColorSchemeSection"
 fi
 
-if grep -En 'gtkColorScheme' "$LIST_THEMES" > /dev/null 2>&1; then
-	pass "list-themes.py exposes gtkColorScheme"
+if grep -En 'gtkColorScheme' "$LIST_THEMES" >/dev/null 2>&1; then
+  pass "list-themes.py exposes gtkColorScheme"
 else
-	fail "list-themes.py missing gtkColorScheme"
+  fail "list-themes.py missing gtkColorScheme"
 fi
 
-if grep -En 'fontFamilyClock' "${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance/sections/FontsSection.qml" > /dev/null 2>&1; then
-	pass "FontsSection exposes clock font"
+if grep -En 'fontFamilyClock' "${ROOT}/home/dot_config/quickshell/modules/controlcenter/appearance/sections/FontsSection.qml" >/dev/null 2>&1; then
+  pass "FontsSection exposes clock font"
 else
-	fail "FontsSection missing clock font"
+  fail "FontsSection missing clock font"
 fi
 
 # Intentional: match the literal shell source pattern containing $HOME.
 # shellcheck disable=SC2016
 if grep -En 'readlink -f "\$HOME/\.cache/wal/wal"|readlink -f \$HOME/\.cache/wal/wal' \
-	"$GTK_MGR" "$GTK_BIN" "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" > /dev/null 2>&1; then
-	fail "unsafe readlink on wal text pointer"
+  "$GTK_MGR" "$GTK_BIN" "${ROOT}/home/dot_local/lib/dots/apply-appearance.sh" >/dev/null 2>&1; then
+  fail "unsafe readlink on wal text pointer"
 else
-	pass "no unsafe wal readlink in GTK apply path"
+  pass "no unsafe wal readlink in GTK apply path"
 fi
 
 [[ $SOURCE_ONLY == true ]] && {
-	echo
-	echo "Results: $PASS pass, $FAIL fail, $SKIP skip (source-only)"
-	[[ $FAIL -eq 0 ]]
-	exit $?
+  echo
+  echo "Results: $PASS pass, $FAIL fail, $SKIP skip (source-only)"
+  [[ $FAIL -eq 0 ]]
+  exit $?
 }
 
 # ── Live environment ─────────────────────────────────────────────────────────
-if ! command -v dots-gtk-theme > /dev/null 2>&1; then
-	skip "dots-gtk-theme not on PATH (live checks)"
+if ! command -v dots-gtk-theme >/dev/null 2>&1; then
+  skip "dots-gtk-theme not on PATH (live checks)"
 else
-	if out="$(dots-gtk-theme -q -p current 2> /dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
-		pass "dots-gtk-theme current: $out"
-	else
-		fail "dots-gtk-theme current"
-	fi
-	if out="$(dots-gtk-theme -q -p current-icon 2> /dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
-		pass "dots-gtk-theme current-icon: $out"
-	else
-		fail "dots-gtk-theme current-icon"
-	fi
-	if mapfile -t themes < <(dots-gtk-theme -q -p list 2> /dev/null); then
-		if [[ ${#themes[@]} -gt 0 ]]; then
-			pass "dots-gtk-theme list (${#themes[@]} themes)"
-		else
-			fail "dots-gtk-theme list empty"
-		fi
-	else
-		fail "dots-gtk-theme list"
-	fi
+  if out="$(dots-gtk-theme -q -p current 2>/dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
+    pass "dots-gtk-theme current: $out"
+  else
+    fail "dots-gtk-theme current"
+  fi
+  if out="$(dots-gtk-theme -q -p current-icon 2>/dev/null)" && [[ -n $out && $out != "Unknown" ]]; then
+    pass "dots-gtk-theme current-icon: $out"
+  else
+    fail "dots-gtk-theme current-icon"
+  fi
+  if mapfile -t themes < <(dots-gtk-theme -q -p list 2>/dev/null); then
+    if [[ ${#themes[@]} -gt 0 ]]; then
+      pass "dots-gtk-theme list (${#themes[@]} themes)"
+    else
+      fail "dots-gtk-theme list empty"
+    fi
+  else
+    fail "dots-gtk-theme list"
+  fi
 fi
 
-if command -v dots-appearance > /dev/null 2>&1; then
-	if dots appearance doctor > /tmp/dots-appearance-doctor.txt 2>&1; then
-		if grep -q '^OK:' /tmp/dots-appearance-doctor.txt; then
-			pass "dots appearance doctor OK"
-		else
-			fail "dots appearance doctor missing OK"
-			cat /tmp/dots-appearance-doctor.txt >&2 || true
-		fi
-	else
-		fail "dots appearance doctor exited nonzero"
-		cat /tmp/dots-appearance-doctor.txt >&2 || true
-	fi
+if command -v dots-appearance >/dev/null 2>&1; then
+  if dots appearance doctor >/tmp/dots-appearance-doctor.txt 2>&1; then
+    if grep -q '^OK:' /tmp/dots-appearance-doctor.txt; then
+      pass "dots appearance doctor OK"
+    else
+      fail "dots appearance doctor missing OK"
+      cat /tmp/dots-appearance-doctor.txt >&2 || true
+    fi
+  else
+    fail "dots appearance doctor exited nonzero"
+    cat /tmp/dots-appearance-doctor.txt >&2 || true
+  fi
 else
-	skip "dots-appearance not on PATH"
+  skip "dots-appearance not on PATH"
 fi
 
 wal="$HOME/.cache/wal/wal"
 if [[ -L $wal ]]; then
-	fail "$HOME/.cache/wal/wal is a symlink (must be text path file)"
+  fail "$HOME/.cache/wal/wal is a symlink (must be text path file)"
 elif [[ -f $wal ]]; then
-	line="$(head -n 1 "$wal" | tr -d '\r')"
-	if [[ -f $line ]]; then
-		pass "wal pointer is text path -> image"
-	else
-		fail "wal pointer does not resolve to an image: $line"
-	fi
+  line="$(head -n 1 "$wal" | tr -d '\r')"
+  if [[ -f $line ]]; then
+    pass "wal pointer is text path -> image"
+  else
+    fail "wal pointer does not resolve to an image: $line"
+  fi
 else
-	skip "wal pointer missing"
+  skip "wal pointer missing"
 fi
 
 echo


### PR DESCRIPTION
## Summary
- `dots-quickshell rebuild` now passes `-DINSTALL_LIBDIR=usr/lib/hornero`, `-DINSTALL_QSCONFDIR=etc/xdg/quickshell/hornero`, and `-DENABLE_MODULES=extras;plugin`, and wipes a CMake cache that still has `caelestia` (CACHE STRING defaults never overwrote it).
- Runtime env vars are `HORNERO_*` (`WALLPAPERS_DIR`, `RECORDINGS_DIR`, `XKB_RULES_PATH`, `LIB_DIR`). Hyprland sets `HORNERO_LIB_DIR` for the user install of `version`.
- Nix packaging follows the same names (`hornero-shell`, `programs.hornero`, `HORNERO_*`). The optional CLI flake URL remains `github:caelestia-dots/cli` because that is the upstream repo.
- Attribution in README/LICENSE is unchanged (GPL provenance).

## Test plan
- [ ] `./scripts/test-appearance-consistency.sh --source`
- [ ] `dots-quickshell rebuild` — install log uses `.../hornero/...`, not `.../caelestia/...`
- [ ] Confirm `~/.local/lib/quickshell/etc/xdg/quickshell/caelestia` and `usr/lib/caelestia` are gone
- [ ] Confirm `~/.local/lib/quickshell/usr/lib/hornero/version` and `qml/Hornero/` exist
- [ ] Quickshell starts and Control Panel still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rebranded the desktop shell and related configuration from Caelestia to Hornero.
  * Added Hornero environment settings for libraries, keyboard layouts, wallpapers, and recordings.
  * Updated Home Manager integration, commands, services, and generated configuration paths to use Hornero naming.

* **Bug Fixes**
  * Rebuilds now configure Hornero paths automatically and clean up stale installation data.

* **Documentation**
  * Updated troubleshooting guidance to recommend the streamlined Hornero rebuild command, while retaining manual recovery steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->