### PR TITLE
ssh: add secure access between personal machines

### DIFF
--- a/docs/wiki/Network-Manager.md
+++ b/docs/wiki/Network-Manager.md
@@ -92,6 +92,36 @@ journalctl -u NetworkManager.service
 
 ---
 
+## 🔐 SSH Between Personal Machines
+
+Personal machines (`hornero` and `colibri`) can reach each other over the local
+network with SSH, reusing the **same personal key** (`~/.ssh/personal_rsa`) that
+is already deployed by `chezmoi` on both of them.
+
+### What the dotfiles manage
+
+| Piece | Managed by | Purpose |
+|---|---|---|
+| `~/.ssh/authorized_keys` | `private_dot_ssh/private_authorized_keys.tmpl` | Accepts inbound logins from the other machine |
+| `/etc/ssh/sshd_config.d/10-hornero-config.conf` | `run_onchange_before_install-ssh-server.sh.tmpl` | Enables and hardens `sshd` (key-only auth, no root login) |
+| Avahi + nss-mdns | `run_onchange_before_install-mdns.sh.tmpl` | Resolves `<hostname>.local` even when DHCP addresses change |
+| `~/.ssh/config` aliases | `private_dot_ssh/executable_config` | `ssh hornero` / `ssh colibri` just work |
+
+### First-time connection
+
+Host keys are intentionally not managed by the dotfiles, so accept the remote
+fingerprint the first time you connect (TOFU — trust on first use):
+
+```sh
+ssh hornero    # from colibri
+ssh colibri    # from hornero
+```
+
+If mDNS is blocked by your router or access point, pin the current IP directly
+in `~/.ssh/config` under the corresponding `Host` block as a fallback.
+
+---
+
 ## 🆘 Need Help?
 
 - [NetworkManager Arch Wiki](https://wiki.archlinux.org/title/NetworkManager)

--- a/docs/wiki/Network-Manager.md
+++ b/docs/wiki/Network-Manager.md
@@ -100,12 +100,12 @@ is already deployed by `chezmoi` on both of them.
 
 ### What the dotfiles manage
 
-| Piece | Managed by | Purpose |
-|---|---|---|
-| `~/.ssh/authorized_keys` | `private_dot_ssh/private_authorized_keys.tmpl` | Accepts inbound logins from the other machine |
-| `/etc/ssh/sshd_config.d/10-hornero-config.conf` | `run_onchange_before_install-ssh-server.sh.tmpl` | Enables and hardens `sshd` (key-only auth, no root login) |
-| Avahi + nss-mdns | `run_onchange_before_install-mdns.sh.tmpl` | Resolves `<hostname>.local` even when DHCP addresses change |
-| `~/.ssh/config` aliases | `private_dot_ssh/executable_config` | `ssh hornero` / `ssh colibri` just work |
+| Piece                                           | Managed by                                       | Purpose                                                     |
+|-------------------------------------------------|--------------------------------------------------|-------------------------------------------------------------|
+| `~/.ssh/authorized_keys`                        | `private_dot_ssh/private_authorized_keys.tmpl`   | Accepts inbound logins from the other machine               |
+| `/etc/ssh/sshd_config.d/10-hornero-config.conf` | `run_onchange_before_install-ssh-server.sh.tmpl` | Enables and hardens `sshd` (key-only auth, no root login)   |
+| Avahi + nss-mdns                                | `run_onchange_before_install-mdns.sh.tmpl`       | Resolves `<hostname>.local` even when DHCP addresses change |
+| `~/.ssh/config` aliases                         | `private_dot_ssh/executable_config`              | `ssh hornero` / `ssh colibri` just work                     |
 
 ### First-time connection
 

--- a/home/.chezmoiscripts/linux/run_onchange_before_install-mdns.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_before_install-mdns.sh.tmpl
@@ -1,0 +1,33 @@
+{{ if and .personal (not .ephemeral) -}}
+{{   if eq .osid "linux-arch" -}}
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+readonly nsswitch_conf="/etc/nsswitch.conf"
+
+# Avahi provides mDNS (.local) name resolution between machines on the LAN,
+# so SSH aliases keep working even when DHCP leases change over time.
+sudo pacman -S --noconfirm --needed avahi nss-mdns
+
+# Register mDNS lookups in nsswitch before regular DNS (idempotent).
+if ! grep -qE '^hosts:[[:space:]].*mdns_minimal' "${nsswitch_conf}"; then
+  sudo sed -i -E '/^hosts:/ s/\bdns\b/mdns_minimal [NOTFOUND=return] dns/' "${nsswitch_conf}"
+fi
+
+sudo systemctl enable --now avahi-daemon
+
+{{   else if or (eq .osid "linux-pop") (eq .osid "linux-ubuntu") -}}
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# libnss-mdns registers mDNS lookups through its package hooks on Debian-based
+# systems, so only the services need to be managed here.
+sudo DEBIAN_FRONTEND=noninteractive apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y avahi-daemon libnss-mdns
+
+sudo systemctl enable --now avahi-daemon
+
+{{   end -}}
+{{ end -}}

--- a/home/.chezmoiscripts/linux/run_onchange_before_install-ssh-server.sh.tmpl
+++ b/home/.chezmoiscripts/linux/run_onchange_before_install-ssh-server.sh.tmpl
@@ -1,0 +1,67 @@
+{{ if and .personal (not .ephemeral) -}}
+{{   if eq .osid "linux-arch" -}}
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+readonly sshd_config_dir="/etc/ssh/sshd_config.d"
+readonly sshd_drop_in="${sshd_config_dir}/10-hornero-config.conf"
+
+# Install the OpenSSH server so this machine accepts inbound connections
+# from the other personal machines over the local network.
+sudo pacman -S --noconfirm --needed openssh
+
+# Harden the SSH daemon through a numbered drop-in so the stock sshd_config
+# stays untouched and keeps winning against later drop-ins (first match wins).
+sudo mkdir -p "${sshd_config_dir}"
+sudo tee "${sshd_drop_in}" > /dev/null <<EOF
+# Managed by HorneroConfig via chezmoi -- do not edit manually.
+PubkeyAuthentication yes
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PermitRootLogin no
+AllowUsers {{ .chezmoi.username }}
+EOF
+
+sudo chmod 644 "${sshd_drop_in}"
+
+# Validate the resulting configuration before (re)starting the service.
+sudo sshd -t
+
+sudo systemctl enable sshd
+sudo systemctl restart sshd
+
+{{   else if or (eq .osid "linux-pop") (eq .osid "linux-ubuntu") -}}
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly sshd_config_dir="/etc/ssh/sshd_config.d"
+readonly sshd_drop_in="${sshd_config_dir}/10-hornero-config.conf"
+
+# Install the OpenSSH server so this machine accepts inbound connections
+# from the other personal machines over the local network.
+sudo DEBIAN_FRONTEND=noninteractive apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server
+
+# Harden the SSH daemon through a numbered drop-in (first match wins).
+sudo mkdir -p "${sshd_config_dir}"
+sudo tee "${sshd_drop_in}" > /dev/null <<EOF
+# Managed by HorneroConfig via chezmoi -- do not edit manually.
+PubkeyAuthentication yes
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PermitRootLogin no
+AllowUsers {{ .chezmoi.username }}
+EOF
+
+sudo chmod 644 "${sshd_drop_in}"
+
+# Validate the resulting configuration before (re)starting the service.
+sudo sshd -t
+
+sudo systemctl enable sshd
+sudo systemctl restart sshd
+
+{{   end -}}
+{{ end -}}

--- a/home/private_dot_ssh/executable_config
+++ b/home/private_dot_ssh/executable_config
@@ -13,3 +13,15 @@ Host gitlab gitlab.com
 Host bitbucket bitbucket.org
     HostName bitbucket.org
     IdentityFile ~/.ssh/bitbucket_rsa
+
+# Personal machines over the local network (mDNS).
+# Both hosts authenticate with the same personal key.
+Host hornero hornero.local
+    HostName hornero.local
+    IdentityFile ~/.ssh/personal_rsa
+    IdentitiesOnly yes
+
+Host colibri colibri.local
+    HostName colibri.local
+    IdentityFile ~/.ssh/personal_rsa
+    IdentitiesOnly yes

--- a/home/private_dot_ssh/private_authorized_keys.tmpl
+++ b/home/private_dot_ssh/private_authorized_keys.tmpl
@@ -1,0 +1,1 @@
+{{- include "private_dot_ssh/personal_rsa.pub" -}}


### PR DESCRIPTION
## What does this PR do?

Adds SSH connectivity between the personal machines (**hornero** ⇄ **colibri**) over the local network, reusing the **same personal key** (`personal_rsa`) that chezmoi already deploys on both of them.

### What's included

| Change | File | Purpose |
|---|---|---|
| `authorized_keys` | `home/private_dot_ssh/private_authorized_keys.tmpl` | Deploys `personal_rsa.pub` (0600) from the committed public key — single source of truth, no duplicated key material |
| sshd install + hardening | `home/.chezmoiscripts/linux/run_onchange_before_install-ssh-server.sh.tmpl` | Installs openssh, writes numbered drop-in `/etc/ssh/sshd_config.d/10-hornero-config.conf` (key-only auth, no root login, per-user allowlist), validates with `sshd -t`, then enables + restarts the service |
| mDNS resolution | `home/.chezmoiscripts/linux/run_onchange_before_install-mdns.sh.tmpl` | Avahi + nss-mdns so `<hostname>.local` keeps resolving even when DHCP leases change; idempotent `/etc/nsswitch.conf` edit |
| Client aliases | `home/private_dot_ssh/executable_config` | Symmetric `ssh hornero` / `ssh colibri` entries using `~/.ssh/personal_rsa` with `IdentitiesOnly yes` |
| Docs | `docs/wiki/Network-Manager.md` | New "SSH Between Personal Machines" section |

### Why

Both machines already pull the identical private key from LastPass via the existing templates (`private_personal_rsa.tmpl`), so inbound auth only needed `authorized_keys`, a running `sshd`, and name resolution — none of which were managed until now.

### Design notes

- Scripts gate on `.personal && !.ephemeral`, so ephemeral/CI environments render a no-op (verified via `chezmoi execute-template` against ephemeral-like data).
- The sshd drop-in uses a low number (`10-`) so it wins over later drop-ins such as cloud-init's `50-cloud-init.conf` (first obtained value wins in sshd config).
- Host keys are intentionally left unmanaged (TOFU on first connection); `known_hosts` stays personal.
- Arch is fully supported; Debian/Ubuntu branches mirror the existing `install-docker.sh` pattern for the other distros this repo supports.
- No `chezmoi apply` was run for authoring this PR; behavior was validated through `chezmoi execute-template`, `chezmoi managed` (shows the new `.ssh/authorized_keys` target) and rendered-script linting (`bash -n`, shellcheck v0.10.0).

## Checklist

- [x] `pre-commit run` passes on all touched files
- [x] Rendered scripts pass `bash -n` and `shellcheck`
- [x] No secrets committed (only the already-public `personal_rsa.pub` is referenced)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local-network SSH access for `hornero` and `colibri` using host aliases and key-based authentication.
  * Devices can now be discovered by local network names, with IP-address access available as a fallback.
  * Linux setup now installs and enables SSH server and mDNS support on supported personal systems.
  * Password and root-login access are disabled by default, with access limited to authorized keys.

* **Documentation**
  * Added a guide covering connection steps, first-time host verification, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->