### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ulises-jeremias


### PR DESCRIPTION
Adds missing `CODEOWNERS` (`* @ulises-jeremias`) for consistent review routing.

Part of repo hardening (Phase 3).