### PR TITLE
fix(quickshell): perScreen list deserialization and avoid killing parent in preset apply

### DIFF
--- a/.github/workflows/clone-and-install.yml
+++ b/.github/workflows/clone-and-install.yml
@@ -42,6 +42,7 @@ jobs:
         run: ./scripts/validate-dots-scripts.sh
 
       - name: Smoke test chezmoi templates
+        shell: bash
         run: |
           curl -fsLS get.chezmoi.io | sh -s -- -b "${HOME}/.local/bin"
           export PATH="${HOME}/.local/bin:${PATH}"

--- a/.github/workflows/clone-and-install.yml
+++ b/.github/workflows/clone-and-install.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           curl -fsLS get.chezmoi.io | sh -s -- -b "${HOME}/.local/bin"
           export PATH="${HOME}/.local/bin:${PATH}"
-          chezmoi init
+          chezmoi init --source=.
           fail=0
           while IFS= read -r -d "" tmpl; do
             if ! chezmoi execute-template --source=. < "$tmpl" > /dev/null; then

--- a/docs/wiki/Quickshell-Shell.md
+++ b/docs/wiki/Quickshell-Shell.md
@@ -123,10 +123,12 @@ horizontal (top/bottom) bars — the classic reference bars use them.
 `bar.perScreen` overrides the global layout per monitor:
 
 ```json
-"perScreen": { "DP-1": { "position": "bottom", "style": "floating" } }
+"perScreen": [
+  { "screen": "DP-1", "position": "bottom", "style": "floating" }
+]
 ```
 
-Apply via `dots-quickshell config set bar.perScreen '{...}'`. Keys not
+Apply via `dots-quickshell config set bar.perScreen '[{"screen": "DP-1", "position": "bottom", "style": "floating"}]'`. Entries not
 present fall back to the global `bar.position` / `bar.style`.
 
 ### Visualizer

--- a/docs/wiki/Quickshell-Shell.md
+++ b/docs/wiki/Quickshell-Shell.md
@@ -12,7 +12,7 @@ Quickshell is the unified desktop shell for HorneroConfig, built with QML/QtQuic
 Quickshell provides all desktop shell functionality through modular QML components:
 
 | Module            | Description                                                          |
-| ----------------- | -------------------------------------------------------------------- |
+|-------------------|----------------------------------------------------------------------|
 | **Left Rail Bar** | Vertical/horizontal rail with workspaces, clock, status icons, power |
 | **Launcher**      | App search, calculator, wallpaper browser, appearance selector       |
 | **Dashboard**     | Tabbed system overview, media, performance, weather                  |
@@ -143,7 +143,7 @@ preset enables it permanently.
 Bar styles have distinct window-management contracts:
 
 | Style      | Surface            | Hyprland space reservation         | Default desktop frame |
-| ---------- | ------------------ | ---------------------------------- | --------------------- |
+|------------|--------------------|------------------------------------|-----------------------|
 | `attached` | Full screen edge   | Bar thickness                      | Preset-controlled     |
 | `floating` | Content-sized pill | None (overlay)                     | Disabled              |
 | `dock`     | Content-sized pill | Pill thickness and floating margin | Disabled              |
@@ -162,7 +162,7 @@ gaps.
 QML singletons providing system integration:
 
 | Service        | Purpose                                            |
-| -------------- | -------------------------------------------------- |
+|----------------|----------------------------------------------------|
 | `Colours`      | M3 theming, transparency, wallpaper luminance      |
 | `Hypr`         | Hyprland IPC (workspaces, monitors, keyboard)      |
 | `Audio`        | PipeWire audio, Cava visualization, beat detection |
@@ -226,7 +226,7 @@ Shell behavior is configured via `~/.config/hornero/shell.json`:
 ## ⌨️ Keybindings
 
 | Keybinding             | Action                    |
-| ---------------------- | ------------------------- |
+|------------------------|---------------------------|
 | `Super+D`              | Toggle launcher           |
 | `Super+X`              | Toggle session/power menu |
 | `Super+Ctrl+B`         | Toggle bar                |

--- a/home/dot_config/quickshell/config/BarConfig.qml
+++ b/home/dot_config/quickshell/config/BarConfig.qml
@@ -8,16 +8,26 @@ JsonObject {
     property string position: "left" // left | right | top | bottom
     property string style: "attached" // attached | floating | dock
     property int floatingMargin: 8
-    // Optional per-screen overrides: { "MONITOR-NAME": { position, style } }
-    property var perScreen: ({})
+    // Optional per-screen overrides: [{ screen: "MONITOR-NAME", position: "...", style: "..." }]
+    property list<var> perScreen: []
+
+    function getOverride(screenName: string): var {
+        if (!perScreen || !Array.isArray(perScreen))
+            return null;
+        for (let i = 0; i < perScreen.length; i++) {
+            if (perScreen[i] && perScreen[i].screen === screenName)
+                return perScreen[i];
+        }
+        return null;
+    }
 
     function positionFor(screenName: string): string {
-        const override = perScreen[screenName];
+        const override = getOverride(screenName);
         return (override && override.position) ? override.position : position;
     }
 
     function styleFor(screenName: string): string {
-        const override = perScreen[screenName];
+        const override = getOverride(screenName);
         return (override && override.style) ? override.style : style;
     }
 

--- a/home/dot_local/bin/executable_dots-quickshell
+++ b/home/dot_local/bin/executable_dots-quickshell
@@ -62,6 +62,13 @@ PRESETS_DIR="${HOME}/.local/share/dots/shell-presets"
 CURRENT_PRESET_FILE="${HOME}/.local/state/dots/current-shell-preset"
 PRESET_MERGER="${HOME}/.local/lib/dots/apply-shell-preset.py"
 
+# Ensure Wayland / Hyprland display environment variables are present
+if [[ -z ${WAYLAND_DISPLAY:-} ]] && [[ -n ${XDG_RUNTIME_DIR:-} ]]; then
+  if command -v systemctl &>/dev/null; then
+    eval "$(systemctl --user show-environment 2>/dev/null | grep -E '^(WAYLAND_DISPLAY|DISPLAY|HYPRLAND_INSTANCE_SIGNATURE|XDG_CURRENT_DESKTOP)=' || true)"
+  fi
+fi
+
 export QML_IMPORT_PATH="${QML_IMPORT_PATH:-${HOME}/.local/lib/quickshell/qml:${HOME}/.local/usr/lib/qt6/qml}"
 # Ensure XDG quickshell path is present even when QML2_IMPORT_PATH is inherited from Hyprland (which may predate fix)
 if [[ -z ${QML2_IMPORT_PATH:-} ]]; then
@@ -328,56 +335,15 @@ preset_apply() {
     return 1
   fi
 
-  read_layout_fields() {
-    python3 - "$1" <<'PYEOF'
-import json, sys
-try:
-    config = json.load(open(sys.argv[1]))
-except (FileNotFoundError, json.JSONDecodeError):
-    config = {}
-bar = config.get("bar", {})
-print("|".join(str(bar.get(k, "")) for k in ("position", "style", "floatingMargin")))
-PYEOF
-  }
-
-  local before_layout after_layout
-  before_layout="$(read_layout_fields "$SHELL_CONFIG")"
-
   python3 "$PRESET_MERGER" "$SHELL_CONFIG" "$preset_file" "$CURRENT_PRESET_FILE" "$name" || {
     log_error "Failed to apply preset: ${name}"
     return 1
   }
 
-  after_layout="$(read_layout_fields "$SHELL_CONFIG")"
-
   log_info "Preset applied: ${display_name}"
 
   if is_running; then
-    if [[ $after_layout != "$before_layout" ]]; then
-      # Layout-affecting changes need a full restart: Quickshell's surgical
-      # hot-reload keeps stale bar geometry when position/style change.
-      if qs ipc call lock isLocked 2>/dev/null | grep -q true; then
-        log_warn "Session locked: run 'dots-quickshell restart' after unlocking"
-      else
-        log_info "Layout changed — restarting Quickshell for clean geometry"
-        cmd_restart
-      fi
-    else
-      log_info "Quickshell will reload automatically"
-    fi
-  fi
-
-  if is_running; then
-    if [[ $after_layout != "$before_layout" ]]; then
-      if qs ipc call lock isLocked 2>/dev/null | grep -q true; then
-        log_warn "Session is locked: layout change needs a manual restart (dots-quickshell restart)"
-      else
-        log_info "Layout changed — restarting Quickshell for clean geometry"
-        cmd_restart
-      fi
-    else
-      log_info "Quickshell will reload automatically"
-    fi
+    log_info "Quickshell will reload automatically"
   fi
 }
 

--- a/home/dot_local/lib/dots/apply-shell-preset.py
+++ b/home/dot_local/lib/dots/apply-shell-preset.py
@@ -24,7 +24,7 @@ OWNED_DEFAULTS: dict[str, Any] = {
         "persistent": True,
         "showOnHover": True,
         "sizes": {"innerWidth": 40},
-        "perScreen": {},
+        "perScreen": [],
         "status": {
             "showAudio": False,
             "showMicrophone": False,

--- a/scripts/test-shell-layout-consistency.sh
+++ b/scripts/test-shell-layout-consistency.sh
@@ -7,9 +7,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 PYTHONDONTWRITEBYTECODE=1 python3 - \
-  "${ROOT}/home/dot_local/lib/dots/apply-shell-preset.py" \
-  "${ROOT}/home/dot_local/share/dots/shell-presets" \
-  "${ROOT}/home/dot_config/quickshell/config/Config.qml" <<'PY'
+	"${ROOT}/home/dot_local/lib/dots/apply-shell-preset.py" \
+	"${ROOT}/home/dot_local/share/dots/shell-presets" \
+	"${ROOT}/home/dot_config/quickshell/config/Config.qml" << 'PY'
 import importlib.util
 import json
 import math

--- a/scripts/test-shell-layout-consistency.sh
+++ b/scripts/test-shell-layout-consistency.sh
@@ -86,8 +86,7 @@ with tempfile.TemporaryDirectory() as temporary:
     assert marker_path.read_text(encoding="utf-8") == "dock-bottom\n"
 
 bar_config = (config_qml.parent / "BarConfig.qml").read_text(encoding="utf-8")
-assert '"perScreen": {}' not in json.dumps(OWNED := module.OWNED_DEFAULTS["bar"]) or True
-assert module.OWNED_DEFAULTS["bar"]["perScreen"] == {}
+assert module.OWNED_DEFAULTS["bar"]["perScreen"] == []
 assert "positionFor" in bar_config and "isFloatingFor" in bar_config
 config_source_pos = config_qml.read_text(encoding="utf-8")
 assert "perScreen: bar.perScreen" in config_source_pos

--- a/scripts/test-shell-layout-consistency.sh
+++ b/scripts/test-shell-layout-consistency.sh
@@ -6,7 +6,19 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-PYTHONDONTWRITEBYTECODE=1 python3 - \
+PYTHON_BIN=""
+if command -v python3 > /dev/null 2>&1; then
+	PYTHON_BIN="$(command -v python3)"
+elif command -v python > /dev/null 2>&1; then
+	PYTHON_BIN="$(command -v python)"
+fi
+
+if [[ -z $PYTHON_BIN ]]; then
+	echo "  SKIP  test-shell-layout-consistency.sh (python not available)"
+	exit 0
+fi
+
+PYTHONDONTWRITEBYTECODE=1 "$PYTHON_BIN" - \
 	"${ROOT}/home/dot_local/lib/dots/apply-shell-preset.py" \
 	"${ROOT}/home/dot_local/share/dots/shell-presets" \
 	"${ROOT}/home/dot_config/quickshell/config/Config.qml" << 'PY'


### PR DESCRIPTION
## Summary
- Fix Quickshell `JsonAdapter` crash (SIGSEGV) when deserializing `bar.perScreen` by declaring it as a list of variant maps instead of a generic `var` object.
- Update shell layout presets merger defaults (`apply-shell-preset.py`) and consistency tests (`test-shell-layout-consistency.sh`).
- Update `dots-quickshell preset apply` to rely on Quickshell's file watcher hot-reload instead of restarting the parent process.
- Ensure Wayland/Hyprland environment variables are sourced if missing.

## Test plan
- [x] Run `test-shell-layout-consistency.sh` -> PASS
- [x] Tested `dots-quickshell preset apply hornero-left` and `hornero-right` live -> Quickshell reloads smoothly without crashing or exiting.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Per-screen bar layouts now use an array-based configuration format with explicit screen names.
  - Preset application restores relevant desktop session settings when needed.
  - Running shell instances automatically reload after successfully applying a preset.

- **Documentation**
  - Updated per-screen layout examples, commands, and fallback wording to reflect the new configuration format.

- **Tests**
  - Updated layout consistency checks for the new empty-list default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->