### PR TITLE
docs(readme): fix theme count and remove stale flowers example (#208)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@
 ### ✨ Highlights
 
 🧠 **Smart Color Intelligence** — Automatic theme-aware color adaptation  
-🎨 **13 Beautiful Themes** — Cyberpunk, Cozy, Vaporwave, Nature & more  
+🎨 **12 Beautiful Themes** — Cyberpunk, Cozy, Vaporwave, Nature & more  
 ⚡ **One-Command Setup** — From zero to hero in minutes  
 🌊 **Hyprland/Wayland** — Modern compositor with smooth animations  
 🔧 **100+ Automation Scripts** — Comprehensive tooling ecosystem  
@@ -159,13 +159,13 @@ Our **game-changing smart colors technology** automatically analyzes your color 
 
 ### 🎨 Appearance Themes & Themes
 
-Choose from **13 stunning themes** organized by aesthetic: Cyberpunk, Cozy, Vaporwave, Nature, and Cosmic:
+Choose from **12 stunning themes** organized by aesthetic: Cyberpunk, Cozy,
+Vaporwave, Nature, and Cosmic. The live count comes straight from
+`dots appearance theme list`, so new packs appear automatically:
 
 ```bash
-dots appearance list        # List available appearances 🎯
-dots appearance apply flowers
-dots appearance theme apply flowers     # Apply a specific theme
 dots appearance theme list              # See all available themes
+dots appearance theme apply vapor-dreams
 ```
 
 > 📖 [Explore all themes →](https://github.com/ulises-jeremias/dotfiles/wiki/Rice-System-Theme-Management)

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ Our **game-changing smart colors technology** automatically analyzes your color 
 ### 🎨 Appearance Themes & Themes
 
 Choose from **12 stunning themes** organized by aesthetic: Cyberpunk, Cozy,
-Vaporwave, Nature, and Cosmic. The live count comes straight from
-`dots appearance theme list`, so new packs appear automatically:
+Vaporwave, Nature, and Cosmic. Run `dots appearance theme list` for the
+full, current list:
 
 ```bash
 dots appearance theme list              # See all available themes


### PR DESCRIPTION
The README theme count and the flowers example both predate PR #253, which replaced the sticky rice system with apply-once theme packs.

Two problems:

- The count said 13 (and before that, the issue notes it described 23 rices). The actual pack count is 12. Verified with list-themes.py: 12 packs in home/dot_local/share/dots/themes.
- The example commands used `dots appearance apply flowers` and `dots appearance theme apply flowers`, but flowers no longer exists as a pack. scripts/migrate-rices-to-themes.py folds flowers into soft-morning under THEME_SOURCES, so following the README produced an unknown-theme error. Swapped the example to vapor-dreams, which exists.

Also reworded the section so the count is attributed to `dots appearance theme list` rather than a hard number users might trust later. I did not add auto-generation of the number into the prose because a template variable in markdown adds build complexity for one line; pointing readers at the live command gets the same anti-drift effect. Happy to do it if maintainers prefer.

Verification: ran scripts/test-appearance-consistency.sh --source before and after; 42 pass, 0 fail both times. Count check: ls themes dir = 12, list-themes.py JSON length = 12, grep confirms no remaining "13 Beautiful" / "13 stunning" / flowers references in README.md.

Fixes #208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the documented theme count from 13 to 12.
  * Added instructions to run `dots appearance theme list` to view the complete, current theme list.
  * Clarified that the documented count reflects the themes currently available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->